### PR TITLE
UI refresh: slim lists, remove broken features, inline editing

### DIFF
--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -21,6 +21,7 @@ import {
   ArrowLeftRight,
 } from 'lucide-react';
 import { vendorApplicationsApi, registrationsApi, eventInvitationsApi, emailDeliveriesApi } from '@/services/api';
+import { toast } from 'sonner';
 import { useEmailNotifications } from '@/hooks/useEmailNotifications';
 import { EmailConfirmationDialog } from './EmailConfirmationDialog';
 import { DebugPanel } from './DebugPanel';
@@ -981,117 +982,6 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                 </div>
               )}
 
-              {/* Email History */}
-              {(selectedApplicant.registrationId || selectedApplicant.invitationId) && (
-                <div className="glass-card p-3 mb-3">
-                  <button
-                    onClick={handleToggleEmailHistory}
-                    className="w-full flex items-center justify-between text-left hover:bg-white/5 p-2 rounded-lg transition-smooth -m-2 mb-0"
-                  >
-                    <h3 className="text-sm font-semibold text-white">Email History</h3>
-                    {emailHistoryExpanded ? (
-                      <ChevronUp className="w-4 h-4 text-white/60" />
-                    ) : (
-                      <ChevronDown className="w-4 h-4 text-white/60" />
-                    )}
-                  </button>
-
-                  {emailHistoryExpanded && (
-                    <div className="mt-3 space-y-2">
-                      {loadingEmailHistory ? (
-                        <div className="flex items-center justify-center py-4">
-                          <div className="w-4 h-4 border-2 border-purple-500/30 border-t-purple-500 rounded-full animate-spin" />
-                        </div>
-                      ) : emailHistoryData.length > 0 ? (
-                        emailHistoryData.map((delivery: any) => {
-                          const deliveryStatus = delivery.status;
-                          const emailSubject = delivery.subject || delivery.scheduled_email?.subject || 'Unknown Email';
-                          const deliveredDate = delivery.delivered_at || delivery.sent_at || delivery.created_at;
-
-                          let statusColor = 'bg-gray-500/20 text-gray-400';
-                          if (deliveryStatus === 'delivered') statusColor = 'bg-green-500/20 text-green-400';
-                          else if (deliveryStatus === 'bounced') statusColor = 'bg-red-500/20 text-red-400';
-                          else if (deliveryStatus === 'dropped') statusColor = 'bg-orange-500/20 text-orange-400';
-                          else if (deliveryStatus === 'unsubscribed') statusColor = 'bg-yellow-500/20 text-yellow-400';
-
-                          return (
-                            <div key={delivery.id} className="bg-white/5 border border-white/10 rounded-lg p-2.5 space-y-1.5">
-                              <div className="flex items-start justify-between gap-2">
-                                <div className="flex-1 min-w-0">
-                                  <p className="text-xs text-white font-medium truncate">{emailSubject}</p>
-                                  <p className="text-[10px] text-white/60 mt-0.5">
-                                    {deliveredDate ? new Date(deliveredDate).toLocaleDateString('en-US', {
-                                      month: 'short',
-                                      day: 'numeric',
-                                      year: 'numeric',
-                                      hour: 'numeric',
-                                      minute: '2-digit'
-                                    }) : 'Date unknown'}
-                                  </p>
-                                </div>
-                                <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-medium ${statusColor} whitespace-nowrap`}>
-                                  {deliveryStatus}
-                                </span>
-                              </div>
-
-                              {(delivery.bounce_reason || delivery.drop_reason) && (
-                                <p className="text-[10px] text-red-400/80 mt-1">
-                                  {delivery.bounce_type && `${delivery.bounce_type}: `}
-                                  {delivery.bounce_reason || delivery.drop_reason}
-                                </p>
-                              )}
-
-                              {(deliveryStatus === 'bounced' || deliveryStatus === 'dropped') && (
-                                <button
-                                  onClick={async () => {
-                                    try {
-                                      await emailDeliveriesApi.retry(delivery.id);
-                                      alert('Email queued for retry');
-                                      // Refresh email history - fetch both registration and invitation emails
-                                      let refreshedHistory: any[] = [];
-                                      if (selectedApplicant.registrationId) {
-                                        const regHistory = await emailDeliveriesApi.getByRegistration(selectedApplicant.registrationId);
-                                        refreshedHistory = [...(regHistory || [])];
-                                      }
-                                      if (selectedApplicant.invitationId) {
-                                        const invHistory = await emailDeliveriesApi.getByInvitation(eventSlug, selectedApplicant.invitationId);
-                                        refreshedHistory = [...refreshedHistory, ...(invHistory || [])];
-                                      }
-                                      // Sort by date (most recent first)
-                                      refreshedHistory.sort((a, b) => {
-                                        const dateA = new Date(a.delivered_at || a.sent_at || a.created_at).getTime();
-                                        const dateB = new Date(b.delivered_at || b.sent_at || b.created_at).getTime();
-                                        return dateB - dateA;
-                                      });
-                                      setEmailHistoryData(refreshedHistory);
-                                    } catch (err: any) {
-                                      alert(`Failed to retry: ${err.message}`);
-                                    }
-                                  }}
-                                  className="text-[10px] px-2 py-1 rounded bg-purple-600/20 text-purple-400 hover:bg-purple-600/30 transition-smooth"
-                                >
-                                  Retry
-                                </button>
-                              )}
-                            </div>
-                          );
-                        })
-                      ) : (
-                        <div className="py-2">
-                          {selectedApplicant.status === 'invited' ? (
-                            <p className="text-xs text-white/60 italic">
-                              No emails sent yet. Check invitation status in Vendors tab for unsubscribe info.
-                            </p>
-                          ) : (
-                            <p className="text-xs text-white/40 italic">No email history found</p>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              )}
-
               {/* Status & Payment Management - Only show for applicants who have applied */}
               {selectedApplicant.status !== 'invited' && selectedApplicant.registrationId && (
                 <div className="glass-card p-3">
@@ -1169,6 +1059,103 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                             >
                               Mark as Paid
                             </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Email History */}
+              {(selectedApplicant.registrationId || selectedApplicant.invitationId) && (
+                <div className="glass-card p-3">
+                  <button
+                    onClick={handleToggleEmailHistory}
+                    className="w-full flex items-center justify-between text-left hover:bg-white/5 p-2 rounded-lg transition-smooth -m-2 mb-0"
+                  >
+                    <h3 className="text-sm font-semibold text-white">Email History</h3>
+                    {emailHistoryExpanded ? (
+                      <ChevronUp className="w-4 h-4 text-white/60" />
+                    ) : (
+                      <ChevronDown className="w-4 h-4 text-white/60" />
+                    )}
+                  </button>
+
+                  {emailHistoryExpanded && (
+                    <div className="mt-3">
+                      {loadingEmailHistory ? (
+                        <div className="flex items-center justify-center py-4">
+                          <div className="w-4 h-4 border-2 border-purple-500/30 border-t-purple-500 rounded-full animate-spin" />
+                        </div>
+                      ) : emailHistoryData.length > 0 ? (
+                        <div className="divide-y divide-white/5">
+                          {emailHistoryData.map((delivery: any) => {
+                            const deliveryStatus = delivery.status;
+                            const emailSubject = delivery.subject || delivery.scheduled_email?.subject || 'Unknown Email';
+                            const deliveredDate = delivery.delivered_at || delivery.sent_at || delivery.created_at;
+
+                            let statusColor = 'text-white/40';
+                            if (deliveryStatus === 'delivered') statusColor = 'text-green-400';
+                            else if (deliveryStatus === 'bounced') statusColor = 'text-red-400';
+                            else if (deliveryStatus === 'dropped') statusColor = 'text-orange-400';
+                            else if (deliveryStatus === 'unsubscribed') statusColor = 'text-yellow-400';
+
+                            return (
+                              <div key={delivery.id} className="flex items-center gap-2 py-1.5">
+                                <Mail className="w-3 h-3 text-white/30 flex-shrink-0" />
+                                <span className="text-[10px] text-white/70 truncate flex-1">{emailSubject}</span>
+                                <span className="text-[10px] text-white/40 tabular-nums flex-shrink-0">
+                                  {deliveredDate ? new Date(deliveredDate).toLocaleDateString('en-US', {
+                                    month: 'short',
+                                    day: 'numeric',
+                                  }) : '—'}
+                                </span>
+                                <span className={`text-[10px] font-medium ${statusColor} flex-shrink-0 w-16 text-right`}>
+                                  {deliveryStatus}
+                                </span>
+                                {(deliveryStatus === 'bounced' || deliveryStatus === 'dropped') && (
+                                  <button
+                                    onClick={async () => {
+                                      try {
+                                        await emailDeliveriesApi.retry(delivery.id);
+                                        toast.success('Email queued for retry');
+                                        let refreshedHistory: any[] = [];
+                                        if (selectedApplicant.registrationId) {
+                                          const regHistory = await emailDeliveriesApi.getByRegistration(selectedApplicant.registrationId);
+                                          refreshedHistory = [...(regHistory || [])];
+                                        }
+                                        if (selectedApplicant.invitationId) {
+                                          const invHistory = await emailDeliveriesApi.getByInvitation(eventSlug, selectedApplicant.invitationId);
+                                          refreshedHistory = [...refreshedHistory, ...(invHistory || [])];
+                                        }
+                                        refreshedHistory.sort((a, b) => {
+                                          const dateA = new Date(a.delivered_at || a.sent_at || a.created_at).getTime();
+                                          const dateB = new Date(b.delivered_at || b.sent_at || b.created_at).getTime();
+                                          return dateB - dateA;
+                                        });
+                                        setEmailHistoryData(refreshedHistory);
+                                      } catch (err: any) {
+                                        toast.error(`Failed to retry: ${err.message}`);
+                                      }
+                                    }}
+                                    className="text-[10px] text-purple-400 hover:text-purple-300 flex-shrink-0"
+                                  >
+                                    Retry
+                                  </button>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <div className="py-2">
+                          {selectedApplicant.status === 'invited' ? (
+                            <p className="text-xs text-white/60 italic">
+                              No emails sent yet. Check invitation status in Vendors tab for unsubscribe info.
+                            </p>
+                          ) : (
+                            <p className="text-xs text-white/40 italic">No email history found</p>
                           )}
                         </div>
                       )}

--- a/src/components/producer/CommandCenter.tsx
+++ b/src/components/producer/CommandCenter.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
-import { ArrowLeft, ClipboardList, Settings, Info, Mail, DollarSign } from 'lucide-react';
+import { ArrowLeft, ClipboardList, Settings, Info, Mail } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import EventSettings from './EventSettings';
 import ApplicantsTab from './ApplicantsTab';
 import EventDetailsTab from './EventDetailsTab';
 import { EmailAutomationTab } from './Email';
-import { PaymentSettingsTab } from './PaymentIntegrations';
 
 interface Event {
   id: number;
@@ -45,7 +44,7 @@ interface CommandCenterProps {
   organizationId?: number;
 }
 
-type Tab = 'details' | 'applicants' | 'emails' | 'payments' | 'settings';
+type Tab = 'details' | 'applicants' | 'emails' | 'settings';
 
 export default function CommandCenter({ event, onBack, onUpdateEvent, onDeleteEvent, onRefreshEvent, organizationId }: CommandCenterProps) {
   const [activeTab, setActiveTab] = useState<Tab>('details');
@@ -56,7 +55,6 @@ export default function CommandCenter({ event, onBack, onUpdateEvent, onDeleteEv
     { id: 'details' as Tab, label: 'Home', icon: Info },
     { id: 'applicants' as Tab, label: 'Vendors', icon: ClipboardList },
     { id: 'emails' as Tab, label: 'Mail', icon: Mail },
-    { id: 'payments' as Tab, label: 'Payments', icon: DollarSign },
     { id: 'settings' as Tab, label: 'Settings', icon: Settings },
   ];
 
@@ -77,8 +75,6 @@ export default function CommandCenter({ event, onBack, onUpdateEvent, onDeleteEv
         return <ApplicantsTab eventSlug={event.slug} event={event} isAdmin={isAdmin} />;
       case 'emails':
         return <EmailAutomationTab eventSlug={event.slug} event={event} isAdmin={isAdmin} />;
-      case 'payments':
-        return <PaymentSettingsTab eventSlug={event.slug} organizationId={organizationId || 1} event={event} isAdmin={isAdmin} />;
       case 'settings':
         return (
           <EventSettings

--- a/src/components/producer/CreateEventWizard/steps/Step4AutoMessages.tsx
+++ b/src/components/producer/CreateEventWizard/steps/Step4AutoMessages.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect } from 'react';
-import { Mail, ChevronDown, ChevronUp, Eye, Edit, Users, Plus, Calendar, Clock } from 'lucide-react';
+import { Mail, Eye } from 'lucide-react';
 import { format, addDays, subDays, parseISO } from 'date-fns';
 import { emailCampaignTemplatesApi } from '@/services/api';
 import type { EmailCampaignTemplate, EmailTemplateItem, EmailCategory } from '@/types/email';
-import ImportTemplateModal from '../ImportTemplateModal';
 import TemplatePreviewModal from '@/components/shared/TemplatePreviewModal';
 import { DebugPanel } from '../../DebugPanel';
 
@@ -111,25 +110,25 @@ export default function Step4AutoMessages({
   paymentDeadline,
   isAdmin
 }: Step4AutoMessagesProps) {
-  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
   const [previewEmail, setPreviewEmail] = useState<EmailTemplateItem | null>(null);
   const [selectedTemplate, setSelectedTemplate] = useState<EmailCampaignTemplate | null>(null);
+  const [allTemplates, setAllTemplates] = useState<EmailCampaignTemplate[]>([]);
   const [emailItems, setEmailItems] = useState<EmailTemplateItem[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchDefaultTemplate();
+    fetchTemplates();
   }, []);
 
-  const fetchDefaultTemplate = async () => {
+  const fetchTemplates = async () => {
     try {
       setLoading(true);
       const templates = await emailCampaignTemplatesApi.getAll();
-      const defaultTemplate = templates.find((t) => t.is_default && t.template_type === 'system');
+      setAllTemplates(templates);
 
+      const defaultTemplate = templates.find((t) => t.is_default && t.template_type === 'system');
       if (defaultTemplate) {
-        // Fetch full template with email items
         const fullTemplate = await emailCampaignTemplatesApi.getById(defaultTemplate.id);
         setSelectedTemplate(fullTemplate);
         setEmailItems(fullTemplate.email_template_items || []);
@@ -139,13 +138,16 @@ export default function Step4AutoMessages({
         }
       }
     } catch (err) {
-      console.error('Failed to fetch template:', err);
+      console.error('Failed to fetch templates:', err);
     } finally {
       setLoading(false);
     }
   };
 
-  const handleTemplateSelect = async (template: EmailCampaignTemplate) => {
+  const handleTemplateChange = async (templateId: number) => {
+    const template = allTemplates.find((t) => t.id === templateId);
+    if (!template) return;
+
     try {
       setLoading(true);
       const fullTemplate = await emailCampaignTemplatesApi.getById(template.id);
@@ -187,26 +189,29 @@ export default function Step4AutoMessages({
             Review and select automated email sequence for your event
           </p>
 
-          {/* Current Template Display & Change Button */}
-          <div className="flex items-center justify-between bg-white/10 rounded-lg p-4 border border-white/20">
-            <div>
-              <p className="text-xs text-white/50 mb-1">Email Sequence</p>
-              <p className="text-white font-medium">
-                {selectedTemplate ? selectedTemplate.name : 'No template selected'}
-              </p>
-              {selectedTemplate && (
-                <p className="text-xs text-white/50 mt-1">
-                  {emailItems.length} {emailItems.length === 1 ? 'email' : 'emails'}
-                </p>
-              )}
-            </div>
-            <button
-              onClick={() => setIsImportModalOpen(true)}
-              className="px-4 py-2 bg-gradient-to-r from-purple-600 to-blue-500 hover:from-purple-700 hover:to-blue-600 text-white rounded-lg transition-colors flex items-center gap-2 font-medium shadow-lg"
+          {/* Email Sequence Selector */}
+          <div className="flex items-center gap-3">
+            <p className="text-xs text-white/50 flex-shrink-0">Email Sequence</p>
+            <select
+              value={selectedTemplate?.id || ''}
+              onChange={(e) => {
+                const id = Number(e.target.value);
+                if (id) handleTemplateChange(id);
+              }}
+              className="flex-1 px-3 py-2 rounded-lg bg-white/10 text-white text-sm border border-white/20 hover:bg-white/15 transition-all"
             >
-              <Plus className="w-4 h-4" />
-              {selectedTemplate ? 'Change Sequence' : 'Select Sequence'}
-            </button>
+              <option value="" disabled>Select a sequence...</option>
+              {allTemplates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}{t.is_default ? ' (Default)' : ''}
+                </option>
+              ))}
+            </select>
+            {selectedTemplate && (
+              <span className="text-[10px] text-white/40 flex-shrink-0 tabular-nums">
+                {emailItems.length} {emailItems.length === 1 ? 'email' : 'emails'}
+              </span>
+            )}
           </div>
         </div>
 
@@ -221,94 +226,64 @@ export default function Step4AutoMessages({
             <p className="text-white/50 text-sm">No template selected. Click "Select Template" to choose one.</p>
           </div>
         ) : (
-          /* Email List - Table View */
-          <div className="bg-white/5 rounded-lg border border-white/10 overflow-hidden">
-            {/* Table Header */}
-            <div className="px-4 py-3 bg-white/5 border-b border-white/10 grid grid-cols-12 gap-4 text-xs font-semibold text-white/70 uppercase tracking-wide">
-              <div className="col-span-3">Trigger Type</div>
-              <div className="col-span-4">Email</div>
-              <div className="col-span-3">Send Date</div>
-              <div className="col-span-2 text-right">Actions</div>
-            </div>
-
-            {/* Table Body */}
-            <div className="divide-y divide-white/10">
-              {[...emailItems].sort((a, b) => (a.position ?? 0) - (b.position ?? 0)).map((email: EmailTemplateItem) => {
-                const sendDate = calculateSendDate(
-                  email.trigger_type,
-                  email.trigger_value ?? null,
-                  eventDate,
-                  applicationDeadline,
-                  paymentDeadline
-                );
-
-                return (
-                  <div
-                    key={email.id}
-                    className="px-4 py-3 hover:bg-white/5 transition-colors grid grid-cols-12 gap-4 items-center"
-                  >
-                    {/* Trigger Type */}
-                    <div className="col-span-3 text-sm text-white/80">
-                      {getTriggerLabel(email.trigger_type, email.trigger_value ?? null)}
-                    </div>
-
-                    {/* Email Name & Subject */}
-                    <div className="col-span-4 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <h4 className="text-sm font-medium text-white truncate">{email.name}</h4>
-                        {!email.enabled_by_default && (
-                          <span className="text-xs px-2 py-0.5 bg-white/10 text-white/50 rounded flex-shrink-0">
-                            Auto
-                          </span>
-                        )}
-                      </div>
-                      <p className="text-xs text-white/60 truncate">{email.subject_template}</p>
-                    </div>
-
-                    {/* Send Date */}
-                    <div className="col-span-3">
-                      {sendDate ? (
-                        <div className="flex items-center gap-1.5 text-sm text-white/80">
-                          <Calendar className="w-3.5 h-3.5 text-purple-400" />
-                          <span>{sendDate}</span>
-                        </div>
-                      ) : (
-                        <span className="text-xs text-white/40">Not calculated</span>
-                      )}
-                    </div>
-
-                    {/* Actions */}
-                    <div className="col-span-2 flex justify-end gap-2">
-                      <button
-                        onClick={() => handlePreviewEmail(email)}
-                        className="p-1.5 hover:bg-white/10 text-white/60 hover:text-white rounded transition-colors"
-                        title="Preview email"
-                      >
-                        <Eye className="w-4 h-4" />
-                      </button>
-                      <button
-                        onClick={() => alert('Edit features coming soon')}
-                        className="p-1.5 hover:bg-white/10 text-white/60 hover:text-white rounded transition-colors"
-                        title="Edit email"
-                      >
-                        <Edit className="w-4 h-4" />
-                      </button>
-                    </div>
+          /* Email List - Grouped by Category */
+          <div className="space-y-4">
+            {Object.entries(
+              [...emailItems]
+                .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+                .reduce((groups, item) => {
+                  const cat = item.category || 'system';
+                  if (!groups[cat]) groups[cat] = [];
+                  groups[cat].push(item);
+                  return groups;
+                }, {} as Record<string, EmailTemplateItem[]>)
+            )
+              .sort(([a], [b]) => (CATEGORY_CONFIG[a as EmailCategory]?.order ?? 99) - (CATEGORY_CONFIG[b as EmailCategory]?.order ?? 99))
+              .map(([category, items]) => (
+                <div key={category}>
+                  <div className="flex items-center gap-2 mb-1.5 px-1">
+                    <h3 className="text-xs font-semibold text-white/70 uppercase tracking-wide">
+                      {CATEGORY_CONFIG[category as EmailCategory]?.label || category}
+                    </h3>
+                    <span className="text-[10px] text-white/30 tabular-nums">{items.length}</span>
                   </div>
-                );
-              })}
-            </div>
+                  <div className="rounded-lg border border-white/10 bg-white/[0.03] divide-y divide-white/5">
+                    {items.map((email) => {
+                      const sendDate = calculateSendDate(
+                        email.trigger_type,
+                        email.trigger_value ?? null,
+                        eventDate,
+                        applicationDeadline,
+                        paymentDeadline
+                      );
+                      return (
+                        <div key={email.id} className="flex items-center gap-3 py-2.5 px-3">
+                          <Mail className="w-3.5 h-3.5 text-white/30 flex-shrink-0" />
+                          <span className="text-sm text-white truncate flex-1">{email.name}</span>
+                          <span className="text-[10px] text-white/40 flex-shrink-0 hidden sm:inline">
+                            {getTriggerLabel(email.trigger_type, email.trigger_value ?? null)}
+                          </span>
+                          {sendDate && (
+                            <span className="text-[10px] text-white/40 tabular-nums flex-shrink-0 hidden md:inline">
+                              {sendDate}
+                            </span>
+                          )}
+                          <button
+                            onClick={() => handlePreviewEmail(email)}
+                            className="p-1.5 rounded text-white/40 hover:text-white hover:bg-white/10 transition-all flex-shrink-0"
+                            title="Preview email"
+                          >
+                            <Eye className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
           </div>
         )}
       </div>
-
-      {/* Import Template Modal */}
-      <ImportTemplateModal
-        isOpen={isImportModalOpen}
-        onClose={() => setIsImportModalOpen(false)}
-        onSelect={handleTemplateSelect}
-        currentTemplateId={selectedTemplate?.id}
-      />
 
       {/* Email Preview Modal */}
       {previewEmail && (

--- a/src/components/producer/Email/EmailAutomationTab.tsx
+++ b/src/components/producer/Email/EmailAutomationTab.tsx
@@ -477,13 +477,7 @@ export default function EmailAutomationTab({ eventSlug, event, isAdmin }: EmailA
               <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
               <span className="hidden sm:inline">Refresh</span>
             </button>
-          </div>
-        </div>
-
-        {/* Auto-refresh toggle and stats */}
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 bg-white/5 rounded-lg border border-white/10">
-          <div className="flex items-center gap-3">
-            <label className="flex items-center gap-2 cursor-pointer group">
+            <label className="flex items-center gap-1.5 cursor-pointer" title="Auto-refresh every 30s">
               <div className="relative">
                 <input
                   type="checkbox"
@@ -491,34 +485,12 @@ export default function EmailAutomationTab({ eventSlug, event, isAdmin }: EmailA
                   onChange={(e) => setAutoRefresh(e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-white/10 rounded-full peer-checked:bg-gradient-to-r peer-checked:from-purple-600 peer-checked:to-blue-500 transition-all"></div>
-                <div className="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-5"></div>
+                <div className="w-8 h-4 bg-white/10 rounded-full peer-checked:bg-purple-600 transition-all"></div>
+                <div className="absolute left-0.5 top-0.5 w-3 h-3 bg-white rounded-full transition-transform peer-checked:translate-x-4"></div>
               </div>
-              <span className="text-sm text-white/80 group-hover:text-white transition-colors">
-                Auto-refresh delivery stats
-              </span>
+              <span className="text-[10px] text-white/50">Auto</span>
             </label>
-            {autoRefresh && (
-              <span className="text-xs text-white/40">
-                Updates every 30s
-              </span>
-            )}
           </div>
-          {lastRefreshTime && (
-            <div className="text-xs text-white/40 flex items-center gap-2">
-              {isRefreshing && (
-                <span className="flex items-center gap-1">
-                  <Loader2 className="w-3 h-3 animate-spin" />
-                  Updating...
-                </span>
-              )}
-              {!isRefreshing && (
-                <span>
-                  Last updated: {lastRefreshTime.toLocaleTimeString()}
-                </span>
-              )}
-            </div>
-          )}
         </div>
       </div>
 

--- a/src/components/producer/Email/TemplateBuilderPage.tsx
+++ b/src/components/producer/Email/TemplateBuilderPage.tsx
@@ -6,15 +6,15 @@ import {
   Plus,
   Trash2,
   Edit,
-  GripVertical,
+
   Loader2,
   AlertCircle,
   ChevronDown,
   ChevronUp
 } from 'lucide-react';
 import { emailCampaignTemplatesApi, emailTemplateItemsApi } from '@/services/api';
-import type { EmailCampaignTemplate, EmailTemplateItem } from '@/types/email';
-import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
+import type { EmailCampaignTemplate, EmailTemplateItem, EmailCategory, TriggerType } from '@/types/email';
+
 import { EmailTemplateEditorPage } from './EmailTemplateEditorPage';
 import { STANDARD_EMAIL_FOOTER } from '@/utils/emailFooter';
 
@@ -221,20 +221,29 @@ export default function TemplateBuilderPage({ templateId, createFromDefault, onB
     }
   };
 
-  const handleAddEmail = async () => {
+  const handleAddEmail = async (category?: string) => {
     if (!template) {
       setError('Please save the template first');
       return;
     }
 
+    const cat = (category || 'application_updates') as EmailCategory;
+    const defaultTriggers: Record<string, TriggerType> = {
+      event_announcements: 'on_application_open',
+      application_updates: 'on_application_submit',
+      payment_reminders: 'on_payment_deadline',
+      event_countdown: 'days_before_event',
+      event_updates: 'on_event_date',
+    };
+
     try {
       const newItem = await emailTemplateItemsApi.create(template.id, {
-        name: `Email ${emailItems.length + 1}`,
+        name: `New Email`,
         position: emailItems.length + 1,
-        category: 'application_updates',
+        category: cat,
         subject_template: 'New Email - [eventName]',
         body_template: '<p>Hi [firstName],</p><p>This is a new email for [eventName].</p><p>Edit this email to customize the content.</p>' + STANDARD_EMAIL_FOOTER,
-        trigger_type: 'on_application_submit',
+        trigger_type: defaultTriggers[cat] || 'on_application_submit' as TriggerType,
         enabled_by_default: true
       });
 
@@ -303,33 +312,6 @@ export default function TemplateBuilderPage({ templateId, createFromDefault, onB
     setEditingItem(null);
   };
 
-  const handleDragEnd = async (result: DropResult) => {
-    if (!result.destination || !template) return;
-
-    const items = Array.from(emailItems);
-    const [reorderedItem] = items.splice(result.source.index, 1);
-    items.splice(result.destination.index, 0, reorderedItem);
-
-    // Update positions
-    const updatedItems = items.map((item, index) => ({
-      ...item,
-      position: index + 1
-    }));
-
-    setEmailItems(updatedItems);
-
-    // Save to backend
-    try {
-      await emailTemplateItemsApi.reorder(
-        template.id,
-        updatedItems.map(item => item.id)
-      );
-    } catch (err: any) {
-      setError(err.message || 'Failed to reorder emails');
-      // Revert on error
-      setEmailItems(emailItems);
-    }
-  };
 
   const isSystem = template?.template_type === 'system';
   const canEdit = !isSystem;
@@ -496,15 +478,6 @@ export default function TemplateBuilderPage({ templateId, createFromDefault, onB
                 <h2 className="text-base font-semibold text-white">
                   Email Sequence ({emailItems.length})
                 </h2>
-                {canEdit && template && (
-                  <button
-                    onClick={handleAddEmail}
-                    className="px-3 py-1.5 rounded-lg bg-purple-500/20 border border-purple-500/40 text-purple-400 hover:bg-purple-500/30 transition-all text-sm flex items-center gap-1.5"
-                  >
-                    <Plus className="w-4 h-4" />
-                    Add Email
-                  </button>
-                )}
               </div>
 
               {emailItems.length === 0 ? (
@@ -513,7 +486,7 @@ export default function TemplateBuilderPage({ templateId, createFromDefault, onB
                   <p className="text-white/60 text-sm mb-3">No emails in this template</p>
                   {canEdit && template && (
                     <button
-                      onClick={handleAddEmail}
+                      onClick={() => handleAddEmail()}
                       className="px-4 py-2 rounded-lg bg-purple-500/20 border border-purple-500/40 text-purple-400 hover:bg-purple-500/30 transition-all text-sm inline-flex items-center gap-2"
                     >
                       <Plus className="w-4 h-4" />
@@ -522,88 +495,76 @@ export default function TemplateBuilderPage({ templateId, createFromDefault, onB
                   )}
                 </div>
               ) : (
-                <DragDropContext onDragEnd={handleDragEnd}>
-                  <Droppable droppableId="email-items">
-                    {(provided) => (
-                      <div
-                        {...provided.droppableProps}
-                        ref={provided.innerRef}
-                        className="space-y-2"
-                      >
-                        {emailItems.map((item, index) => (
-                          <Draggable
-                            key={item.id}
-                            draggableId={item.id.toString()}
-                            index={index}
-                            isDragDisabled={!canEdit}
-                          >
-                            {(provided, snapshot) => (
-                              <div
-                                ref={provided.innerRef}
-                                {...provided.draggableProps}
-                                className={`p-4 rounded-lg border transition-all ${
-                                  snapshot.isDragging
-                                    ? 'border-purple-500 bg-purple-500/10 shadow-lg'
-                                    : 'border-white/10 bg-white/5 hover:bg-white/[0.07]'
-                                }`}
-                              >
-                                <div className="flex items-start gap-3">
-                                  {canEdit && (
-                                    <div
-                                      {...provided.dragHandleProps}
-                                      className="text-white/40 hover:text-white/60 cursor-grab active:cursor-grabbing mt-1"
-                                    >
-                                      <GripVertical className="w-5 h-5" />
-                                    </div>
-                                  )}
-
-                                  <div className="flex-shrink-0 w-8 h-8 rounded-full bg-purple-500/20 flex items-center justify-center">
-                                    <span className="text-sm font-medium text-purple-400">
-                                      {item.position}
-                                    </span>
-                                  </div>
-
-                                  <div className="flex-1 min-w-0">
-                                    <h3 className="font-medium text-white mb-1">{item.name}</h3>
-                                    <p className="text-sm text-white/60 truncate">
-                                      {item.subject_template || 'No subject'}
-                                    </p>
-                                    <div className="flex items-center gap-3 mt-2 text-xs text-white/50">
-                                      <span className="px-2 py-0.5 rounded bg-white/5 border border-white/10">
-                                        {item.category}
-                                      </span>
-                                      <span>{item.trigger_type}</span>
-                                    </div>
-                                  </div>
-
-                                  {canEdit && (
-                                    <div className="flex items-center gap-2">
-                                      <button
-                                        onClick={() => handleEditEmail(item)}
-                                        className="p-2 rounded-lg bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all"
-                                        title="Edit email"
-                                      >
-                                        <Edit className="w-4 h-4" />
-                                      </button>
-                                      <button
-                                        onClick={() => handleDeleteEmail(item.id)}
-                                        className="p-2 rounded-lg bg-white/5 border border-white/10 text-white/60 hover:text-red-400 hover:border-red-500/40 transition-all"
-                                        title="Delete email"
-                                      >
-                                        <Trash2 className="w-4 h-4" />
-                                      </button>
-                                    </div>
-                                  )}
+                <div className="space-y-4">
+                  {Object.entries(
+                    emailItems.reduce((groups, item) => {
+                      const cat = item.category || 'uncategorized';
+                      if (!groups[cat]) groups[cat] = [];
+                      groups[cat].push(item);
+                      return groups;
+                    }, {} as Record<string, EmailTemplateItem[]>)
+                  ).map(([category, items]) => {
+                    const categoryLabels: Record<string, string> = {
+                      event_announcements: 'Event Announcements',
+                      application_updates: 'Application Updates',
+                      payment_reminders: 'Payment Reminders',
+                      art_calls: 'Art Calls',
+                      artist_payment: 'Artist Payment',
+                      vendor_payment: 'Vendor Payment',
+                      artist_countdown: 'Artist Countdown',
+                      vendor_countdown: 'Vendor Countdown',
+                      uncategorized: 'Other',
+                    };
+                    return (
+                      <div key={category}>
+                        <div className="flex items-center gap-2 mb-1.5 px-1">
+                          <h3 className="text-xs font-semibold text-white/70 uppercase tracking-wide">
+                            {categoryLabels[category] || category}
+                          </h3>
+                          <span className="text-[10px] text-white/30 tabular-nums">{items.length}</span>
+                          {canEdit && template && (
+                            <button
+                              onClick={() => handleAddEmail(category)}
+                              className="p-0.5 rounded text-white/30 hover:text-purple-400 hover:bg-white/10 transition-all ml-auto"
+                              title={`Add email to ${categoryLabels[category] || category}`}
+                            >
+                              <Plus className="w-3.5 h-3.5" />
+                            </button>
+                          )}
+                        </div>
+                        <div className="rounded-lg border border-white/10 bg-white/[0.03] divide-y divide-white/5">
+                          {items.map((item) => (
+                            <div key={item.id} className="flex items-center gap-3 py-2.5 px-3">
+                              <Mail className="w-3.5 h-3.5 text-white/30 flex-shrink-0" />
+                              <span className="text-sm text-white truncate flex-1">{item.name}</span>
+                              <span className="text-[10px] text-white/40 flex-shrink-0 hidden sm:inline">
+                                {item.trigger_type}
+                              </span>
+                              {canEdit && (
+                                <div className="flex items-center gap-1 flex-shrink-0">
+                                  <button
+                                    onClick={() => handleEditEmail(item)}
+                                    className="p-1.5 rounded text-white/40 hover:text-white hover:bg-white/10 transition-all"
+                                    title="Edit email"
+                                  >
+                                    <Edit className="w-3.5 h-3.5" />
+                                  </button>
+                                  <button
+                                    onClick={() => handleDeleteEmail(item.id)}
+                                    className="p-1.5 rounded text-white/30 hover:text-red-400 hover:bg-white/10 transition-all"
+                                    title="Delete email"
+                                  >
+                                    <Trash2 className="w-3.5 h-3.5" />
+                                  </button>
                                 </div>
-                              </div>
-                            )}
-                          </Draggable>
-                        ))}
-                        {provided.placeholder}
+                              )}
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                    )}
-                  </Droppable>
-                </DragDropContext>
+                    );
+                  })}
+                </div>
               )}
             </div>
 

--- a/src/components/producer/Email/TemplateLibraryPage.tsx
+++ b/src/components/producer/Email/TemplateLibraryPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Mail, Plus, Copy, Trash2, Edit, Loader2, ArrowLeft, FileText, Calendar, Eye, Send, CheckCircle2, XCircle, AlertCircle } from 'lucide-react';
+import { Mail, Plus, Copy, Trash2, Edit, Loader2, ArrowLeft, Eye, Send, CheckCircle2, XCircle, AlertCircle } from 'lucide-react';
 import { emailCampaignTemplatesApi, emailTemplateItemsApi } from '@/services/api';
 import type { EmailCampaignTemplate, EmailTemplateItem } from '@/types/email';
 import { useAuth } from '@/contexts/AuthContext';
@@ -284,26 +284,84 @@ export default function TemplateLibraryPage({ onNavigateToBuilder, onBack }: Tem
         {/* All Sequences */}
         {!isLoading && !error && templates.length > 0 && (
           <div>
-            <div className="flex items-center gap-2 mb-3">
-              <Mail className="w-4 h-4 text-purple-400" />
-              <h2 className="text-base font-semibold text-white">All Sequences</h2>
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-purple-500/20 text-purple-400">
-                {templates.length}
-              </span>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {templates.map(template => (
-                <TemplateCard
-                  key={template.id}
-                  template={template}
-                  onEdit={() => onNavigateToBuilder?.(template.id)}
-                  onClone={() => handleClone(template)}
-                  onDelete={() => handleDelete(template)}
-                  onPreview={() => handlePreview(template)}
-                  deleteConfirm={deleteConfirmId === template.id}
-                  isAdmin={isAdmin}
-                />
-              ))}
+            <div className="rounded-lg border border-white/10 bg-white/[0.03] divide-y divide-white/5">
+              {templates.map(template => {
+                const isDefault = template.is_default;
+                const isSystem = template.template_type === 'system';
+                const canDelete = !isDefault && (template.template_type === 'user' || isAdmin);
+
+                return (
+                  <div
+                    key={template.id}
+                    className={`flex items-center gap-3 py-3 px-4 ${
+                      isDefault ? 'bg-yellow-500/[0.03]' : ''
+                    }`}
+                  >
+                    <Mail className="w-3.5 h-3.5 text-white/30 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-white font-medium truncate">{template.name}</span>
+                        {isDefault && (
+                          <span className="px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-yellow-500/20 text-yellow-300 border border-yellow-500/30 flex-shrink-0">
+                            Default
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 text-[10px] text-white/40 mt-0.5">
+                        <span>{template.email_count || 0} emails</span>
+                        {template.events_count > 0 && (
+                          <>
+                            <span className="text-white/20">·</span>
+                            <span>{template.events_count} events</span>
+                          </>
+                        )}
+                        {template.description && (
+                          <>
+                            <span className="text-white/20">·</span>
+                            <span className="truncate">{template.description}</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      <button
+                        onClick={() => onNavigateToBuilder?.(template.id)}
+                        className="p-1.5 rounded text-white/40 hover:text-white hover:bg-white/10 transition-all"
+                        title={isSystem ? 'View sequence' : 'Edit sequence'}
+                      >
+                        <Edit className="w-3.5 h-3.5" />
+                      </button>
+                      <button
+                        onClick={() => handlePreview(template)}
+                        className="p-1.5 rounded text-white/40 hover:text-white hover:bg-white/10 transition-all"
+                        title="Preview emails"
+                      >
+                        <Eye className="w-3.5 h-3.5" />
+                      </button>
+                      <button
+                        onClick={() => handleClone(template)}
+                        className="p-1.5 rounded text-white/40 hover:text-white hover:bg-white/10 transition-all"
+                        title="Clone sequence"
+                      >
+                        <Copy className="w-3.5 h-3.5" />
+                      </button>
+                      {canDelete && (
+                        <button
+                          onClick={() => handleDelete(template)}
+                          className={`p-1.5 rounded transition-all ${
+                            deleteConfirmId === template.id
+                              ? 'text-red-400 bg-red-500/10'
+                              : 'text-white/30 hover:text-red-400 hover:bg-white/10'
+                          }`}
+                          title={deleteConfirmId === template.id ? 'Click again to confirm' : 'Delete sequence'}
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}
@@ -562,106 +620,3 @@ export default function TemplateLibraryPage({ onNavigateToBuilder, onBack }: Tem
   );
 }
 
-interface TemplateCardProps {
-  template: EmailCampaignTemplate;
-  onEdit: () => void;
-  onClone: () => void;
-  onDelete: () => void;
-  onPreview: () => void;
-  deleteConfirm: boolean;
-  isAdmin: boolean;
-}
-
-function TemplateCard({ template, onEdit, onClone, onDelete, onPreview, deleteConfirm, isAdmin }: TemplateCardProps) {
-  const isSystem = template.template_type === 'system';
-  const isDefault = template.is_default;
-
-  // Can delete if: (1) Not default, AND (2) Either user template OR (admin + system template)
-  const canDelete = !isDefault && (template.template_type === 'user' || isAdmin);
-
-  return (
-    <div className={`p-4 rounded-lg border transition-all group ${
-      isDefault
-        ? 'border-yellow-500/50 bg-gradient-to-br from-yellow-500/5 via-white/5 to-white/5 hover:border-yellow-500/70 hover:shadow-lg hover:shadow-yellow-500/20'
-        : 'border-white/10 bg-white/5 hover:bg-white/[0.07]'
-    }`}>
-      {/* Header */}
-      <div className="flex items-start justify-between mb-2">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-0.5">
-            <h3 className="text-sm font-medium text-white truncate">
-              {template.name}
-            </h3>
-            {isDefault && (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-500/20 text-yellow-300 border border-yellow-500/30 flex-shrink-0 flex items-center gap-1">
-                <span className="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse"></span>
-                Default
-              </span>
-            )}
-          </div>
-          {template.description && (
-            <p className="text-xs text-white/60 line-clamp-2 mb-2">
-              {template.description}
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* Stats */}
-      <div className="flex items-center gap-4 text-xs text-white/50 mb-3">
-        <div className="flex items-center gap-1">
-          <Mail className="w-3.5 h-3.5" />
-          <span>{template.email_count || 0} emails</span>
-        </div>
-        {template.events_count > 0 && (
-          <div className="flex items-center gap-1">
-            <Calendar className="w-3.5 h-3.5" />
-            <span>{template.events_count} events</span>
-          </div>
-        )}
-      </div>
-
-      {/* Actions */}
-      <div className="flex items-center gap-2">
-        <button
-          onClick={onEdit}
-          className="flex-1 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-white text-sm hover:bg-white/10 transition-all flex items-center justify-center gap-1.5"
-          title={isSystem ? 'View sequence details' : 'Edit sequence'}
-        >
-          <Edit className="w-3.5 h-3.5" />
-          {isSystem ? 'View' : 'Edit'}
-        </button>
-        <button
-          onClick={onPreview}
-          className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-white text-sm hover:bg-white/10 transition-all flex items-center gap-1.5"
-          title="Preview all emails in this sequence"
-        >
-          <Eye className="w-3.5 h-3.5" />
-          <span className="hidden sm:inline">Preview</span>
-        </button>
-        <button
-          onClick={onClone}
-          className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-white text-sm hover:bg-white/10 transition-all flex items-center gap-1.5"
-          title="Create a copy of this sequence"
-        >
-          <Copy className="w-3.5 h-3.5" />
-          <span className="hidden sm:inline">Clone</span>
-        </button>
-        {canDelete && (
-          <button
-            onClick={onDelete}
-            className={`px-3 py-1.5 rounded-lg border text-sm transition-all flex items-center gap-1.5 ${
-              deleteConfirm
-                ? 'bg-red-500/20 border-red-500/40 text-red-400 hover:bg-red-500/30'
-                : 'bg-white/5 border-white/10 text-white/60 hover:text-red-400 hover:border-red-500/40'
-            }`}
-            title={deleteConfirm ? 'Click again to confirm deletion' : 'Delete this sequence'}
-          >
-            <Trash2 className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">{deleteConfirm ? 'Confirm' : 'Delete'}</span>
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}

--- a/src/components/producer/EventSettings.tsx
+++ b/src/components/producer/EventSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Calendar, Trash2, FileText, Edit, Pause, Link, Copy, ExternalLink, Check, X, Download, Database } from 'lucide-react';
+import { Trash2, FileText, Edit, Link, Copy, ExternalLink, Check, X, Plus } from 'lucide-react';
 import { vendorApplicationsApi, registrationsApi, eventInvitationsApi } from '@/services/api';
 import CreateApplicationForm from './CreateApplicationForm';
 import { formatDateForInput, formatEventDate } from '@/utils/dateHelpers';
@@ -68,20 +68,12 @@ interface EventSettingsProps {
   isAdmin?: boolean;
 }
 
-type View = 'settings' | 'create_app' | 'edit_app';
+type View = 'settings' | 'create_app';
 
 export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: EventSettingsProps) {
   const [currentView, setCurrentView] = useState<View>('settings');
   const [applications, setApplications] = useState<VendorApplication[]>([]);
-  const [selectedApplication, setSelectedApplication] = useState<VendorApplication | null>(null);
   const [loadingApps, setLoadingApps] = useState(false);
-
-  // Original settings state
-  const [isPublished, setIsPublished] = useState(event.published || event.status?.published || false);
-  const [registrationOpen, setRegistrationOpen] = useState(event.status?.registration_open || false);
-  const [eventStatus, setEventStatus] = useState<'draft' | 'published' | 'cancelled' | 'completed'>(
-    event.status?.status || 'draft'
-  );
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -99,6 +91,23 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
     application_deadline: formatDateForInput(event.application_deadline) || '',
     payment_deadline: formatDateForInput(event.payment_deadline) || '',
   });
+
+  // Inline application editing state
+  const [editingAppId, setEditingAppId] = useState<number | null>(null);
+  const [editFormData, setEditFormData] = useState({
+    name: '',
+    description: '',
+    booth_price: 0,
+    install_date: '',
+    install_start_time: '',
+    install_end_time: '',
+    payment_link: '',
+    status: 'active' as 'active' | 'inactive',
+  });
+  const [editTags, setEditTags] = useState<string[]>([]);
+  const [editNewTag, setEditNewTag] = useState('');
+  const [editLoading, setEditLoading] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
 
   // Copy link states
   const [copiedEventPageLink, setCopiedEventPageLink] = useState(false);
@@ -118,28 +127,6 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
       console.error('Failed to fetch applications:', err);
     } finally {
       setLoadingApps(false);
-    }
-  };
-
-  const handleSaveSettings = async () => {
-    if (!onUpdate) {
-      alert('Settings will be saved');
-      return;
-    }
-
-    try {
-      setIsSaving(true);
-      await onUpdate(event.slug, {
-        published: isPublished,
-        status: eventStatus,
-        registration_open: registrationOpen,
-      });
-      alert('Settings saved successfully!');
-    } catch (err) {
-      console.error('Failed to save settings:', err);
-      alert('Failed to save settings. Please try again.');
-    } finally {
-      setIsSaving(false);
     }
   };
 
@@ -196,7 +183,74 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
   const handleApplicationSuccess = () => {
     fetchApplications();
     setCurrentView('settings');
-    setSelectedApplication(null);
+  };
+
+  const startEditing = (app: VendorApplication) => {
+    setEditingAppId(app.id);
+    setEditFormData({
+      name: app.name || '',
+      description: app.description || '',
+      booth_price: app.pricing?.booth_price || 0,
+      install_date: formatDateForInput(app.install_date) || '',
+      install_start_time: app.install_start_time || '',
+      install_end_time: app.install_end_time || '',
+      payment_link: app.payment_link || '',
+      status: app.status || 'active',
+    });
+    setEditTags(
+      app.application_tags
+        ? app.application_tags.split(',').map(t => t.trim()).filter(t => t)
+        : []
+    );
+    setEditNewTag('');
+    setEditError(null);
+  };
+
+  const handleCancelInlineEdit = () => {
+    setEditingAppId(null);
+    setEditError(null);
+  };
+
+  const handleSaveInlineEdit = async () => {
+    if (!editFormData.name.trim()) {
+      setEditError('Application name is required');
+      return;
+    }
+    if (editFormData.booth_price < 0) {
+      setEditError('Booth price must be $0 or greater');
+      return;
+    }
+
+    try {
+      setEditLoading(true);
+      setEditError(null);
+      await vendorApplicationsApi.update(editingAppId!, {
+        name: editFormData.name.trim(),
+        description: editFormData.description.trim() || undefined,
+        booth_price: editFormData.booth_price,
+        status: editFormData.status,
+        install_date: editFormData.install_date || undefined,
+        install_start_time: editFormData.install_start_time || undefined,
+        install_end_time: editFormData.install_end_time || undefined,
+        payment_link: editFormData.payment_link || undefined,
+        application_tags: editTags.length > 0 ? editTags.join(',') : undefined,
+      });
+      setEditingAppId(null);
+      fetchApplications();
+    } catch (err: any) {
+      console.error('Failed to save application:', err);
+      setEditError(err.message || 'Failed to save application');
+    } finally {
+      setEditLoading(false);
+    }
+  };
+
+  const handleAddEditTag = () => {
+    const trimmed = editNewTag.trim();
+    if (trimmed && !editTags.includes(trimmed)) {
+      setEditTags([...editTags, trimmed]);
+      setEditNewTag('');
+    }
   };
 
   const copyToClipboard = async (text: string, type: 'eventpage' | 'portal') => {
@@ -354,8 +408,8 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
 
   const inputClasses = "w-full px-3 py-2 bg-white/5 border border-white/10 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-purple-500";
 
-  // Show create/edit form
-  if (currentView === 'create_app' || currentView === 'edit_app') {
+  // Show create form
+  if (currentView === 'create_app') {
     return (
       <CreateApplicationForm
         event={{
@@ -364,12 +418,8 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
           event_date: event.event_date,
           location: event.location,
         }}
-        onBack={() => {
-          setCurrentView('settings');
-          setSelectedApplication(null);
-        }}
+        onBack={() => setCurrentView('settings')}
         onSuccess={handleApplicationSuccess}
-        existingApplication={currentView === 'edit_app' ? selectedApplication || undefined : undefined}
       />
     );
   }
@@ -563,74 +613,6 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
             </div>
           </div>
 
-          {/* Event Status */}
-          <div className="bg-white/5 rounded-xl p-4 border border-white/10">
-            <div className="flex items-start gap-3">
-              <div className="flex-shrink-0 w-8 h-8 bg-purple-500/20 rounded-lg flex items-center justify-center">
-                <Calendar className="w-4 h-4 text-purple-400" />
-              </div>
-              <div className="flex-1">
-                <h3 className="text-sm text-white font-semibold mb-1">Event Status</h3>
-                <p className="text-white/60 text-xs mb-3">
-                  Update the current status of your event.
-                </p>
-                <div className="max-w-xs">
-                  <select
-                    value={eventStatus}
-                    onChange={(e) => setEventStatus(e.target.value as any)}
-                    className={`${inputClasses} cursor-pointer`}
-                  >
-                    <option value="draft">Draft</option>
-                    <option value="published">Published</option>
-                    <option value="cancelled">Cancelled</option>
-                    <option value="completed">Completed</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Data Export */}
-          <div className="bg-white/5 rounded-xl p-4 border border-white/10">
-            <div className="flex items-start gap-3">
-              <div className="flex-shrink-0 w-8 h-8 bg-blue-500/20 rounded-lg flex items-center justify-center">
-                <Database className="w-4 h-4 text-blue-400" />
-              </div>
-              <div className="flex-1">
-                <h3 className="text-sm text-white font-semibold mb-1">Data Export</h3>
-                <p className="text-white/60 text-xs mb-3">
-                  Export your event data for offline use or integration with other tools.
-                </p>
-                <div className="flex items-center justify-between p-3 bg-white/5 rounded-lg border border-white/10 hover:border-blue-500/30 transition-all">
-                  <div>
-                    <h4 className="text-white text-xs font-medium mb-0.5">Invites & Applications CSV</h4>
-                    <p className="text-white/50 text-[11px]">
-                      Download all invited contacts and submitted applications with their current status
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleExportInvitesCSV}
-                    className="flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium transition-all"
-                  >
-                    <Download className="w-3.5 h-3.5" />
-                    Export
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Save Button */}
-          <div className="flex justify-end">
-            <button
-              onClick={handleSaveSettings}
-              disabled={isSaving}
-              className="px-4 py-2 text-sm rounded-lg bg-gradient-to-r from-purple-600 to-blue-500 text-white font-medium hover:shadow-lg hover:scale-105 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isSaving ? 'Saving...' : 'Save Settings'}
-            </button>
-          </div>
-
       {/* Application Settings Section */}
       <div>
           <div className="flex items-center gap-2 mb-3">
@@ -640,31 +622,6 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
             <div>
               <h2 className="text-lg font-bold text-white">Application Settings</h2>
               <p className="text-white/60 text-xs">Control which categories are accepting applications</p>
-            </div>
-          </div>
-
-          {/* All Applications Master Toggle */}
-          <div className="bg-[#1e1536] rounded-xl p-4 border border-purple-500/20 mb-3">
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="text-sm text-white font-semibold">All Applications</h3>
-                <p className="text-white/60 text-xs">Master toggle for all categories</p>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className={`text-xs font-semibold ${registrationOpen ? 'text-green-400' : 'text-white/60'}`}>
-                  {registrationOpen ? 'Open' : 'Closed'}
-                </span>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={registrationOpen}
-                    onChange={(e) => setRegistrationOpen(e.target.checked)}
-                    className="sr-only peer"
-                  />
-                  <div className="w-11 h-6 bg-white/10 rounded-full peer peer-checked:bg-gradient-to-r peer-checked:from-green-600 peer-checked:to-green-500 transition-all"></div>
-                  <div className="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-5"></div>
-                </label>
-              </div>
             </div>
           </div>
 
@@ -691,9 +648,10 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
               applications.map((app) => (
                 <div
                   key={app.id}
-                  className="bg-[#1e1536] rounded-xl p-4 border border-purple-500/20 hover:border-purple-500/40 transition-all"
+                  className="bg-[#1e1536] rounded-xl border border-purple-500/20 hover:border-purple-500/40 transition-all"
                 >
-                  <div className="flex items-center justify-between">
+                  {/* Category Row */}
+                  <div className="flex items-center justify-between p-4">
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-0.5">
                         <h4 className="text-sm text-white font-semibold">{app.name}</h4>
@@ -702,51 +660,199 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
                             ${app.pricing.booth_price.toFixed(0)}
                           </span>
                         )}
+                        <span className={`text-[10px] font-medium ${app.status === 'active' ? 'text-green-400' : 'text-white/40'}`}>
+                          {app.status === 'active' ? 'Active' : 'Inactive'}
+                        </span>
                       </div>
                       <p className="text-white/60 text-xs">
                         {app.submissions_count} {app.submissions_count === 1 ? 'application' : 'applications'}
                       </p>
                     </div>
 
-                    <div className="flex items-center gap-2">
-                      <button
-                        disabled
-                        className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-white/20 text-white/40 cursor-not-allowed"
-                        title="Coming soon"
-                      >
-                        <Pause className="w-3.5 h-3.5" />
-                      </button>
+                    <button
+                      onClick={() => editingAppId === app.id ? handleCancelInlineEdit() : startEditing(app)}
+                      className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-white/30 text-white hover:bg-white/5 transition-all"
+                    >
+                      <Edit className="w-3.5 h-3.5" />
+                      <span className="text-xs">{editingAppId === app.id ? 'Cancel' : 'Edit'}</span>
+                    </button>
+                  </div>
 
-                      <button
-                        onClick={() => {
-                          setSelectedApplication(app);
-                          setCurrentView('edit_app');
-                        }}
-                        className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-white/30 text-white hover:bg-white/5 transition-all"
-                      >
-                        <Edit className="w-3.5 h-3.5" />
-                      </button>
+                  {/* Inline Edit Form */}
+                  {editingAppId === app.id && (
+                    <div className="border-t border-purple-500/20 p-4 space-y-3">
+                      {editError && (
+                        <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-2">
+                          <p className="text-red-400 text-xs">{editError}</p>
+                        </div>
+                      )}
 
-                      <div className="flex items-center gap-2">
-                        <span className={`text-xs font-semibold ${app.status === 'active' ? 'text-green-400' : 'text-white/60'}`}>
-                          {app.status === 'active' ? 'Accepting' : 'Closed'}
-                        </span>
-                        <label className="relative inline-flex items-center cursor-pointer">
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <div>
+                          <label className="block text-xs text-white/60 mb-1">Category Name *</label>
                           <input
-                            type="checkbox"
-                            checked={app.status === 'active'}
-                            onChange={() => {
-                              // TODO: Toggle application status
-                              console.log('Toggle application status:', app.id);
-                            }}
-                            className="sr-only peer"
+                            type="text"
+                            value={editFormData.name}
+                            onChange={(e) => setEditFormData({ ...editFormData, name: e.target.value })}
+                            className={inputClasses}
                           />
-                          <div className="w-11 h-6 bg-white/10 rounded-full peer peer-checked:bg-gradient-to-r peer-checked:from-green-600 peer-checked:to-green-500 transition-all"></div>
-                          <div className="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-5"></div>
-                        </label>
+                        </div>
+                        <div>
+                          <label className="block text-xs text-white/60 mb-1">Booth Price *</label>
+                          <div className="relative">
+                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-white/60 text-sm">$</span>
+                            <input
+                              type="number"
+                              min="0"
+                              step="0.01"
+                              value={editFormData.booth_price ?? ''}
+                              onChange={(e) => setEditFormData({ ...editFormData, booth_price: parseFloat(e.target.value) || 0 })}
+                              className={`${inputClasses} pl-7`}
+                            />
+                          </div>
+                        </div>
+                      </div>
+
+                      <div>
+                        <label className="block text-xs text-white/60 mb-1">Description</label>
+                        <textarea
+                          value={editFormData.description}
+                          onChange={(e) => setEditFormData({ ...editFormData, description: e.target.value })}
+                          rows={2}
+                          className={inputClasses}
+                        />
+                      </div>
+
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                        <div>
+                          <label className="block text-xs text-white/60 mb-1">Install Date</label>
+                          <input
+                            type="date"
+                            value={editFormData.install_date}
+                            onChange={(e) => setEditFormData({ ...editFormData, install_date: e.target.value })}
+                            className={inputClasses}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-white/60 mb-1">Install Start</label>
+                          <input
+                            type="time"
+                            value={editFormData.install_start_time}
+                            onChange={(e) => setEditFormData({ ...editFormData, install_start_time: e.target.value })}
+                            className={inputClasses}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-white/60 mb-1">Install End</label>
+                          <input
+                            type="time"
+                            value={editFormData.install_end_time}
+                            onChange={(e) => setEditFormData({ ...editFormData, install_end_time: e.target.value })}
+                            className={inputClasses}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <div>
+                          <label className="block text-xs text-white/60 mb-1">Payment Link</label>
+                          <input
+                            type="url"
+                            value={editFormData.payment_link}
+                            onChange={(e) => setEditFormData({ ...editFormData, payment_link: e.target.value })}
+                            placeholder="https://..."
+                            className={inputClasses}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-white/60 mb-1">Status</label>
+                          <select
+                            value={editFormData.status}
+                            onChange={(e) => setEditFormData({ ...editFormData, status: e.target.value as 'active' | 'inactive' })}
+                            className={`${inputClasses} cursor-pointer`}
+                          >
+                            <option value="active">Active</option>
+                            <option value="inactive">Inactive</option>
+                          </select>
+                        </div>
+                      </div>
+
+                      {/* Tags */}
+                      <div>
+                        <label className="block text-xs text-white/60 mb-1">Tags</label>
+                        <div className="flex gap-2 mb-2">
+                          <input
+                            type="text"
+                            value={editNewTag}
+                            onChange={(e) => setEditNewTag(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault();
+                                handleAddEditTag();
+                              }
+                            }}
+                            placeholder="Add tag..."
+                            className={`${inputClasses} flex-1`}
+                          />
+                          <button
+                            type="button"
+                            onClick={handleAddEditTag}
+                            className="px-2.5 py-2 rounded-lg bg-purple-600 hover:bg-purple-700 text-white transition-all"
+                          >
+                            <Plus className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                        {editTags.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5">
+                            {editTags.map((tag, index) => (
+                              <span
+                                key={index}
+                                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-purple-500/20 border border-purple-500/30 text-white text-[11px]"
+                              >
+                                {tag}
+                                <button
+                                  type="button"
+                                  onClick={() => setEditTags(editTags.filter(t => t !== tag))}
+                                  className="text-white/60 hover:text-white"
+                                >
+                                  <X className="w-2.5 h-2.5" />
+                                </button>
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Save / Cancel */}
+                      <div className="flex gap-2 pt-1">
+                        <button
+                          onClick={handleSaveInlineEdit}
+                          disabled={editLoading}
+                          className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {editLoading ? (
+                            <>
+                              <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                              Saving...
+                            </>
+                          ) : (
+                            <>
+                              <Check className="w-3.5 h-3.5" />
+                              Save
+                            </>
+                          )}
+                        </button>
+                        <button
+                          onClick={handleCancelInlineEdit}
+                          disabled={editLoading}
+                          className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-white/30 text-white hover:bg-white/5 transition-all disabled:opacity-50"
+                        >
+                          <X className="w-3.5 h-3.5" />
+                          Cancel
+                        </button>
                       </div>
                     </div>
-                  </div>
+                  )}
                 </div>
               ))
             )}
@@ -976,7 +1082,7 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
           event,
           currentView,
           applications,
-          selectedApplication,
+          editingAppId,
         }}
         isAdmin={isAdmin}
       />

--- a/src/components/producer/EventsList.tsx
+++ b/src/components/producer/EventsList.tsx
@@ -264,7 +264,6 @@ export default function EventsList({
           filteredAndSortedEvents.map((event) => {
             const badge = getStatusBadge(event);
             const applicantCount = event.capacity?.registered || event.registered_count || 0;
-            const acceptedCount = Math.floor(applicantCount * 0.6); // Mock calculation
 
             return (
               <div
@@ -305,8 +304,6 @@ export default function EventsList({
                       )}
                       <span className="text-white/30">•</span>
                       <span>{applicantCount} applicants</span>
-                      <span className="text-white/30">•</span>
-                      <span>{acceptedCount} accepted</span>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary
- **Slim list patterns** across all email views: vendor email history, sequence library, sequence editor, and wizard Step 4 — replacing chunky card grids and drag-and-drop layouts with consistent `divide-y` rows grouped by category
- **Removed broken/incomplete features**: Payments tab, Data Export, Event Status dropdown, pause toggles, fake accepted count, dead Edit button in wizard
- **Inline application editing** in Settings — category rows expand in-place instead of full-page takeover
- **Per-category "Add Email" buttons** in sequence editor with smart default triggers
- **Compacted auto-refresh toggle** on Mail tab from full card section to tiny inline switch

## Files changed (8)
- `ApplicantsTab.tsx` — slim email history rows, section reorder
- `CommandCenter.tsx` — removed Payments tab
- `Step4AutoMessages.tsx` — dropdown selector, grouped rows
- `EmailAutomationTab.tsx` — compact auto-refresh toggle
- `TemplateBuilderPage.tsx` — category-grouped rows, per-category add button
- `TemplateLibraryPage.tsx` — card grid → slim list
- `EventSettings.tsx` — removed broken features, inline editing
- `EventsList.tsx` — removed fake accepted count

## Test plan
- [ ] Verify email history renders as slim rows in vendor detail panel
- [ ] Verify email sequence library shows as slim list with action icons
- [ ] Verify per-category "+" button adds email to correct category
- [ ] Verify inline edit expand/collapse works for application categories
- [ ] Verify Payments tab is removed from command center
- [ ] Verify no regressions in existing email preview/clone/delete flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)