### PR TITLE
Staging feedback: tags, retry, spacing, delete button

### DIFF
--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -1138,36 +1138,6 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                             <span className={`text-[10px] font-medium ${statusColor} flex-shrink-0 w-16 text-right`}>
                               {deliveryStatus}
                             </span>
-                            {(deliveryStatus === 'bounced' || deliveryStatus === 'dropped') && (
-                              <button
-                                onClick={async () => {
-                                  try {
-                                    await emailDeliveriesApi.retry(delivery.id);
-                                    toast.success('Email queued for retry');
-                                    let refreshedHistory: any[] = [];
-                                    if (selectedApplicant.registrationId) {
-                                      const regHistory = await emailDeliveriesApi.getByRegistration(selectedApplicant.registrationId);
-                                      refreshedHistory = [...(regHistory || [])];
-                                    }
-                                    if (selectedApplicant.invitationId) {
-                                      const invHistory = await emailDeliveriesApi.getByInvitation(eventSlug, selectedApplicant.invitationId);
-                                      refreshedHistory = [...refreshedHistory, ...(invHistory || [])];
-                                    }
-                                    refreshedHistory.sort((a, b) => {
-                                      const dateA = new Date(a.delivered_at || a.sent_at || a.created_at).getTime();
-                                      const dateB = new Date(b.delivered_at || b.sent_at || b.created_at).getTime();
-                                      return dateB - dateA;
-                                    });
-                                    setEmailHistoryData(refreshedHistory);
-                                  } catch (err: any) {
-                                    toast.error(`Failed to retry: ${err.message}`);
-                                  }
-                                }}
-                                className="text-[10px] text-purple-400 hover:text-purple-300 flex-shrink-0"
-                              >
-                                Retry
-                              </button>
-                            )}
                           </div>
                         );
                       })}

--- a/src/components/producer/Email/EmailSequenceEditorOverlay.tsx
+++ b/src/components/producer/Email/EmailSequenceEditorOverlay.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useMemo } from 'react';
-import { ArrowLeft, Mail, Edit2, Eye, MoreVertical, Play, Pause, Trash2, Megaphone, FileText, CreditCard, Calendar, Settings2, Plus, HelpCircle, Send, Loader2, X } from 'lucide-react';
+import { ArrowLeft, Mail, Edit2, Eye, MoreVertical, Play, Pause, Megaphone, FileText, CreditCard, Calendar, Settings2, Plus, HelpCircle, Send, Loader2, X } from 'lucide-react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { Button } from '@/components/ui/button';
 import type { ScheduledEmail } from '@/types/email';
