### PR TITLE
Fix duplicate event name error handling

### DIFF
--- a/src/components/producer/CreateEventWizard/CreateEventWizard.tsx
+++ b/src/components/producer/CreateEventWizard/CreateEventWizard.tsx
@@ -213,8 +213,22 @@ export default function CreateEventWizard({ onCancel, onSubmit, organizationId }
     setIsSubmitting(true);
     try {
       await onSubmit(wizardState);
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to create event:', error);
+
+      // Display error message to user
+      const errorMessage = error?.response?.data?.errors?.[0]
+        || error?.message
+        || 'Failed to create event. Please try again.';
+
+      setErrors({
+        submit: errorMessage.includes('taken') || errorMessage.includes('duplicate')
+          ? 'An event with this name already exists. Please choose a different name.'
+          : errorMessage
+      });
+
+      // Go back to step 1 so user can fix the title
+      setWizardState((prev) => ({ ...prev, currentStep: 1 }));
     } finally {
       setIsSubmitting(false);
     }
@@ -267,6 +281,13 @@ export default function CreateEventWizard({ onCancel, onSubmit, organizationId }
         completedSteps={completedSteps}
         onStepClick={handleStepClick}
       />
+
+      {/* Submit Error Display */}
+      {errors.submit && (
+        <div className="mb-6 p-4 rounded-lg bg-red-500/10 border border-red-500/30">
+          <p className="text-red-400 text-sm">{errors.submit}</p>
+        </div>
+      )}
 
       {/* Current Step Content */}
       {renderCurrentStep()}


### PR DESCRIPTION
## Problem
When creating an event with a duplicate name, the form would silently fail and reset, losing all entered data. Users had to start over from scratch without knowing what went wrong.

## Root Cause
The CreateEventWizard caught API errors but didn't display them to the user. When the parent component reset the view to 'create', it would unmount and remount the wizard, clearing all form state.

## Solution
- Parse error response from API and extract meaningful error message
- Detect duplicate name errors and show user-friendly message
- Display error prominently above wizard progress
- Keep user on Step 1 with all data intact so they can edit the event name
- Only reset `isSubmitting` state, not form data

## User Experience
**Before**: 
- Submit form with duplicate name → form closes → all data lost → start over

**After**:
- Submit form with duplicate name → error appears: "An event with this name already exists. Please choose a different name." → user edits name → resubmits

## Testing
1. Create an event named "Test Event 2026"
2. Try to create another event with the same name
3. Verify error message appears: "An event with this name already exists..."
4. Verify all form data is still filled in
5. Change the event name
6. Verify successful submission

## Files Changed
- `src/components/producer/CreateEventWizard/CreateEventWizard.tsx`

## Related
- Fixes production bug reported by user
- Should be deployed to fix ongoing user frustration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>