### PR TITLE
feat(portal): vendor event portal UI, hero preview pill, location map…

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -228,6 +228,49 @@ Covered by Bug 2 above — fix `getAvailablePriceTypes` to filter per-type.
 
 ### 🟡 BUG 5: LegalLayout Uses Inline Hex Gradient (RL-001 / RL-002)
 
+---
+
+### 🟡 BUG 6: Vendor Portal — Dark Mode Colours Need Adjustment (RL-001)
+
+**Symptom**: The vendor portal page canvas and hero overlay use raw hex dark-mode gradients (`#120b1c`, `#1a1228`) that need to be tuned to match the central dark mode style guide.
+
+**Fix needed**: Align gradient stops in `VendorPortalPageCanvas.tsx` and `VendorEventPortalPage.tsx` (hero overlay) with the `--voxxy-*` dark palette or extract to a shared CSS class.
+
+**Files**:
+- `src/components/vendor-portal/VendorPortalPageCanvas.tsx`
+- `src/pages/VendorEventPortalPage.tsx` (hero overlay ~line 376)
+
+---
+
+### 🟡 BUG 7: Vendor Portal — FAQ Section Is Hardcoded (Hide Until Editable)
+
+**Symptom**: The `VendorPortalFaq` component renders hardcoded FAQ content. There is no producer-facing UI to create or edit FAQ entries yet.
+
+**Decision pending**: Should FAQ editing live in the **Create Event Wizard** or in the **Event Settings / Command Center**? Until decided and built, the FAQ section should be hidden from the portal.
+
+**Fix needed**: Conditionally hide `<VendorPortalFaq />` render in `VendorEventPortalPage.tsx` (e.g. behind a feature flag or simply comment out) until the editing flow is implemented.
+
+**Files**:
+- `src/pages/VendorEventPortalPage.tsx`
+- `src/components/vendor-portal/VendorPortalFaq.tsx`
+
+---
+
+### 🟡 BUG 8: Vendor Portal — Hero Banner Image Upload Not Persisting
+
+**Symptom**: Producers can pick a hero banner image via the uploader UI, but the image is only held in local state (preview URL). It is not saved to the backend — there is no attachment endpoint or model field for it yet.
+
+**Fix needed (backend + frontend)**:
+1. Backend: Add an Active Storage attachment (e.g. `has_one_attached :portal_banner`) to the Event model, expose an upload endpoint.
+2. Frontend: POST the selected file to the new endpoint on save, load the persisted URL on portal render instead of relying on local blob preview.
+
+**Files**:
+- `src/pages/VendorEventPortalPage.tsx` (banner state + upload handlers)
+- `src/components/vendor-portal/VendorPortalHero.tsx` (displays banner)
+- Backend: Event model + controller (TBD)
+
+---
+
 **Symptom**: `LegalLayout.tsx` line 25 uses `style={{ background: 'linear-gradient(160deg, #f5f3ff 0%, #ede9fe 40%, #f0f4ff 100%)' }}` — raw hex values and inline style.
 
 **Context**: This is intentional for the forced-light legal pages (`useForceTheme('light')`). Standard dark-mode tokens don't apply here. Low priority but should be extracted to a CSS class (e.g. `voxxy-legal-bg`) in `src/index.css` for consistency.

--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -1,10 +1,10 @@
-# Developer Handoff — UI Polish + Payment Preferences Sprint
+# Known Bugs & Issues
 
-> **Branch**: `feature/design-tweaks-and-applicants` → merge target: `staging`
-> **Date**: May 2026
-> **Backend branch**: `feature/category-payment-fields` in `voxxy-rails-react`
+> **Last updated**: May 8, 2026
+> **Frontend**: `voxxy-presents-client` (staging)
+> **Backend**: `voxxy-rails-react` (staging)
 
-This document is intended for the next developer (or agent) picking up this work. It summarises what was completed, what is partially working, and the known bugs that must be resolved **before merging to `main`**.
+Tracks known bugs, incomplete features, and issues to resolve before merging staging to `main`.
 
 ---
 
@@ -281,22 +281,51 @@ Covered by Bug 2 above — fix `getAvailablePriceTypes` to filter per-type.
 
 ---
 
-## Before Opening the PR to Main
+## Resolved (Merged to Staging)
 
