### PR TITLE
SEO: Block voxxyai.com from search indexing

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <!-- Additional Meta Tags -->
     <meta name="keywords" content="community management, event management, creative communities, recurring events, creative business tools, community organizers" />
     <meta name="author" content="Voxxy, Inc." />
-    <meta name="robots" content="index, follow" />
+    <meta name="robots" content="noindex, nofollow" />
     <link rel="canonical" href="https://www.voxxypresents.com/" />
   </head>
   <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+# Block all search engines from indexing voxxyai.com
+# Only heyvoxxy.com should appear in search results
+
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- Added robots.txt to block all search engine crawlers
- Updated meta robots tag from "index, follow" to "noindex, nofollow"

## Purpose
Prevent voxxyai.com from appearing in search results. Only heyvoxxy.com should be indexed by search engines.

## Changes
1. **public/robots.txt** (new file)
   - Disallow all user agents from crawling/indexing

2. **index.html**
   - Updated meta robots tag to "noindex, nofollow"

## Testing
Once deployed to voxxyai.com, search engines will stop indexing the site and it will gradually disappear from search results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)