### PR TITLE
🔥 Hotfix: Fix TypeScript build error in InvitesTab

### DIFF
--- a/src/components/producer/InvitesTab.tsx
+++ b/src/components/producer/InvitesTab.tsx
@@ -449,7 +449,7 @@ export default function InvitesTab({ eventSlug, organizationId }: InvitesTabProp
         <div className="text-center py-12">
           <p className="text-sm text-red-400 mb-3">{error}</p>
           <button
-            onClick={fetchInviteRows}
+            onClick={() => fetchInviteRows(1)}
             className="px-3 py-1.5 text-xs rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-smooth"
           >
             Retry


### PR DESCRIPTION
## Urgent Fix - Deployment Failure

This hotfix resolves the TypeScript compilation error that's causing deployment failures on the develop branch.

## Error
```
src/components/producer/InvitesTab.tsx(452,13): error TS2322: Type '(page?: number, append?: boolean) => Promise<void>' is not assignable to type 'MouseEventHandler<HTMLButtonElement>'.
```

## Fix
Changed the retry button's onClick handler from:
```tsx
onClick={fetchInviteRows}  // ❌ Wrong - passes MouseEvent
```

To:
```tsx
onClick={() => fetchInviteRows(1)}  // ✅ Correct - passes page number
```

## Impact
- **Before**: Build fails, deployment blocked
- **After**: Build succeeds, deployment can proceed

## Files Changed
- `src/components/producer/InvitesTab.tsx` (1 line)

## Testing
✅ TypeScript compilation passes
✅ Build succeeds locally

## Urgency
🔴 **Critical** - This is blocking all deployments to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)