-- [ ] Resolve Bug 1 (payment preferences 4-layer fix: migration + params + API type + uncomment Dashboard)
-- [ ] Resolve Bug 2 (enforce single-instance for non-early-bird types in wizard + category modal)
-- [ ] Resolve Bug 4 (EditContactModal inputs → `voxxy-input-frost`)
-- [ ] Resolve Bug 5 (LegalLayout inline hex gradient → CSS class)
-- [ ] Resolve Bug 6 (Vendor portal dark mode colours → align with style guide)
-- [ ] Resolve Bug 7 (Hide hardcoded FAQ section until editing UI is built)
-- [ ] Resolve Bug 8 (Hero banner upload — backend attachment + frontend persistence)
-- [ ] Resolve Bug 9 (Payment email scheduling — guard in generator when deadline is blank)
-- [ ] Confirm `bin/rails db:migrate` has been run on staging DB
-- [ ] Run all unit tests: `npm run test:run` — expect 83 passing
-- [ ] Smoke test: add a category with mixed fee types, create an event with that category, confirm Step 3 pre-populates correctly
+- [x] ~~Bug 1~~ — Payment preferences 4-layer fix (PR #105 backend + PR #87 frontend)
+- [x] ~~Bug 2~~ — Fee type limits enforced (max 3 early birds, 1 of each other)
+- [x] ~~Bug 3~~ — Pending migration resolved (migrations ran on staging)
+- [x] ~~Bug 7~~ — FAQ section hidden until backend editing UI exists
+- [x] ~~Bug 9~~ — Payment email scheduling fixed (`.to_date` + required deadline in wizard)
+
+---
+
+## Open Issues — Before Merging to Main
+
+- [ ] Bug 4 (EditContactModal inputs → `voxxy-input-frost`)
+- [ ] Bug 5 (LegalLayout inline hex gradient → CSS class)
+- [ ] Bug 6 (Vendor portal dark mode colours → align with style guide)
+- [ ] Bug 8 (Hero banner upload — backend attachment + frontend persistence)
+- [ ] Bug 10 (Vendor portal login page — verify auth path, unknown login page discovered)
+- [ ] Bug 11 (Vendor portal color theme — purple/gradient tones don't match producer app palette)
+- [ ] Smoke test: add a category with mixed fee types, create event, confirm Step 3 pre-populates
 - [ ] Verify legal pages look correct in both dark and light system theme
-- [ ] Verify pricing page "Request Access" buttons render at proper size
 - [ ] Retro: review all Sentry alerts for related regressions
+
+---
+
+### 🟡 BUG 10: Vendor Portal — Auth Path / Login Page Needs Verification
+
+**Symptom**: The portal has its own email-based login gate (`VendorEventPortalPage.tsx`). Need to verify this auth flow works correctly and doesn't conflict with the main app login. Confirm whether the portal login page is intentional or if vendors should use the standard auth flow.
+
+**Files**:
+- `src/pages/VendorEventPortalPage.tsx` (email gate ~line 369-451)
+- `src/services/eventPortalService.ts` (portal access verification)
+
+---
+
+### 🟡 BUG 11: Vendor Portal — Color Theme Mismatch
+
+**Symptom**: The event portal auth page, hero overlay, and section cards use purple/violet gradients and hex values (`#120b1c`, `#1a1228`) that don't match the central `--voxxy-*` token palette used in the producer app. The portal should feel like the same product.
+
+**Fix needed**: Audit all portal components against `STYLE_GUIDE.md` and replace raw hex values with CSS tokens or `voxxy-*` utility classes.
+
+**Files**:
+- `src/components/vendor-portal/VendorPortalPageCanvas.tsx`
+- `src/components/vendor-portal/VendorPortalHero.tsx`
+- `src/components/vendor-portal/VendorPortalSection.tsx`
+- `src/pages/VendorEventPortalPage.tsx`
 
 ---
 

--- a/docs/SESSION_GUIDE.md
+++ b/docs/SESSION_GUIDE.md
@@ -49,14 +49,14 @@
 | RL-010 | All producer-app form fields must use `voxxy-input-frost` class. Do not use raw shadcn Input styling. | [STYLE_GUIDE.md](./STYLE_GUIDE.md) §5 |
 | RL-011 | New Voxxy-specific CSS utility classes must be prefixed with `voxxy-` and defined in `@layer components` in `src/index.css`. | [STYLE_GUIDE.md](./STYLE_GUIDE.md) §5 |
 | RL-012 | Modals should use standardised shell: `max-w-2xl max-h-[82vh]` with gradient header and scrollable body, unless a wider size is justified. | [GLASS_MODAL_DESIGN_SYSTEM.md](./design/GLASS_MODAL_DESIGN_SYSTEM.md) |
-| RL-013 | When removing a duplicate guard (like fee-type dedup), check if it should be narrowed rather than fully removed. Only `early_bird_price` allows multiples. | [HANDOFF.md](./HANDOFF.md) Bug 2 |
+| RL-013 | When removing a duplicate guard (like fee-type dedup), check if it should be narrowed rather than fully removed. Only `early_bird_price` allows multiples. | [KNOWN_BUGS.md](./KNOWN_BUGS.md) Bug 2 |
 
 ### Backend Rules
 
 | ID | Rule | Source |
 |------|------|--------|
-| RL-014 | Always run `bin/rails db:migrate` after pulling changes. Pending migrations block login and API calls. | [HANDOFF.md](./HANDOFF.md) Bug 3 |
-| RL-015 | When adding a new model attribute, update BOTH `strong_params` (permit) AND the serialiser method. Missing serialiser output is a silent bug. | [HANDOFF.md](./HANDOFF.md) Bug 1 |
+| RL-014 | Always run `bin/rails db:migrate` after pulling changes. Pending migrations block login and API calls. | [KNOWN_BUGS.md](./KNOWN_BUGS.md) Bug 3 |
+| RL-015 | When adding a new model attribute, update BOTH `strong_params` (permit) AND the serialiser method. Missing serialiser output is a silent bug. | [KNOWN_BUGS.md](./KNOWN_BUGS.md) Bug 1 |
 | RL-016 | Sidekiq workers run on a 5-minute cron cycle. Test email jobs with `EmailSenderWorker.new.perform` in rails console rather than waiting for cron. | Backend email docs |
 | RL-017 | Verify SendGrid template IDs match between environments. Staging and production use different template sets. | Backend email docs |
 | RL-018 | Use FactoryBot for test data in RSpec. Never create records with raw `Model.create!` in specs. | Backend TESTING.md |
@@ -159,7 +159,7 @@ fi
 # ── Frontend ──
 cd ~/Development/voxxy-presents-client
 npm run test:run
-# Expected: 62+ tests passing (see HANDOFF.md for current count)
+# Expected: 62+ tests passing (see KNOWN_BUGS.md for current count)
 ```
 
 ```bash
@@ -176,7 +176,7 @@ Based on your task, read the relevant docs from the **Extended Doc References** 
 
 At minimum, always read:
 - This file (you are reading it now)
-- [docs/HANDOFF.md](./HANDOFF.md) — Current sprint status and known bugs
+- [docs/KNOWN_BUGS.md](./KNOWN_BUGS.md) — Current sprint status and known bugs
 
 ### Step 4: Produce bootstrap summary
 
@@ -225,7 +225,7 @@ bundle exec rspec           # Tests
 
 ### Step 4: Check the HANDOFF known bugs list
 
-Read [docs/HANDOFF.md](./HANDOFF.md) "Known Bugs" section.
+Read [docs/KNOWN_BUGS.md](./KNOWN_BUGS.md) "Known Bugs" section.
 - If your PR resolves any listed bug, note it in the summary and in the PR description.
 - If your PR introduces changes that interact with a known bug, flag the risk.
 
@@ -262,15 +262,15 @@ Read only the docs relevant to your current task.
 | **Auth** | [ARCHITECTURE_SUMMARY.md §1](./architecture/ARCHITECTURE_SUMMARY.md), [AUTH_QUICK_REFERENCE.md](./guides/AUTH_QUICK_REFERENCE.md) | Auth changes, protected routes |
 | **API** | [API_CONFIGURATION.md](./architecture/API_CONFIGURATION.md), `src/services/api.ts` | New endpoints, API changes |
 | **Email System** | [EMAIL_DOCUMENTATION_INDEX.md](./email-system/EMAIL_DOCUMENTATION_INDEX.md) | Any email work |
-| **Events / Wizard** | [HANDOFF.md](./HANDOFF.md), Step2/Step3 source files | Event creation changes |
-| **Network / CRM** | [HANDOFF.md](./HANDOFF.md) Network section | Contact management work |
+| **Events / Wizard** | [KNOWN_BUGS.md](./KNOWN_BUGS.md), Step2/Step3 source files | Event creation changes |
+| **Network / CRM** | [KNOWN_BUGS.md](./KNOWN_BUGS.md) Network section | Contact management work |
 | **Payments** | [PAYMENT_DEADLINE_FEATURE.md](./features/PAYMENT_DEADLINE_FEATURE.md), [PAYMENT_SYSTEM.md](./PAYMENT_SYSTEM.md) | Payment config |
 | **Testing** | [TESTING_ROADMAP.md](./TESTING_ROADMAP.md), `vitest.config.ts` | Adding tests, CI changes |
 | **Git / Release** | [CONTRIBUTING.md](./CONTRIBUTING.md), [BRANCHING_STRATEGY.md](./development/BRANCHING_STRATEGY.md) | Branch management, PRs |
 | **Deployment** | [DEPLOYMENT.md](./deployment/DEPLOYMENT.md), [RUNBOOK.md](./development/RUNBOOK.md) | Deployment issues |
 | **Backend** | `../voxxy-rails-react/docs/README.md`, [LOCAL_DEVELOPMENT_GUIDE.md (backend)](../voxxy-rails-react/docs/development/LOCAL_DEVELOPMENT_GUIDE.md) | Backend changes |
 | **Roles / Permissions** | [ROLE_MAPPING.md](./architecture/ROLE_MAPPING.md) | Role-based features |
-| **Current Sprint** | [HANDOFF.md](./HANDOFF.md) | **Always read this** |
+| **Current Sprint** | [KNOWN_BUGS.md](./KNOWN_BUGS.md) | **Always read this** |
 
 ### Key Source Files
 
@@ -362,12 +362,12 @@ After completing SESSION_START mode, output this:
 - Frontend: <N> passed, <N> failed | SKIPPED (conflict blocks tests)
 - Backend: <N> examples passed, <N> failed | N/A
 
-### Known Bugs (from HANDOFF.md)
+### Known Bugs (from KNOWN_BUGS.md)
 - [ ] BUG 1: <one-line summary>
 - [ ] BUG 2: <one-line summary>
 
 ### Context Loaded
-- Read: SESSION_GUIDE.md, HANDOFF.md
+- Read: SESSION_GUIDE.md, KNOWN_BUGS.md
 - Also read: <additional docs relevant to task>
 
 ### Ready to Code

--- a/src/components/producer/GoLiveCard.tsx
+++ b/src/components/producer/GoLiveCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { Send, Mail, AlertCircle, Check, Edit } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Send, Mail, AlertCircle, Check, Users, ExternalLink, Rocket } from 'lucide-react';
 import { eventsApi } from '@/services/api';
 import GoLiveInvitationEditor from './GoLiveInvitationEditor';
 
@@ -10,6 +11,7 @@ interface GoLiveCardProps {
 }
 
 export default function GoLiveCard({ event, onGoLive, organizationId }: GoLiveCardProps) {
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [showEditor, setShowEditor] = useState(false);
@@ -26,11 +28,6 @@ export default function GoLiveCard({ event, onGoLive, organizationId }: GoLiveCa
   // Update isLive when event prop changes (fixes issue where state doesn't update after going live)
   useEffect(() => {
     const newIsLive = event.status?.is_live || false;
-    // console.log('🔄 [GoLiveCard] Event status changed:', {
-    //   slug: event.slug,
-    //   isLive: newIsLive,
-    //   status: event.status
-    // });
     setIsLive(newIsLive);
   }, [event, event.status?.is_live]);
 
@@ -38,8 +35,6 @@ export default function GoLiveCard({ event, onGoLive, organizationId }: GoLiveCa
   const hasInvitations = invitationCount > 0;
 
   // Count scheduled emails that are paused
-  // Note: This would need to be passed from parent or fetched separately
-  // For now, we'll show a generic message
   const hasScheduledEmails = true;
 
   const handleSaveInvitations = async (data: {
@@ -78,6 +73,11 @@ export default function GoLiveCard({ event, onGoLive, organizationId }: GoLiveCa
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleEditPortal = () => {
+    const slug = event.namespaced_slug || event.slug;
+    navigate(`/portal/${slug}`);
   };
 
   // Already live - show success state
@@ -214,52 +214,71 @@ export default function GoLiveCard({ event, onGoLive, organizationId }: GoLiveCa
     );
   }
 
-  // Initial state - not live yet
+  // Draft state — 3 pill action buttons
   return (
-    <div className="voxxy-gradient-panel rounded-xl border border-amber-500/20 p-5 transition-all hover:border-amber-500/40">
-      <div className="mb-3 flex items-start justify-between">
-        <div className="rounded-lg bg-amber-500/20 p-3">
-          <AlertCircle className="h-6 w-6 text-amber-800 dark:text-amber-400" />
+    <div className="voxxy-gradient-panel rounded-xl border border-amber-500/20 p-5 transition-all">
+      <div className="mb-4">
+        <div className="mb-3 flex items-center gap-2">
+          <span className="inline-flex items-center rounded-md bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-800 dark:bg-amber-500/20 dark:text-amber-300">
+            Draft
+          </span>
+          {hasInvitations && (
+            <span className="text-xs text-muted-foreground">
+              {invitationCount} contact{invitationCount !== 1 ? 's' : ''} selected
+            </span>
+          )}
         </div>
-      </div>
-      <div className="mb-2">
-        <p className="mb-1 text-sm text-muted-foreground">Event Status</p>
-        <p className="mb-1 text-lg font-semibold text-foreground">Not Live Yet</p>
+        <p className="text-sm font-semibold text-foreground">Ready to launch</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Set up your portal, review your invite list, then go live.
+        </p>
       </div>
 
-      {hasInvitations && (
-        <p className="mb-3 text-xs text-muted-foreground">
-          {invitationCount} contact{invitationCount !== 1 ? 's' : ''} ready to invite
-        </p>
+      {error && (
+        <div className="mb-3 rounded-lg border border-red-500/20 bg-red-500/10 p-2">
+          <p className="text-xs text-red-800 dark:text-red-400">{error}</p>
+        </div>
       )}
 
-      <div className="flex flex-col gap-2">
-        {error && (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-2">
-            <p className="text-xs text-red-800 dark:text-red-400">{error}</p>
+      <div className="grid grid-cols-3 gap-2">
+        {/* Edit Vendor Portal */}
+        <button
+          onClick={handleEditPortal}
+          className="group flex flex-col items-center gap-2 rounded-xl border border-purple-200/40 bg-violet-50/60 px-2 py-3.5 text-center transition-all hover:border-purple-300/60 hover:bg-violet-50 hover:shadow-sm dark:border-purple-500/20 dark:bg-purple-950/30 dark:hover:border-purple-500/35 dark:hover:bg-purple-950/45"
+        >
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-500/12 transition-colors group-hover:bg-purple-500/20 dark:bg-purple-500/20 dark:group-hover:bg-purple-500/30">
+            <ExternalLink className="h-4 w-4 text-purple-700 dark:text-purple-300" />
           </div>
-        )}
+          <span className="text-[11px] font-medium leading-tight text-foreground">Edit Portal</span>
+        </button>
+
+        {/* Review Invites */}
         <button
           onClick={() => {
             if (!organizationId) {
               setError('Organization information is required');
-              console.error('Missing organizationId for invitation editor');
               return;
             }
             setShowEditor(true);
             setError(null);
           }}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-border bg-muted/50 px-3 py-2 text-xs font-medium text-foreground transition-all hover:bg-muted"
+          className="group flex flex-col items-center gap-2 rounded-xl border border-purple-200/40 bg-violet-50/60 px-2 py-3.5 text-center transition-all hover:border-purple-300/60 hover:bg-violet-50 hover:shadow-sm dark:border-purple-500/20 dark:bg-purple-950/30 dark:hover:border-purple-500/35 dark:hover:bg-purple-950/45"
         >
-          <Edit className="h-3.5 w-3.5" />
-          Review Invitations
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-500/12 transition-colors group-hover:bg-purple-500/20 dark:bg-purple-500/20 dark:group-hover:bg-purple-500/30">
+            <Users className="h-4 w-4 text-purple-700 dark:text-purple-300" />
+          </div>
+          <span className="text-[11px] font-medium leading-tight text-foreground">Review Invites</span>
         </button>
+
+        {/* Go Live */}
         <button
           onClick={() => setShowConfirm(true)}
-          className="w-full px-3 py-2 voxxy-btn-cta text-xs font-semibold rounded-lg transition-all flex items-center justify-center gap-1.5"
+          className="group flex flex-col items-center gap-2 rounded-xl border border-emerald-200/40 bg-emerald-50/60 px-2 py-3.5 text-center transition-all hover:border-emerald-300/60 hover:bg-emerald-50 hover:shadow-sm dark:border-emerald-500/20 dark:bg-emerald-950/30 dark:hover:border-emerald-500/35 dark:hover:bg-emerald-950/45"
         >
-          <Send className="w-3.5 h-3.5" />
-          Go Live Now
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-500/12 transition-colors group-hover:bg-emerald-500/20 dark:bg-emerald-500/20 dark:group-hover:bg-emerald-500/30">
+            <Rocket className="h-4 w-4 text-emerald-700 dark:text-emerald-300" />
+          </div>
+          <span className="text-[11px] font-medium leading-tight text-foreground">Go Live</span>
         </button>
       </div>
     </div>

--- a/src/components/producer/GoLiveInvitationEditor.tsx
+++ b/src/components/producer/GoLiveInvitationEditor.tsx
@@ -161,6 +161,9 @@ export default function GoLiveInvitationEditor({
   const [loadingListContacts, setLoadingListContacts] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // ── View mode: show only invited contacts by default ──
+  const [showAllContacts, setShowAllContacts] = useState(false);
+
   // ── Search, filter, sort, pagination ──
   const [searchTerm, setSearchTerm] = useState('');
   const [sortColumn, setSortColumn] = useState<'name' | 'email'>('name');
@@ -191,6 +194,12 @@ export default function GoLiveInvitationEditor({
   useEffect(() => {
     let filtered = contacts;
 
+    // When in "selected only" mode, show only invited contacts
+    if (!showAllContacts) {
+      const invitedSet = new Set(invitedContactIds);
+      filtered = filtered.filter((c) => invitedSet.has(c.id));
+    }
+
     // When lists are selected, show only contacts from those lists
     if (selectedListIds.length > 0 && listContacts.length > 0) {
       const listContactIdSet = new Set(listContacts.map((c) => c.id));
@@ -208,7 +217,7 @@ export default function GoLiveInvitationEditor({
       );
     }
     setFilteredContacts(filtered);
-  }, [contacts, searchTerm, selectedListIds, listContacts]);
+  }, [contacts, searchTerm, selectedListIds, listContacts, showAllContacts, invitedContactIds]);
 
   const handleSort = (column: 'name' | 'email') => {
     if (sortColumn === column) {
@@ -365,7 +374,7 @@ export default function GoLiveInvitationEditor({
   // ── Reset to page 1 when filters/search change ──
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchTerm, selectedListIds, listContacts]);
+  }, [searchTerm, selectedListIds, listContacts, showAllContacts]);
 
   // ── Computed values ──
   const unsubscribedCount = contacts.filter(
@@ -460,11 +469,39 @@ export default function GoLiveInvitationEditor({
 
       {/* ── Toolbar ── */}
       <div className="px-5 py-3 border-b border-border flex items-center gap-3 flex-shrink-0">
-        <ListDropdown
-          organizationId={organizationId}
-          selectedListIds={selectedListIds}
-          onListsChange={setSelectedListIds}
-        />
+        {/* View toggle */}
+        <div className="flex rounded-lg border border-border overflow-hidden flex-shrink-0">
+          <button
+            type="button"
+            onClick={() => setShowAllContacts(false)}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+              !showAllContacts
+                ? 'bg-primary/15 text-violet-800 dark:text-primary border-r border-primary/20'
+                : 'bg-background/5 text-foreground/60 hover:bg-background/10 border-r border-border'
+            }`}
+          >
+            Invited
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowAllContacts(true)}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+              showAllContacts
+                ? 'bg-primary/15 text-violet-800 dark:text-primary'
+                : 'bg-background/5 text-foreground/60 hover:bg-background/10'
+            }`}
+          >
+            All Contacts
+          </button>
+        </div>
+
+        {showAllContacts && (
+          <ListDropdown
+            organizationId={organizationId}
+            selectedListIds={selectedListIds}
+            onListsChange={setSelectedListIds}
+          />
+        )}
 
         <div className="flex-1 relative">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -642,14 +679,31 @@ export default function GoLiveInvitationEditor({
           <div className="flex-1 overflow-y-auto">
             {sortedContacts.length === 0 ? (
               <div className="text-center py-16">
-                <p className="text-foreground/50 text-sm">No contacts match your search criteria</p>
-                <button
-                  type="button"
-                  onClick={() => setSearchTerm('')}
-                  className="mt-3 text-primary hover:text-primary/70 text-sm transition-colors"
-                >
-                  Clear search
-                </button>
+                {!showAllContacts && invitedContactIds.length === 0 ? (
+                  <>
+                    <Users className="mx-auto mb-3 h-8 w-8 text-foreground/20" />
+                    <p className="text-foreground/50 text-sm">No contacts selected yet</p>
+                    <button
+                      type="button"
+                      onClick={() => setShowAllContacts(true)}
+                      className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 voxxy-btn-solid rounded-lg text-sm font-medium transition-colors"
+                    >
+                      <Plus className="w-4 h-4" />
+                      Add contacts
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-foreground/50 text-sm">No contacts match your search criteria</p>
+                    <button
+                      type="button"
+                      onClick={() => setSearchTerm('')}
+                      className="mt-3 text-primary hover:text-primary/70 text-sm transition-colors"
+                    >
+                      Clear search
+                    </button>
+                  </>
+                )}
               </div>
             ) : (
               paginatedContacts.map((contact) => {

--- a/src/components/vendor-portal/VendorPortalFaq.tsx
+++ b/src/components/vendor-portal/VendorPortalFaq.tsx
@@ -1,0 +1,112 @@
+import type { EventDetails } from '@/types/eventPortal';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { CircleHelp } from 'lucide-react';
+import { VendorPortalSection } from '@/components/vendor-portal/VendorPortalSection';
+
+type FormatDateFn = (dateString: string | null) => string;
+
+type FaqDefinition = {
+  id: string;
+  question: string;
+  when?: (event: EventDetails) => boolean;
+  answer: string | ((event: EventDetails, formatDate: FormatDateFn) => string);
+};
+
+const FAQ_DEFINITIONS: FaqDefinition[] = [
+  {
+    id: 'what-is-portal',
+    question: 'What is this portal?',
+    answer:
+      'This is your home base for the event: dates and location, booth fees and payment (when applicable), and notes from the organizer. Sign in with the same email you used on your application.',
+  },
+  {
+    id: 'application-status',
+    question: 'How do I check my application or payment status?',
+    answer:
+      'The organizer may email you directly with decisions or requests. On this page you can confirm deadlines, your category, and whether a payment link is available. For questions about your specific application, contact the organizer.',
+  },
+  {
+    id: 'application-deadline',
+    question: 'When is the application deadline?',
+    answer: (ev, formatDate) =>
+      ev.application_deadline
+        ? `Applications should be submitted by ${formatDate(ev.application_deadline)} unless the organizer tells you otherwise.`
+        : "If an application deadline appears under Event details on this page, use that date. Otherwise follow the timeline in your emails from the organizer.",
+  },
+  {
+    id: 'payment-deadline',
+    question: 'When is payment due?',
+    answer: (ev, formatDate) =>
+      ev.payment_deadline
+        ? `The payment deadline shown on this portal is ${formatDate(ev.payment_deadline)}. If you have a payment link on your category, complete checkout before that date unless the organizer gives different instructions.`
+        : 'When payment is required, complete it before any deadline shown under Event details. If your category includes a payment link, you’ll find it in Your booth & payment below.',
+  },
+  {
+    id: 'install-times',
+    question: 'When is load-in or booth setup?',
+    answer:
+      'Load-in and setup depend on your category. Check the notes under your category in Your booth & payment, and watch for organizer announcements below. If you’re unsure, reach out to the organizer.',
+  },
+  {
+    id: 'contact-organizer',
+    question: 'Who do I contact with questions?',
+    answer: ev => {
+      const name = ev.organization?.name?.trim();
+      const email = ev.organization?.email?.trim();
+      if (name && email) {
+        return `${name} runs this event. Reach them at ${email}.`;
+      }
+      if (name) {
+        return `${name} runs this event. Use the contact information from your confirmation emails to reach the organizer.`;
+      }
+      return 'The event organizer manages vendor communication. Use the contact information from your confirmation emails, or any links the organizer shared with you.';
+    },
+  },
+];
+
+function resolveAnswer(
+  def: FaqDefinition,
+  event: EventDetails,
+  formatDate: FormatDateFn
+): string {
+  return typeof def.answer === 'function' ? def.answer(event, formatDate) : def.answer;
+}
+
+export interface VendorPortalFaqProps {
+  event: EventDetails;
+  formatDate: FormatDateFn;
+}
+
+export function VendorPortalFaq({ event, formatDate }: VendorPortalFaqProps) {
+  const items = FAQ_DEFINITIONS.filter(def => (def.when ? def.when(event) : true));
+
+  return (
+    <VendorPortalSection
+      title="Frequently asked questions"
+      description="Quick answers about deadlines, payment, and who to contact—expand any row for details."
+      icon={CircleHelp}
+    >
+      <Accordion
+        type="single"
+        collapsible
+        className="w-full divide-y divide-purple-200/40 rounded-2xl border border-purple-200/35 bg-violet-50/40 px-2 dark:divide-purple-500/15 dark:border-purple-500/20 dark:bg-purple-950/25 md:px-3"
+      >
+        {items.map(def => (
+          <AccordionItem key={def.id} value={def.id} className="border-0">
+            <AccordionTrigger className="min-h-[3rem] py-4 text-left text-sm font-medium text-foreground hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/40 focus-visible:ring-offset-2 md:py-5 md:text-base [&[data-state=open]]:text-purple-950 dark:[&[data-state=open]]:text-purple-100">
+              {def.question}
+            </AccordionTrigger>
+            <AccordionContent className="text-sm leading-relaxed text-muted-foreground md:text-base">
+              {resolveAnswer(def, event, formatDate)}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </VendorPortalSection>
+  );
+}

--- a/src/components/vendor-portal/VendorPortalHero.tsx
+++ b/src/components/vendor-portal/VendorPortalHero.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useId, useState } from 'react';
+import { Building2, Calendar, Clock, ImagePlus, X } from 'lucide-react';
+import type { EventDetails } from '@/types/eventPortal';
+
+/** Fallback hero when no poster and no local upload (prototype polish). */
+const DEFAULT_HERO_IMAGE =
+  'https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3?auto=format&fit=crop&w=1920&q=80';
+
+export interface VendorPortalHeroProps {
+  event: EventDetails;
+  formatDate: (dateString: string | null) => string;
+  formatTime: (timeString: string | null) => string;
+  /** Object URL from a local file pick; takes precedence over poster_url */
+  bannerPreviewUrl: string | null;
+  onPickBannerFile: (file: File) => void;
+  onClearBannerPreview: () => void;
+  /** Show local-only upload UI (e.g. producer preview or ?design=1) */
+  showBannerUploader: boolean;
+  isProducerPreview: boolean;
+  onSignOut?: () => void;
+}
+
+export function VendorPortalHero({
+  event,
+  formatDate,
+  formatTime,
+  bannerPreviewUrl,
+  onPickBannerFile,
+  onClearBannerPreview,
+  showBannerUploader,
+  isProducerPreview,
+  onSignOut,
+}: VendorPortalHeroProps) {
+  const fileInputId = useId();
+  const [imgBroken, setImgBroken] = useState(false);
+
+  const src = bannerPreviewUrl || event.poster_url?.trim() || DEFAULT_HERO_IMAGE;
+
+  useEffect(() => {
+    setImgBroken(false);
+  }, [src]);
+
+  return (
+    <div className="relative w-full px-0 pb-1 pt-4 sm:px-4 sm:pb-2 sm:pt-6 lg:px-8">
+      <div className="relative mx-auto max-w-6xl overflow-hidden rounded-none border border-purple-400/25 shadow-xl shadow-purple-950/20 ring-1 ring-purple-500/15 sm:rounded-3xl dark:border-purple-400/30 dark:shadow-black/40 dark:ring-purple-400/20">
+        <div className="relative min-h-[240px] md:min-h-[300px] lg:min-h-[340px]">
+          {/* Fallback wash when image fails or behind photo */}
+          <div
+            className="absolute inset-0 bg-gradient-to-br from-violet-200 via-purple-100 to-white dark:from-purple-950 dark:via-violet-900 dark:to-slate-950"
+            aria-hidden
+          />
+          {!imgBroken && (
+            <img
+              src={src}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover opacity-100 dark:opacity-90"
+              onError={() => setImgBroken(true)}
+            />
+          )}
+          {/* Light: bottom-heavy scrim so the photo stays vivid on top; dark: full cinematic overlay */}
+          <div
+            className="absolute inset-0 bg-gradient-to-t from-black/78 via-black/20 to-transparent dark:from-black/90 dark:via-black/50 dark:to-black/25"
+            aria-hidden
+          />
+          <div
+            className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(168,85,247,0.18),transparent_55%)] dark:bg-[radial-gradient(ellipse_at_top_right,rgba(168,85,247,0.25),transparent_50%)]"
+            aria-hidden
+          />
+
+          {/* Top bar: upload + preview pills (same glass treatment), sign out */}
+          <div className="relative z-10 flex flex-col gap-3 p-4 pb-0 md:p-6 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+              {showBannerUploader && (
+                <div className="flex w-full max-w-xl flex-col gap-2 rounded-xl border border-purple-200/80 bg-white/92 px-3 py-2.5 text-left text-purple-950 shadow-md shadow-purple-900/10 backdrop-blur-md dark:border-white/20 dark:bg-black/45 dark:text-white dark:shadow-black/40 md:flex-row md:items-center md:gap-3">
+                  <div className="flex items-center gap-2 text-xs font-medium text-purple-900 dark:text-white/90">
+                    <ImagePlus className="h-4 w-4 shrink-0 text-purple-600 dark:text-purple-300" aria-hidden />
+                    <span>Banner preview (not saved)</span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <label
+                      htmlFor={fileInputId}
+                      className="cursor-pointer rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-purple-700 dark:bg-white/15 dark:text-white dark:ring-1 dark:ring-white/25 dark:hover:bg-white/25"
+                    >
+                      Upload image
+                    </label>
+                    <input
+                      id={fileInputId}
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp,image/gif"
+                      className="sr-only"
+                      onChange={e => {
+                        const f = e.target.files?.[0];
+                        if (f) onPickBannerFile(f);
+                        e.target.value = '';
+                      }}
+                    />
+                    {bannerPreviewUrl && (
+                      <button
+                        type="button"
+                        onClick={onClearBannerPreview}
+                        className="inline-flex items-center gap-1 rounded-lg border border-purple-200/90 bg-white px-2.5 py-1.5 text-xs font-medium text-purple-900 transition hover:bg-purple-50 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white/20"
+                      >
+                        <X className="h-3.5 w-3.5" aria-hidden />
+                        Reset to poster
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+              {isProducerPreview && (
+                <div
+                  role="status"
+                  className="w-full max-w-xl rounded-xl border border-purple-200/80 bg-white/92 px-3 py-2.5 text-left text-purple-950 shadow-md shadow-purple-900/10 backdrop-blur-md dark:border-white/20 dark:bg-black/45 dark:text-white dark:shadow-black/40"
+                >
+                  <p className="text-xs font-semibold text-purple-900 dark:text-white">Vendor preview</p>
+                  <p className="mt-1 text-[11px] leading-snug text-purple-900/85 dark:text-white/80">
+                    Same page vendors see after they sign in.
+                  </p>
+                  {showBannerUploader ? (
+                    <p className="mt-1.5 text-[11px] leading-snug text-purple-800/75 dark:text-white/65">
+                      Banner controls above are for testing only—not shown to vendors.
+                    </p>
+                  ) : (
+                    <p className="mt-1.5 text-[11px] leading-snug text-purple-800/75 dark:text-white/65">
+                      Optional: add{' '}
+                      <kbd className="rounded border border-purple-300/70 bg-white/90 px-1 py-0.5 font-mono text-[10px] font-normal text-purple-950 dark:border-white/25 dark:bg-black/40 dark:text-white">
+                        ?design=1
+                      </kbd>{' '}
+                      to try the banner upload prototype.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {onSignOut && !isProducerPreview && (
+              <button
+                type="button"
+                onClick={onSignOut}
+                className="shrink-0 self-end rounded-lg border border-purple-200/90 bg-white/92 px-3 py-1.5 text-xs font-medium text-purple-950 shadow-sm backdrop-blur-md transition hover:bg-purple-50 sm:self-start md:text-sm dark:border-white/25 dark:bg-black/35 dark:text-white dark:hover:bg-black/50"
+              >
+                Sign out
+              </button>
+            )}
+          </div>
+
+          {/* Title block — white type reads on bottom scrim in both modes */}
+          <div className="relative z-10 flex flex-col justify-end px-4 pb-6 pt-16 md:px-8 md:pb-8 md:pt-20">
+            <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-white/75 md:text-xs">
+              Vendor portal
+            </p>
+            {event.organization && (
+              <p className="mb-2 flex items-center gap-2 text-sm font-medium text-white/95 drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)] dark:text-white/85 dark:drop-shadow-none">
+                <Building2 className="h-4 w-4 shrink-0 text-purple-200 dark:text-purple-300" aria-hidden />
+                <span>{event.organization.name}</span>
+              </p>
+            )}
+            <h1 className="mb-3 max-w-3xl text-3xl font-bold tracking-tight text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.45)] md:text-4xl md:drop-shadow-[0_2px_16px_rgba(0,0,0,0.5)] lg:text-5xl dark:drop-shadow-sm">
+              {event.title}
+            </h1>
+            {event.dates?.event_date && (
+              <p className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-white/95 drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)] md:text-base dark:text-white/85 dark:drop-shadow-none">
+                <span className="inline-flex items-center gap-1.5">
+                  <Calendar className="h-4 w-4 text-purple-200 dark:text-purple-300" aria-hidden />
+                  {formatDate(event.dates.event_date)}
+                </span>
+                {(event.dates.start_time || event.dates.end_time) && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <Clock className="h-4 w-4 text-purple-200 dark:text-purple-300" aria-hidden />
+                    {event.dates.start_time && formatTime(event.dates.start_time)}
+                    {event.dates.start_time && event.dates.end_time && ' – '}
+                    {event.dates.end_time && formatTime(event.dates.end_time)}
+                  </span>
+                )}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/vendor-portal/VendorPortalLocationMap.tsx
+++ b/src/components/vendor-portal/VendorPortalLocationMap.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const GOOGLE_EMBED_KEY = import.meta.env.VITE_GOOGLE_MAPS_EMBED_API_KEY as string | undefined;
+
+function buildPlaceQuery(venue: string, location: string) {
+  return [venue, location].map(s => s?.trim()).filter(Boolean).join(', ');
+}
+
+export function VendorPortalLocationMap({ venue, location }: { venue: string; location: string }) {
+  const query = buildPlaceQuery(venue, location);
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const [embedLoaded, setEmbedLoaded] = useState(false);
+
+  useEffect(() => {
+    const el = detailsRef.current;
+    if (!el) return;
+    const onToggle = () => {
+      if (el.open) setEmbedLoaded(true);
+    };
+    el.addEventListener('toggle', onToggle);
+    return () => el.removeEventListener('toggle', onToggle);
+  }, []);
+
+  if (!query) return null;
+
+  const mapsSearchUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+
+  const embedSrc = GOOGLE_EMBED_KEY?.trim()
+    ? `https://www.google.com/maps/embed/v1/place?key=${encodeURIComponent(GOOGLE_EMBED_KEY.trim())}&q=${encodeURIComponent(query)}`
+    : `https://maps.google.com/maps?q=${encodeURIComponent(query)}&hl=en&z=15&output=embed`;
+
+  return (
+    <details
+      ref={detailsRef}
+      className="group mt-3 rounded-xl border border-purple-200/50 bg-white/70 ring-1 ring-purple-500/[0.06] dark:border-purple-500/25 dark:bg-black/25 dark:ring-purple-400/10"
+    >
+      <summary
+        className={cn(
+          'flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2.5 text-xs font-medium text-purple-950 transition-colors hover:bg-purple-500/[0.06] dark:text-purple-100 dark:hover:bg-white/[0.06]',
+          '[&::-webkit-details-marker]:hidden'
+        )}
+      >
+        <span>Show map</span>
+        <ChevronDown
+          className="h-4 w-4 shrink-0 text-purple-600 opacity-80 transition-transform duration-200 group-open:rotate-180 dark:text-purple-300"
+          aria-hidden
+        />
+      </summary>
+      <div className="border-t border-purple-200/45 px-3 pb-3 pt-3 dark:border-purple-500/20">
+        {embedLoaded ? (
+          <div className="overflow-hidden rounded-lg border border-purple-200/40 bg-muted/30 shadow-inner dark:border-purple-500/20">
+            <iframe
+              title={`Map: ${query}`}
+              src={embedSrc}
+              className="aspect-[16/10] min-h-[200px] w-full border-0 sm:aspect-video sm:min-h-[240px]"
+              loading="lazy"
+              referrerPolicy="no-referrer-when-downgrade"
+              allowFullScreen
+            />
+          </div>
+        ) : null}
+        <a
+          href={mapsSearchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-purple-700 underline-offset-4 hover:underline dark:text-purple-300"
+        >
+          Open in Google Maps
+          <ExternalLink className="h-3.5 w-3.5 opacity-80" aria-hidden />
+        </a>
+      </div>
+    </details>
+  );
+}

--- a/src/components/vendor-portal/VendorPortalPageCanvas.tsx
+++ b/src/components/vendor-portal/VendorPortalPageCanvas.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+/** Voxxy-tinted canvas: soft violet wash on zinc (light + dark) */
+export function VendorPortalPageCanvas({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'min-h-screen bg-gradient-to-b from-violet-50/90 via-zinc-50/95 to-violet-50/50 text-foreground antialiased dark:from-[#120b1c] dark:via-zinc-950 dark:to-[#1a1228]',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/vendor-portal/VendorPortalSection.tsx
+++ b/src/components/vendor-portal/VendorPortalSection.tsx
@@ -1,0 +1,55 @@
+import { useId, type ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const shellClass =
+  'rounded-3xl border border-purple-200/35 bg-white shadow-sm shadow-purple-500/5 ring-1 ring-purple-500/[0.07] backdrop-blur-sm dark:border-purple-500/20 dark:bg-zinc-900/75 dark:shadow-black/30 dark:ring-purple-400/10';
+
+export function VendorPortalSection({
+  title,
+  description,
+  icon: Icon,
+  children,
+  className,
+  headerClassName,
+  contentClassName,
+}: {
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  children: ReactNode;
+  className?: string;
+  headerClassName?: string;
+  contentClassName?: string;
+}) {
+  const headingId = useId();
+
+  return (
+    <section
+      className={cn(shellClass, 'p-5 md:p-8', className)}
+      aria-labelledby={headingId}
+    >
+      <header className={cn('mb-5 md:mb-6', headerClassName)}>
+        <div className="flex items-start gap-3 md:gap-4">
+          {Icon && (
+            <div
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-purple-500/[0.11] ring-1 ring-purple-500/10 dark:bg-purple-500/[0.18] dark:ring-purple-400/15"
+              aria-hidden
+            >
+              <Icon className="h-5 w-5 text-purple-700 dark:text-purple-300" />
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <h2 id={headingId} className="text-lg font-semibold tracking-tight text-foreground md:text-xl">
+              {title}
+            </h2>
+            {description ? (
+              <p className="mt-1.5 max-w-prose text-sm leading-relaxed text-muted-foreground">{description}</p>
+            ) : null}
+          </div>
+        </div>
+      </header>
+      <div className={contentClassName}>{children}</div>
+    </section>
+  );
+}

--- a/src/pages/VendorEventPortalPage.tsx
+++ b/src/pages/VendorEventPortalPage.tsx
@@ -1,18 +1,18 @@
 import { useState, useEffect } from 'react';
-import { useParams, useSearchParams, useLocation } from 'react-router-dom';
+import { useSearchParams, useLocation } from 'react-router-dom';
 import {
   Calendar,
   MapPin,
-  Clock,
   ExternalLink,
   DollarSign,
   Loader2,
   AlertCircle,
   Users,
-  Building2,
   Megaphone,
   Pin,
-  Eye,
+  LayoutList,
+  Tags,
+  ArrowUpRight,
 } from 'lucide-react';
 import {
   verifyPortalAccess,
@@ -26,11 +26,14 @@ import { useAuth } from '@/contexts/AuthContext';
 import { eventsApi, vendorApplicationsApi, bulletinsApi } from '@/services/api';
 import type { EventPortalData } from '@/types/eventPortal';
 import type { Bulletin } from '@/types/bulletin';
+import { VendorPortalFaq } from '@/components/vendor-portal/VendorPortalFaq';
+import { VendorPortalHero } from '@/components/vendor-portal/VendorPortalHero';
+import { VendorPortalLocationMap } from '@/components/vendor-portal/VendorPortalLocationMap';
+import { VendorPortalPageCanvas } from '@/components/vendor-portal/VendorPortalPageCanvas';
+import { VendorPortalSection } from '@/components/vendor-portal/VendorPortalSection';
 import { formatDistanceToNow } from 'date-fns';
-import { useForceTheme } from '@/hooks/useForceTheme';
 
 export default function VendorEventPortalPage() {
-  useForceTheme('dark');
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const { isAuthenticated: isLoggedIn, isProducer, isAdmin } = useAuth();
@@ -55,6 +58,35 @@ export default function VendorEventPortalPage() {
   const [portalData, setPortalData] = useState<EventPortalData | null>(null);
   const [loading, setLoading] = useState(false);
   const [dataError, setDataError] = useState<string | null>(null);
+  /** Local-only banner preview (object URL); never persisted */
+  const [bannerPreviewUrl, setBannerPreviewUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (bannerPreviewUrl) URL.revokeObjectURL(bannerPreviewUrl);
+    };
+  }, [bannerPreviewUrl]);
+
+  useEffect(() => {
+    setBannerPreviewUrl(prev => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
+  }, [portalData?.event?.id]);
+
+  const handlePickBannerFile = (file: File) => {
+    setBannerPreviewUrl(prev => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
+  };
+
+  const handleClearBannerPreview = () => {
+    setBannerPreviewUrl(prev => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
+  };
 
   // Pre-fill email from URL params on mount
   useEffect(() => {
@@ -185,6 +217,7 @@ export default function VendorEventPortalPage() {
           title: eventData.title,
           slug: eventData.slug,
           description: eventData.description || '',
+          poster_url: eventData.poster_url ?? null,
           status: eventData.status?.status || eventData.status || null,
           dates: {
             event_date: eventData.event_date,
@@ -237,6 +270,8 @@ export default function VendorEventPortalPage() {
         title: 'Summer Art Market 2026',
         slug: 'summer-art-market',
         description: 'Join us for our annual summer art market featuring local artists, food vendors, and live music. This is a family-friendly event showcasing the best of our creative community.',
+        poster_url:
+          'https://images.unsplash.com/photo-1533174072545-7a4b6ad7a6c3?auto=format&fit=crop&w=1920&q=80',
         dates: {
           event_date: '2026-06-15',
           event_end_date: '2026-06-15',
@@ -333,21 +368,32 @@ export default function VendorEventPortalPage() {
   // Authentication Form
   if (!isAuthenticated) {
     return (
-      <div className="min-h-screen voxxy-gradient-page text-foreground">
-        <div className="container mx-auto px-4 py-16">
-          <div className="max-w-md mx-auto">
-            <div className="text-center mb-8">
-              <h1 className="text-3xl font-bold mb-2">Event Portal Access</h1>
+      <VendorPortalPageCanvas className="relative overflow-hidden">
+        <div
+          className="pointer-events-none absolute inset-0 bg-[url('https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=1920&q=60')] bg-cover bg-center opacity-[0.14] dark:opacity-[0.1]"
+          aria-hidden
+        />
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-violet-50/88 via-zinc-50/94 to-purple-50/70 dark:from-[#120b1c]/92 dark:via-zinc-950/96 dark:to-[#1a1228]/95" />
+        <div className="container relative mx-auto px-4 py-16">
+          <div className="mx-auto max-w-md">
+            <div className="mb-8 text-center">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-purple-700/90 dark:text-purple-300/90">
+                Vendors & artists
+              </p>
+              <h1 className="mb-2 text-3xl font-bold tracking-tight text-foreground">Your event portal</h1>
               <p className="text-muted-foreground">
-                Enter your email to view event details
+                Sign in with the email you used when you applied—then view your event info, fees, and updates.
               </p>
             </div>
 
-            <form onSubmit={handleAccessPortal} className="bg-muted rounded-lg p-6 shadow-xl">
+            <form
+              onSubmit={handleAccessPortal}
+              className="rounded-3xl border border-purple-200/45 bg-white/92 p-6 shadow-sm shadow-purple-500/10 ring-1 ring-purple-500/10 backdrop-blur-md dark:border-purple-500/25 dark:bg-zinc-900/88 dark:shadow-black/25 dark:ring-purple-400/15"
+            >
               <div className="space-y-4">
                 <div>
-                  <label htmlFor="email" className="block text-sm font-medium mb-2">
-                    Email Address
+                  <label htmlFor="email" className="mb-2 block text-sm font-medium text-foreground">
+                    Email address
                   </label>
                   <input
                     type="email"
@@ -355,12 +401,12 @@ export default function VendorEventPortalPage() {
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="your.email@example.com"
-                    className="w-full px-4 py-2 bg-muted border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-foreground placeholder:text-muted-foreground"
+                    className="w-full px-4 py-2 bg-muted border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 text-foreground placeholder:text-muted-foreground"
                     required
                     autoFocus
                   />
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Use the email you provided when you applied to this event
+                  <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                    Same email as your application so we can match you to this event.
                   </p>
                 </div>
 
@@ -374,7 +420,7 @@ export default function VendorEventPortalPage() {
                 <button
                   type="submit"
                   disabled={verifying}
-                  className="w-full voxxy-btn-solid disabled:bg-muted disabled:cursor-not-allowed font-semibold py-3 px-6 rounded-lg transition-colors flex items-center justify-center gap-2"
+                  className="voxxy-btn-solid flex w-full items-center justify-center gap-2 rounded-full py-3 px-6 font-semibold shadow-sm transition disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {verifying ? (
                     <>
@@ -382,95 +428,99 @@ export default function VendorEventPortalPage() {
                       Verifying...
                     </>
                   ) : (
-                    'Access Portal'
+                    'Continue to portal'
                   )}
                 </button>
               </div>
             </form>
 
-            <div className="mt-6 text-center text-sm text-muted-foreground">
-              <p>
-                This portal is only accessible to vendors who have applied to this event.
-              </p>
+            <div className="mt-6 text-center text-sm leading-relaxed text-muted-foreground">
+              <p>Only applicants for this event can open this page.</p>
             </div>
           </div>
         </div>
-      </div>
+      </VendorPortalPageCanvas>
     );
   }
 
   // Loading state
   if (loading || !portalData) {
     return (
-      <div className="min-h-screen voxxy-gradient-page text-foreground flex items-center justify-center">
+      <VendorPortalPageCanvas className="flex items-center justify-center">
         <div className="text-center">
-          <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-primary" />
-          <p className="text-muted-foreground">Loading event details...</p>
+          <Loader2 className="mx-auto mb-4 h-12 w-12 animate-spin text-purple-600 dark:text-purple-400" />
+          <p className="text-muted-foreground">Loading your portal…</p>
         </div>
-      </div>
+      </VendorPortalPageCanvas>
     );
   }
 
   // Error state
   if (dataError) {
     return (
-      <div className="min-h-screen voxxy-gradient-page text-foreground flex items-center justify-center">
-        <div className="max-w-md text-center">
-          <AlertCircle className="h-12 w-12 mx-auto mb-4 text-red-500" />
-          <h2 className="text-2xl font-bold mb-2">Error Loading Portal</h2>
-          <p className="text-muted-foreground mb-6">{dataError}</p>
+      <VendorPortalPageCanvas className="flex items-center justify-center px-4">
+        <div className="max-w-md rounded-3xl border border-purple-200/40 bg-white p-8 text-center shadow-sm ring-1 ring-purple-500/10 dark:border-purple-500/25 dark:bg-zinc-900/85 dark:ring-purple-400/10">
+          <AlertCircle className="mx-auto mb-4 h-12 w-12 text-red-500" />
+          <h2 className="mb-2 text-2xl font-semibold tracking-tight">Error loading portal</h2>
+          <p className="mb-6 text-muted-foreground">{dataError}</p>
           <button
             onClick={() => {
               clearPortalSession();
               setIsAuthenticated(false);
             }}
-            className="voxxy-btn-solid font-semibold py-2 px-6 rounded-lg transition-colors"
+            className="voxxy-btn-solid rounded-full px-6 py-2.5 text-sm font-semibold transition"
           >
-            Back to Login
+            Back to login
           </button>
         </div>
-      </div>
+      </VendorPortalPageCanvas>
     );
   }
 
   const { event, vendor_categories } = portalData;
+  const showBannerTools = isProducerPreview || searchParams.get('design') === '1';
 
   // Show cancellation message if event is cancelled
   if (event.status === 'cancelled') {
     return (
-      <div className="min-h-screen voxxy-gradient-page text-foreground">
-        <div className="max-w-4xl mx-auto px-6 py-12">
-          {/* Producer Preview Banner */}
+      <VendorPortalPageCanvas>
+        <div className="mx-auto max-w-2xl px-4 py-10 md:py-14">
           {isProducerPreview && (
-            <div className="bg-primary/20 border border-primary/30 rounded-lg p-3 mb-6 flex items-center gap-2">
-              <Eye className="w-4 h-4 text-primary flex-shrink-0" />
-              <p className="text-sm text-primary">
-                <span className="font-semibold">Producer Preview</span> — This is how vendors see your event portal.
-              </p>
+            <div
+              role="status"
+              className="mb-5 rounded-xl border border-purple-200/60 bg-white/90 px-4 py-3 text-sm shadow-sm dark:border-purple-500/25 dark:bg-zinc-900/80"
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-3">
+                <span className="inline-flex w-fit shrink-0 rounded-md bg-purple-500/12 px-2.5 py-1 text-xs font-semibold text-purple-950 dark:bg-purple-500/20 dark:text-purple-100">
+                  Vendor preview
+                </span>
+                <p className="text-muted-foreground">
+                  You&apos;re viewing this cancellation notice the same way an applicant would.
+                </p>
+              </div>
             </div>
           )}
 
-          <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-8 text-center">
-            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-500/20 flex items-center justify-center">
-              <svg className="w-8 h-8 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <div className="rounded-3xl border border-red-200/70 bg-white p-8 text-center shadow-sm ring-1 ring-purple-500/8 dark:border-red-900/35 dark:bg-zinc-900/90 dark:text-zinc-50 dark:ring-purple-400/10">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-950/50">
+              <svg className="h-8 w-8 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-white mb-2">Event Cancelled</h1>
-            <p className="text-lg text-white/90 mb-4">{event.title}</p>
-            <p className="text-white/70 mb-6">
+            <h1 className="mb-2 text-2xl font-semibold tracking-tight text-foreground">Event cancelled</h1>
+            <p className="mb-4 text-lg text-muted-foreground">{event.title}</p>
+            <p className="mb-6 text-muted-foreground">
               This event has been cancelled by the event organizer. If you submitted payment, you will be contacted regarding refund details.
             </p>
 
-            {/* Organization Contact Info */}
             {event.organization && (
-              <div className="bg-white/5 border border-white/10 rounded-lg p-6 mb-6 max-w-md mx-auto">
-                <p className="text-sm text-white/60 mb-3">For questions about this cancellation, please contact:</p>
-                <p className="text-lg font-semibold text-white mb-2">{event.organization.name}</p>
+              <div className="mx-auto mb-6 max-w-md rounded-2xl border border-purple-200/35 bg-violet-50/60 p-6 text-left dark:border-purple-500/20 dark:bg-purple-950/30">
+                <p className="mb-3 text-sm text-muted-foreground">For questions about this cancellation, please contact:</p>
+                <p className="mb-2 text-lg font-semibold text-foreground">{event.organization.name}</p>
                 {event.organization.email ? (
                   <a
                     href={`mailto:${event.organization.email}`}
-                    className="inline-flex items-center gap-2 text-primary hover:text-primary/70 text-sm transition-colors"
+                    className="inline-flex items-center gap-2 text-sm font-medium text-purple-700 underline-offset-4 hover:underline dark:text-purple-300"
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
@@ -478,9 +528,9 @@ export default function VendorEventPortalPage() {
                     {event.organization.email}
                   </a>
                 ) : (
-                  <p className="text-sm text-white/60 italic">Contact information not available</p>
+                  <p className="text-sm italic text-muted-foreground">Contact information not available</p>
                 )}
-                <p className="text-xs text-white/50 mt-4">
+                <p className="mt-4 text-xs text-muted-foreground">
                   This event was managed through Voxxy Presents, but all event decisions including cancellations are made by the event organizer.
                 </p>
               </div>
@@ -492,230 +542,231 @@ export default function VendorEventPortalPage() {
                   clearPortalSession();
                   setIsAuthenticated(false);
                 }}
-                className="px-6 py-3 rounded-lg bg-white/10 border border-white/20 text-white hover:bg-white/20 transition-all"
+                className="rounded-full border border-purple-300/50 bg-transparent px-6 py-3 text-sm font-medium text-foreground transition hover:bg-purple-50 dark:border-purple-500/35 dark:hover:bg-purple-950/40"
               >
-                Sign Out
+                Sign out
               </button>
             )}
           </div>
         </div>
-      </div>
+      </VendorPortalPageCanvas>
     );
   }
 
   // Portal Dashboard
   return (
-    <div className="min-h-screen voxxy-gradient-page text-foreground">
-      <div className="max-w-4xl mx-auto px-6 md:px-12 lg:px-16 py-8">
-        {/* Producer Preview Banner */}
-        {isProducerPreview && (
-          <div className="bg-primary/20 border border-primary/30 rounded-lg p-3 mb-6 flex items-center gap-2">
-            <Eye className="w-4 h-4 text-primary flex-shrink-0" />
-            <p className="text-sm text-primary">
-              <span className="font-semibold">Producer Preview</span> — This is how vendors see your event portal.
-            </p>
-          </div>
-        )}
+    <VendorPortalPageCanvas>
+      <VendorPortalHero
+        event={event}
+        formatDate={formatDate}
+        formatTime={formatTime}
+        bannerPreviewUrl={bannerPreviewUrl}
+        onPickBannerFile={handlePickBannerFile}
+        onClearBannerPreview={handleClearBannerPreview}
+        showBannerUploader={showBannerTools}
+        isProducerPreview={isProducerPreview}
+        onSignOut={() => {
+          clearPortalSession();
+          setIsAuthenticated(false);
+        }}
+      />
 
-        {/* Header */}
-        <div className="mb-6 md:mb-8">
-          <div className="flex items-center justify-between mb-3 md:mb-4">
-            <h1 className="text-2xl md:text-4xl font-bold">{event.title}</h1>
-            {!isProducerPreview && (
-              <button
-                onClick={() => {
-                  clearPortalSession();
-                  setIsAuthenticated(false);
-                }}
-                className="text-xs md:text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Sign Out
-              </button>
-            )}
-          </div>
-          {event.organization && (
-            <div className="flex items-center gap-2 text-muted-foreground text-sm">
-              <Building2 className="h-4 w-4" />
-              <span>Presented by {event.organization.name}</span>
-            </div>
-          )}
-        </div>
-
-        {/* Event Details Section */}
-        <div className="bg-muted rounded-lg p-4 md:p-6 mb-6 shadow-xl">
-          <h2 className="text-xl md:text-2xl font-bold mb-3 md:mb-4">Event Details</h2>
-
-          {event.description && (
-            <p className="text-sm md:text-base text-muted-foreground mb-4 md:mb-6 leading-relaxed">{event.description}</p>
-          )}
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4">
-            {event.location && (
-              <div className="flex items-start gap-3">
-                <MapPin className="h-5 w-5 text-primary mt-1 flex-shrink-0" />
-                <div>
-                  <p className="font-semibold">Location</p>
-                  <p className="text-muted-foreground">{event.venue}</p>
+      <div className="relative mx-auto mt-6 max-w-5xl space-y-6 px-4 pb-16 pt-0 sm:px-6 md:mt-8 md:space-y-8 md:px-8 lg:px-10">
+        <VendorPortalSection
+          title="Event details"
+          description="Schedule context, venue, deadlines, and links your organizer has shared."
+          icon={LayoutList}
+        >
+          {event.description ? (
+            <p className="mb-6 text-sm leading-relaxed text-muted-foreground md:text-base">{event.description}</p>
+          ) : null}
+          <div className="divide-y divide-purple-200/40 rounded-2xl border border-purple-200/40 bg-violet-50/60 dark:divide-purple-500/15 dark:border-purple-500/18 dark:bg-purple-950/25">
+            {event.location ? (
+              <div className="flex gap-3 px-4 py-3.5 md:px-5 md:py-4">
+                <MapPin className="mt-0.5 h-5 w-5 shrink-0 text-purple-600 dark:text-purple-400" aria-hidden />
+                <div className="min-w-0 flex-1">
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Location</p>
+                  <p className="font-medium text-foreground">{event.venue}</p>
                   <p className="text-sm text-muted-foreground">{event.location}</p>
+                  <VendorPortalLocationMap venue={event.venue} location={event.location} />
                 </div>
               </div>
-            )}
-
-            {event.age_restriction && (
-              <div className="flex items-start gap-3">
-                <Users className="h-5 w-5 text-primary mt-1 flex-shrink-0" />
+            ) : null}
+            {event.application_deadline ? (
+              <div className="flex gap-3 px-4 py-3.5 md:px-5 md:py-4">
+                <Calendar className="mt-0.5 h-5 w-5 shrink-0 text-purple-600 dark:text-purple-400" aria-hidden />
                 <div>
-                  <p className="font-semibold">Age Restriction</p>
-                  <p className="text-muted-foreground">{event.age_restriction}</p>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    Apply by
+                  </p>
+                  <p className="font-medium text-foreground">{formatDate(event.application_deadline)}</p>
                 </div>
               </div>
-            )}
-
-            {event.payment_deadline && (
-              <div className="flex items-start gap-3">
-                <DollarSign className="h-5 w-5 text-primary mt-1 flex-shrink-0" />
+            ) : null}
+            {event.age_restriction ? (
+              <div className="flex gap-3 px-4 py-3.5 md:px-5 md:py-4">
+                <Users className="mt-0.5 h-5 w-5 shrink-0 text-purple-600 dark:text-purple-400" aria-hidden />
                 <div>
-                  <p className="font-semibold">Payment Deadline</p>
-                  <p className="text-muted-foreground">{formatDate(event.payment_deadline)}</p>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    Audience
+                  </p>
+                  <p className="text-foreground">{event.age_restriction}</p>
                 </div>
               </div>
-            )}
-
-            {event.ticket_url && (
-              <div className="flex items-start gap-3">
-                <ExternalLink className="h-5 w-5 text-primary mt-1 flex-shrink-0" />
+            ) : null}
+            {event.payment_deadline ? (
+              <div className="flex gap-3 px-4 py-3.5 md:px-5 md:py-4">
+                <DollarSign className="mt-0.5 h-5 w-5 shrink-0 text-purple-600 dark:text-purple-400" aria-hidden />
                 <div>
-                  <p className="font-semibold">Event Tickets</p>
-                  <a
-                    href={event.ticket_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-primary hover:text-primary/70 underline text-sm transition-colors"
-                  >
-                    View Ticket Page
-                  </a>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    Payment due
+                  </p>
+                  <p className="text-foreground">{formatDate(event.payment_deadline)}</p>
                 </div>
               </div>
-            )}
-          </div>
-        </div>
-
-        {/* Producer Updates Section */}
-        <div className="bg-muted rounded-lg p-4 md:p-6 mb-6 shadow-xl">
-          <div className="flex items-center gap-2 md:gap-3 mb-4 md:mb-6">
-            <div className="w-8 h-8 md:w-10 md:h-10 rounded-lg voxxy-accent-tile flex items-center justify-center">
-              <Megaphone className="w-4 h-4 md:w-5 md:h-5 text-foreground" />
-            </div>
-            <h2 className="text-xl md:text-2xl font-bold">Producer Updates</h2>
-          </div>
-
-          {portalData.producer_updates && portalData.producer_updates.length > 0 ? (
-            <div className="space-y-3 md:space-y-4">
-              {portalData.producer_updates.map((bulletin: Bulletin) => {
-                const getInitials = (name: string) => {
-                  return name
-                    .split(' ')
-                    .map(n => n[0])
-                    .join('')
-                    .toUpperCase()
-                    .slice(0, 2);
-                };
-
-                return (
-                  <div
-                    key={bulletin.id}
-                    className={`voxxy-gradient-card-deep rounded-lg p-4 md:p-6 border ${
-                      bulletin.pinned ? 'border-primary' : 'border-border'
-                    }`}
-                  >
-                    {/* Header */}
-                    <div className="flex items-start gap-2 md:gap-3 mb-3 md:mb-4">
-                      {/* Author Avatar */}
-                      <div className="w-8 h-8 md:w-10 md:h-10 rounded-full voxxy-accent-tile flex items-center justify-center text-xs md:text-sm font-medium flex-shrink-0">
-                        {getInitials(bulletin.author.name)}
-                      </div>
-
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <h3 className="text-sm md:text-base text-foreground font-semibold">{bulletin.subject}</h3>
-                          {bulletin.pinned && (
-                            <Pin className="w-3 h-3 md:w-4 md:h-4 text-primary fill-primary flex-shrink-0" />
-                          )}
-                        </div>
-                        <p className="text-muted-foreground text-xs md:text-sm">
-                          {bulletin.author.name} · {formatDistanceToNow(new Date(bulletin.created_at), { addSuffix: true })}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Body */}
-                    <div className="text-sm md:text-base text-muted-foreground whitespace-pre-wrap">
-                      {bulletin.body}
-                    </div>
+            ) : null}
+            {event.ticket_url ? (
+              <div className="flex flex-col gap-3 px-4 py-3.5 sm:flex-row sm:items-center sm:justify-between md:px-5 md:py-4">
+                <div className="flex gap-3">
+                  <ExternalLink className="mt-0.5 h-5 w-5 shrink-0 text-purple-600 dark:text-purple-400" aria-hidden />
+                  <div>
+                    <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Tickets
+                    </p>
+                    <p className="text-sm text-muted-foreground">Public ticket link</p>
                   </div>
-                );
-              })}
-            </div>
-          ) : (
-            <p className="text-muted-foreground text-center py-6 md:py-8 text-sm md:text-base">
-              No updates at this time. Check back later for announcements from the event producer.
-            </p>
-          )}
-        </div>
+                </div>
+                <a
+                  href={event.ticket_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-purple-300/55 bg-white px-4 py-2 text-sm font-medium text-purple-900 shadow-sm transition hover:bg-purple-50 dark:border-purple-500/35 dark:bg-zinc-900 dark:text-purple-100 dark:hover:bg-purple-950/50"
+                >
+                  View tickets
+                  <ArrowUpRight className="h-4 w-4 opacity-70" aria-hidden />
+                </a>
+              </div>
+            ) : null}
+          </div>
+        </VendorPortalSection>
 
-        {/* Vendor Categories Section */}
-        {vendor_categories.length > 0 && (
-          <div className="bg-muted rounded-lg p-4 md:p-6 shadow-xl">
-            <h2 className="text-xl md:text-2xl font-bold mb-3 md:mb-4">Vendor Categories & Pricing</h2>
-
-            <div className="space-y-3 md:space-y-4">
-              {vendor_categories.map((category) => (
-                <div key={category.id} className="bg-muted rounded-lg p-3 md:p-4 border border-border">
-                  <div className="flex flex-col md:flex-row md:items-start md:justify-between mb-3 gap-3">
-                    <div className="flex-1">
-                      <h3 className="text-lg md:text-xl font-semibold">{category.name}</h3>
-                      {category.categories.length > 0 && (
-                        <div className="flex flex-wrap gap-1.5 md:gap-2 mt-2">
+        {vendor_categories.length > 0 ? (
+          <VendorPortalSection
+            title="Your booth & payment"
+            description="Find your category, booth fee, and secure checkout when the organizer has enabled online payment."
+            icon={Tags}
+            headerClassName="mb-4 md:mb-5"
+          >
+            <div className="flex flex-wrap gap-3 md:gap-4">
+              {vendor_categories.map(category => (
+                <div
+                  key={category.id}
+                  className="flex min-w-[min(100%,17.5rem)] flex-1 basis-[17.5rem] flex-col rounded-2xl border border-purple-200/45 bg-violet-50/80 p-4 shadow-sm shadow-purple-500/[0.06] ring-1 ring-purple-500/[0.04] transition-[box-shadow] duration-200 hover:shadow-md hover:shadow-purple-500/10 dark:border-purple-500/20 dark:bg-purple-950/35 dark:ring-purple-400/[0.06] dark:hover:shadow-purple-950/40"
+                >
+                  <div className="flex flex-col gap-3">
+                    <div className="space-y-2">
+                      <h3 className="text-sm font-semibold leading-snug tracking-tight text-foreground md:text-base">
+                        {category.name}
+                      </h3>
+                      {category.categories.length > 0 ? (
+                        <div className="flex flex-wrap gap-1.5">
                           {category.categories.map((cat, idx) => (
                             <span
                               key={idx}
-                              className="px-2 py-0.5 md:py-1 bg-muted text-xs rounded-full text-muted-foreground"
+                              className="inline-flex items-center rounded-md bg-purple-500/10 px-2 py-0.5 text-xs font-medium text-purple-950 dark:bg-purple-500/20 dark:text-purple-100"
                             >
                               {cat}
                             </span>
                           ))}
                         </div>
-                      )}
+                      ) : null}
                     </div>
-                    {category.booth_price && (
-                      <div className="flex items-center justify-between md:block md:text-right">
-                        <p className="text-xl md:text-2xl font-bold text-primary">
+                    {category.booth_price != null ? (
+                      <div className="flex flex-row items-center justify-between gap-3 border-t border-purple-200/45 pt-3 dark:border-purple-500/18">
+                        <p className="text-base font-semibold tabular-nums tracking-tight text-purple-950 dark:text-purple-100">
                           {formatPrice(category.booth_price)}
                         </p>
-                        {category.payment_link && (
+                        {category.payment_link ? (
                           <a
                             href={category.payment_link}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 mt-0 md:mt-2 text-xs md:text-sm voxxy-btn-solid px-3 py-1.5 rounded transition-colors"
+                            className="voxxy-btn-solid inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-violet-50 dark:focus-visible:ring-offset-zinc-950"
                           >
-                            Pay Now
-                            <ExternalLink className="h-3 w-3" />
+                            Pay online
+                            <ExternalLink className="h-3.5 w-3.5 opacity-90" aria-hidden />
                           </a>
-                        )}
+                        ) : null}
                       </div>
-                    )}
+                    ) : null}
                   </div>
-
-                  {category.description && (
-                    <p className="text-muted-foreground text-xs md:text-sm mb-3">{category.description}</p>
-                  )}
+                  {category.description ? (
+                    <p className="mt-3 border-t border-purple-200/35 pt-3 text-xs leading-relaxed text-muted-foreground line-clamp-4 dark:border-purple-500/15">
+                      {category.description}
+                    </p>
+                  ) : null}
                 </div>
               ))}
             </div>
-          </div>
-        )}
+          </VendorPortalSection>
+        ) : null}
+
+        <VendorPortalFaq event={event} formatDate={formatDate} />
+
+        <VendorPortalSection
+          title="Updates from the organizer"
+          description="Official notes about schedule changes, load-in, rules, or anything vendors should know."
+          icon={Megaphone}
+        >
+          {portalData.producer_updates && portalData.producer_updates.length > 0 ? (
+            <div className="space-y-3 md:space-y-4">
+              {portalData.producer_updates.map((bulletin: Bulletin) => {
+                const getInitials = (name: string) =>
+                  name
+                    .split(' ')
+                    .map(n => n[0])
+                    .join('')
+                    .toUpperCase()
+                    .slice(0, 2);
+
+                return (
+                  <article
+                    key={bulletin.id}
+                    className={`rounded-2xl border border-purple-200/40 bg-white/95 p-4 shadow-sm shadow-purple-500/[0.07] transition-shadow duration-200 hover:shadow-md dark:border-purple-500/20 dark:bg-zinc-900/50 md:p-5 ${
+                      bulletin.pinned ? 'border-l-4 border-l-purple-500 pl-5 md:pl-6 dark:border-l-purple-400' : ''
+                    }`}
+                  >
+                    <div className="mb-3 flex items-start gap-3 md:mb-4">
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-purple-500/15 text-xs font-semibold text-purple-900 dark:bg-purple-500/25 dark:text-purple-100 md:text-sm">
+                        {getInitials(bulletin.author.name)}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="text-sm font-semibold text-foreground md:text-base">{bulletin.subject}</h3>
+                          {bulletin.pinned ? (
+                            <Pin className="h-3.5 w-3.5 shrink-0 fill-purple-400 text-purple-600 dark:text-purple-400" aria-label="Pinned" />
+                          ) : null}
+                        </div>
+                        <p className="text-xs text-muted-foreground md:text-sm">
+                          {bulletin.author.name} ·{' '}
+                          {formatDistanceToNow(new Date(bulletin.created_at), { addSuffix: true })}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground md:text-base">
+                      {bulletin.body}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="rounded-2xl border border-dashed border-purple-200/50 bg-violet-50/40 py-10 text-center text-sm leading-relaxed text-muted-foreground dark:border-purple-500/25 dark:bg-purple-950/20 md:text-base">
+              No announcements yet. When the organizer posts something, it will show up here.
+            </p>
+          )}
+        </VendorPortalSection>
       </div>
-    </div>
+    </VendorPortalPageCanvas>
   );
 }

--- a/src/pages/VendorEventPortalPage.tsx
+++ b/src/pages/VendorEventPortalPage.tsx
@@ -711,7 +711,8 @@ export default function VendorEventPortalPage() {
           </VendorPortalSection>
         ) : null}
 
-        <VendorPortalFaq event={event} formatDate={formatDate} />
+        {/* FAQ section hidden until backend editing UI is built */}
+        {/* <VendorPortalFaq event={event} formatDate={formatDate} /> */}
 
         <VendorPortalSection
           title="Updates from the organizer"

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_ENVIRONMENT?: 'development' | 'staging' | 'production';
   readonly VITE_MIXPANEL_TOKEN?: string;
+  /** Google Maps Embed API (optional; restricts embed by HTTP referrer in GCP). */
+  readonly VITE_GOOGLE_MAPS_EMBED_API_KEY?: string;
 }
 
 interface ImportMeta {

--- a/src/types/eventPortal.ts
+++ b/src/types/eventPortal.ts
@@ -15,6 +15,8 @@ export interface EventDetails {
   title: string;
   slug: string;
   description: string;
+  /** Event poster / hero image URL when provided by API or mocks */
+  poster_url?: string | null;
   status?: string;
   dates: {
     event_date: string;


### PR DESCRIPTION
… embed

- Extract vendor portal sections (hero, canvas, FAQ, location map)
- Polish copy, spacing, booth payment cards, producer preview strip in hero
- Optional Google Maps embed under location (VITE_GOOGLE_MAPS_EMBED_API_KEY)
- env.d.ts for embed key; eventPortal types extended as needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI refactor of the vendor portal page plus new optional Google Maps iframe embedding and local image preview logic, which could introduce regressions in portal rendering and client-side resource cleanup but doesn’t change backend behavior.
> 
> **Overview**
> Reworks the vendor event portal UI into a new sectioned layout with reusable components (`VendorPortalPageCanvas`, `VendorPortalSection`, `VendorPortalHero`) and updated copy/styling across login, loading/error, cancelled, and main portal views.
> 
> Adds portal enhancements: a hardcoded FAQ accordion (`VendorPortalFaq`), an optional lazy-loaded location map embed (`VendorPortalLocationMap`) controlled by `VITE_GOOGLE_MAPS_EMBED_API_KEY`, and a producer-only/local `?design=1` banner uploader that previews a hero image via object URLs (not persisted). Also extends portal event types to include `event.poster_url` and documents new vendor-portal-related bugs/tasks in `docs/HANDOFF.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f009e599af17dfb13b4ab3031752b977a37c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->