### PR TITLE
fix: improve API error messages by prioritizing validation errors

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -132,7 +132,16 @@ async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> 
         errors: errorData.errors
       })
 
-      const errorMessage = errorData.message || errorData.error || `API request failed (${response.status})`
+      // Build error message - prioritize specific validation errors from errors array
+      let errorMessage: string
+      if (errorData.errors && Array.isArray(errorData.errors) && errorData.errors.length > 0) {
+        // If we have specific validation errors, use the first one as the main message
+        errorMessage = errorData.errors[0]
+      } else {
+        // Fallback to message/error field or generic message
+        errorMessage = errorData.message || errorData.error || `API request failed: ${response.status}`
+      }
+
       throw new ApiError(errorMessage, response.status, errorData.errors)
     }
 


### PR DESCRIPTION
Previously, when the backend returned validation errors in the 'errors' array (e.g., { errors: ['Email already exists for this organization'] }), the fetchApi function would ignore them and construct a generic message like 'API request failed: 422'.

This commit updates the error message construction logic to:
1. First check if errorData.errors array exists and has items
2. Use the first error from the array as the error message
3. Fall back to errorData.message/error fields if no errors array
4. Finally fall back to generic 'API request failed: {status}' message

This provides users with specific, actionable error messages instead of generic HTTP status codes, improving the overall UX across the application.

Impact:
- AddContactModal: Now shows 'Email already exists...' instead of '422'
- All form validations: Shows specific backend validation messages
- Backward compatible: error.errors array still available for components that want to display multiple errors or map to specific fields

Fixes issue where customer received generic 422 error when trying to create duplicate vendor contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)