@@ -522,20 +522,6 @@ export default function EmailSequenceEditorOverlay({
                           {isSent ? <Eye className="w-3.5 h-3.5" /> : <Edit2 className="w-3.5 h-3.5" />}
                           {isSent ? 'View' : 'Edit'}
                         </button>
-                        {!isSent && isCustomCountdown(selectedEmail.trigger_type) && (
-                          <button
-                            onClick={() => {
-                              if (confirm('Delete this email? This cannot be undone.')) {
-                                onDelete(selectedEmail.id);
-                              }
-                            }}
-                            className="px-3 py-1.5 rounded-lg border border-red-500/40 bg-red-500/20 text-red-300 hover:bg-red-500/30 transition-all text-sm flex items-center gap-1.5"
-                            title="Delete email"
-                          >
-                            <Trash2 className="w-3.5 h-3.5" />
-                            Delete
-                          </button>
-                        )}
                         {!isSent && (
                           <SequenceRowMenu
                             email={selectedEmail}

--- a/src/components/producer/Email/EmailTemplateEditorPage.tsx
+++ b/src/components/producer/Email/EmailTemplateEditorPage.tsx
@@ -20,6 +20,7 @@ import {
   CheckCircle2,
   AlertCircle,
   Lock,
+  Search,
 } from 'lucide-react';
 import type { EmailTemplateItem } from '@/types/email';
 import {
@@ -133,6 +134,7 @@ export function EmailTemplateEditorPage({
   const [activeField, setActiveField] = useState<'subject' | 'body' | null>(null);
   const [triggerSettingsOpen, setTriggerSettingsOpen] = useState(true);
   const [availableTagsOpen, setAvailableTagsOpen] = useState(true);
+  const [tagSearch, setTagSearch] = useState('');
   const [bodyEditor, setBodyEditor] = useState<Editor | null>(null);
   const [showPreview, setShowPreview] = useState(false);
   const [emailFooter, setEmailFooter] = useState<string>(''); // Locked footer content
@@ -635,6 +637,16 @@ export function EmailTemplateEditorPage({
 
               {availableTagsOpen && (
                 <div className="space-y-3">
+                  <div className="relative">
+                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/40" />
+                    <input
+                      type="text"
+                      value={tagSearch}
+                      onChange={(e) => setTagSearch(e.target.value)}
+                      placeholder="Search tags..."
+                      className="w-full pl-8 pr-3 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder-white/30 focus:outline-none focus:border-purple-500/50"
+                    />
+                  </div>
                   <p className="text-[10px] text-white/60 mb-2 leading-relaxed">
                     Click a tag to insert it at your cursor position
                     {formData.category === 'event_announcements' && (
@@ -644,13 +656,22 @@ export function EmailTemplateEditorPage({
                     )}
                   </p>
                   <div className="space-y-3">
-                    {getGroupedVariablesForUI().map((group) => (
+                    {getGroupedVariablesForUI().map((group) => {
+                      const filteredVars = tagSearch
+                        ? group.variables.filter(v =>
+                            v.label.toLowerCase().includes(tagSearch.toLowerCase()) ||
+                            v.frontendVar.toLowerCase().includes(tagSearch.toLowerCase()) ||
+                            v.description.toLowerCase().includes(tagSearch.toLowerCase())
+                          )
+                        : group.variables;
+                      if (filteredVars.length === 0) return null;
+                      return (
                       <div key={group.label}>
                         <h4 className="text-[10px] font-semibold text-purple-400 uppercase tracking-wide mb-1.5 px-1">
                           {group.label}
                         </h4>
                         <div className="space-y-0.5">
-                          {group.variables.map((variable) => {
+                          {filteredVars.map((variable) => {
                             const isAnnouncementEmail = formData.category === 'event_announcements';
                             const isDisabled = (isAnnouncementEmail && !variable.worksInInvitations) || !activeField;
 
@@ -685,7 +706,8 @@ export function EmailTemplateEditorPage({
                           })}
                         </div>
                       </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/src/components/producer/InvitesTab.tsx
+++ b/src/components/producer/InvitesTab.tsx
@@ -868,24 +868,6 @@ export default function InvitesTab({ eventSlug, organizationId, event, isAdmin }
 
                                           {/* Action buttons */}
                                           <div className="flex gap-2 mt-2">
-                                            {(deliveryStatus === 'bounced' || deliveryStatus === 'dropped') && (
-                                              <button
-                                                onClick={async () => {
-                                                  try {
-                                                    await emailDeliveriesApi.retry(delivery.id);
-                                                    alert('Email queued for retry');
-                                                    // Refresh email history
-                                                    const updated = await emailDeliveriesApi.getByRegistration(row.registrationId!);
-                                                    setEmailHistoryData((prev) => ({ ...prev, [row.id]: updated }));
-                                                  } catch (err: any) {
-                                                    alert(`Failed to retry: ${err.message}`);
-                                                  }
-                                                }}
-                                                className="text-[10px] px-2 py-1 rounded bg-purple-600/20 text-purple-400 hover:bg-purple-600/30 transition-smooth"
-                                              >
-                                                Retry
-                                              </button>
-                                            )}
                                           </div>
                                         </div>
                                       );

--- a/src/components/producer/Network/ContactRow.tsx
+++ b/src/components/producer/Network/ContactRow.tsx
@@ -34,7 +34,7 @@ export default function ContactRow({
 
   return (
     <div className="hover:bg-white/5 transition-colors border-b border-white/5 last:border-0">
-      <div className={`grid grid-cols-[28px,1fr,130px,110px,120px,90px,70px,1fr,120px,60px] gap-2 px-2 py-2 items-center text-[11px] ${isUnsubscribed ? 'opacity-60' : ''}`}>
+      <div className={`grid grid-cols-[28px,160px,130px,110px,120px,90px,70px,1fr,120px,60px] gap-2 px-2 py-2 items-center text-[11px] ${isUnsubscribed ? 'opacity-60' : ''}`}>
         {/* Checkbox */}
         <div className="flex items-center justify-center" onClick={(e) => e.stopPropagation()}>
           <input

--- a/src/components/producer/Network/ContactsTable.tsx
+++ b/src/components/producer/Network/ContactsTable.tsx
@@ -34,7 +34,7 @@ export default function ContactsTable({
     <div className="bg-white/5 rounded-lg border border-white/10 overflow-hidden">
       {/* Table Header - Condensed view for all screen sizes */}
       <div className="bg-gradient-to-r from-purple-900/40 to-blue-900/40 border-b border-white/10">
-        <div className="grid grid-cols-[28px,1fr,130px,110px,120px,90px,70px,1fr,120px,60px] gap-2 px-2 py-1 items-center text-[10px] font-semibold text-white/70 uppercase tracking-wide">
+        <div className="grid grid-cols-[28px,160px,130px,110px,120px,90px,70px,1fr,120px,60px] gap-2 px-2 py-1 items-center text-[10px] font-semibold text-white/70 uppercase tracking-wide">
           <div className="flex items-center justify-center">
             <input
               type="checkbox"

--- a/src/utils/emailVariables.ts
+++ b/src/utils/emailVariables.ts
@@ -24,7 +24,7 @@ export interface EmailVariable {
   backendVar: string;
 
   // Category for grouping
-  category: 'event' | 'organization' | 'vendor' | 'computed';
+  category: 'event' | 'organization' | 'vendor' | 'computed' | 'links';
 
   // Help text
   description: string;
@@ -90,8 +90,8 @@ export const EMAIL_VARIABLES: EmailVariable[] = [
     frontendVar: '[eventLocation]',
     backendVar: '{{event_location}}',
     category: 'event',
-    description: 'Venue and address',
-    example: 'Piedmont Park, Atlanta, GA',
+    description: 'City and state of the event',
+    example: 'Atlanta, GA',
     worksInInvitations: true
   },
   {
@@ -99,17 +99,26 @@ export const EMAIL_VARIABLES: EmailVariable[] = [
     frontendVar: '[eventCity]',
     backendVar: '{{event_city}}',
     category: 'event',
-    description: 'City extracted from event location',
+    description: 'City of the event',
     example: 'Atlanta',
     worksInInvitations: true
   },
   {
-    label: 'Address',
-    frontendVar: '[address]',
-    backendVar: '{{address}}',
+    label: 'Event State',
+    frontendVar: '[eventState]',
+    backendVar: '{{event_state}}',
     category: 'event',
-    description: 'Full event location/address (same as Event Location)',
-    example: 'Piedmont Park, Atlanta, GA',
+    description: 'State/region of the event',
+    example: 'GA',
+    worksInInvitations: true
+  },
+  {
+    label: 'Event Address',
+    frontendVar: '[eventAddress]',
+    backendVar: '{{event_address}}',
+    category: 'event',
+    description: 'Street address of the event',
+    example: '123 Johnson Street',
     worksInInvitations: true
   },
   {
@@ -117,7 +126,7 @@ export const EMAIL_VARIABLES: EmailVariable[] = [
     frontendVar: '[eventVenue]',
     backendVar: '{{event_venue}}',
     category: 'event',
-    description: 'Venue name only',
+    description: 'Venue name/title of the event location',
     example: 'Piedmont Park',
     worksInInvitations: true
   },
@@ -309,18 +318,18 @@ export const EMAIL_VARIABLES: EmailVariable[] = [
     label: 'Category Payment Link',
     frontendVar: '[categoryPaymentLink]',
     backendVar: '{{category_payment_link}}',
-    category: 'vendor',
+    category: 'links',
     description: 'Payment link for the specific vendor category (only works after they apply)',
     example: 'https://pay.stripe.com/...',
     worksInInvitations: false
   },
 
-  // Computed/Link Variables
+  // Link Variables
   {
     label: 'Apply to Event',
     frontendVar: '[eventLink]',
     backendVar: '{{event_link}}',
-    category: 'computed',
+    category: 'links',
     description: 'Public application page URL - where vendors apply to your event',
     example: 'https://voxxy.io/events/org-slug/event-slug-123',
     worksInInvitations: true
@@ -329,7 +338,7 @@ export const EMAIL_VARIABLES: EmailVariable[] = [
     label: 'Event Dashboard',
     frontendVar: '[eventPortalLink]',
     backendVar: '{{event_portal_link}}',
-    category: 'computed',
+    category: 'links',
     description: 'Vendor portal/dashboard link (requires email to access)',
     example: 'https://voxxy.io/portal/org-slug/event-slug-123',
     worksInInvitations: true
@@ -338,19 +347,10 @@ export const EMAIL_VARIABLES: EmailVariable[] = [
     label: 'Unsubscribe Link',
     frontendVar: '[unsubscribeLink]',
     backendVar: '{{unsubscribe_link}}',
-    category: 'computed',
+    category: 'links',
     description: 'Unsubscribe URL (required for all emails)',
     example: 'https://voxxy.io/unsubscribe/abc123token',
     worksInInvitations: true
-  },
-  {
-    label: 'Payment Link',
-    frontendVar: '[paymentLink]',
-    backendVar: '{{payment_link}}',
-    category: 'computed',
-    description: 'Payment URL for vendor (category-specific - only works after they apply)',
-    example: 'https://pay.stripe.com/...',
-    worksInInvitations: false
   },
   {
     label: 'Application Code',
@@ -508,7 +508,13 @@ export function getGroupedVariablesForUI(): VariableGroup[] {
     {
       label: 'Event Details',
       variables: EMAIL_VARIABLES
-        .filter(v => v.category === 'event' || v.category === 'computed')
+        .filter(v => v.category === 'event')
+        .sort(sortByLabel)
+    },
+    {
+      label: 'Links',
+      variables: EMAIL_VARIABLES
+        .filter(v => v.category === 'links' || v.category === 'computed')
         .sort(sortByLabel)
     }
   ];


### PR DESCRIPTION
## Summary
- **Email tags:** Add `[eventState]` and `[eventAddress]` (street address), update `[eventLocation]` to city+state, remove redundant `[paymentLink]`, move link tags to new "Links" section
- **Tag picker UI:** Add search bar to filter tags by name/description
- **Retry button:** Remove non-functional retry button on bounced/dropped emails in command center (ApplicantsTab + InvitesTab)
- **Network tab:** Reduce name column width from `1fr` to `160px` to fix excessive spacing
- **Sequence editor:** Remove Delete button from inside the editor overlay (broken for events with FK constraints)

## Test plan
- [ ] Open email template editor → verify 4 groups: Vendor Details, Organization Details, Event Details, Links
- [ ] Search bar filters tags correctly
- [ ] `[eventState]`, `[eventAddress]` appear in Event Details group
- [ ] `[paymentLink]` is gone, only Category Payment Link exists (in Links)
- [ ] Command center → expand vendor → email history → no Retry button on bounced/dropped
- [ ] Network tab → name column is narrower, less whitespace
- [ ] Email sequence editor → no Delete button on countdown emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)