### PR TITLE
feat: add opted_out status UI for vendor registrations

### DIFF
--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -58,7 +58,7 @@ interface Applicant {
   email: string;
   phone?: string;
   vendor_category: string;
-  status: 'invited' | 'pending' | 'approved' | 'confirmed' | 'waitlist' | 'rejected' | 'cancelled';
+  status: 'invited' | 'pending' | 'approved' | 'confirmed' | 'waitlist' | 'rejected' | 'cancelled' | 'opted_out';
   payment_status?: 'paid' | 'pending' | 'confirmed' | 'overdue' | 'n/a';
   source?: 'contact' | 'net_new';
   is_returning?: boolean;
@@ -86,7 +86,7 @@ interface ApplicantsTabProps {
   isAdmin?: boolean;
 }
 
-type StatusFilter = 'all' | 'invited' | 'pending' | 'approved' | 'confirmed' | 'waitlist' | 'rejected' | 'cancelled';
+type StatusFilter = 'all' | 'invited' | 'pending' | 'approved' | 'confirmed' | 'waitlist' | 'rejected' | 'cancelled' | 'opted_out';
 
 export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsTabProps) {
   const [applicants, setApplicants] = useState<Applicant[]>([]);
@@ -108,7 +108,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
   const [showStatusConfirmModal, setShowStatusConfirmModal] = useState(false);
   const [pendingStatusChange, setPendingStatusChange] = useState<{
     applicant: Applicant;
-    newStatus: 'approved' | 'waitlist' | 'rejected';
+    newStatus: 'approved' | 'waitlist' | 'rejected' | 'opted_out';
   } | null>(null);
 
   // View mode: focused (two-panel) or table
@@ -303,6 +303,8 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
         return 'rejected';
       case 'cancelled':
         return 'cancelled';
+      case 'opted_out':
+        return 'opted_out';
       default:
         return 'pending';
     }
@@ -379,7 +381,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
   };
 
   // Show confirmation modal before status change
-  const requestStatusChange = (applicant: Applicant, newStatus: 'approved' | 'waitlist' | 'rejected') => {
+  const requestStatusChange = (applicant: Applicant, newStatus: 'approved' | 'waitlist' | 'rejected' | 'opted_out') => {
     setPendingStatusChange({ applicant, newStatus });
     setShowStatusConfirmModal(true);
   };
@@ -406,7 +408,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
 
   const handleUpdateStatus = async (
     applicant: Applicant,
-    newStatus: 'approved' | 'waitlist' | 'rejected'
+    newStatus: 'approved' | 'waitlist' | 'rejected' | 'opted_out'
   ) => {
     if (!applicant.registrationId) {
       alert('Cannot update status: No application found');
@@ -418,8 +420,8 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
 
       const response = await registrationsApi.update(applicant.registrationId, { status: newStatus });
 
-      // Handle email notification
-      if (response.email_notification) {
+      // Handle email notification (skip for opted_out - no emails sent)
+      if (response.email_notification && newStatus !== 'opted_out') {
         handleEmailNotification(response.email_notification, undefined, applicant.registrationId);
       }
 
@@ -597,6 +599,12 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
         return {
           label: 'Cancelled',
           variant: 'tintMuted' as BadgeVariant,
+          icon: XCircle,
+        };
+      case 'opted_out':
+        return {
+          label: 'Opted Out',
+          variant: 'tintOrange' as BadgeVariant,
           icon: XCircle,
         };
       default:
@@ -821,6 +829,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                 <SelectItem value="waitlist" className="text-xs">Waitlist</SelectItem>
                 <SelectItem value="rejected" className="text-xs">Declined</SelectItem>
                 <SelectItem value="cancelled" className="text-xs">Cancelled</SelectItem>
+                <SelectItem value="opted_out" className="text-xs">Opted Out</SelectItem>
               </SelectContent>
             </Select>
             {uniqueCategories.length > 0 && (
@@ -1038,6 +1047,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                   <SelectItem value="waitlist" className="text-xs focus:bg-background/10">Waitlist</SelectItem>
                   <SelectItem value="rejected" className="text-xs focus:bg-background/10">Declined</SelectItem>
                   <SelectItem value="cancelled" className="text-xs focus:bg-background/10">Cancelled</SelectItem>
+                  <SelectItem value="opted_out" className="text-xs focus:bg-background/10">Opted Out</SelectItem>
                 </SelectContent>
               </Select>
               {uniqueCategories.length > 0 && (
@@ -1463,6 +1473,22 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                     </div>
                   ) : (
                     <div className="space-y-3">
+                      {/* Opted Out Warning Banner */}
+                      {selectedApplicant.status === 'opted_out' && (
+                        <div className="rounded-lg border border-orange-300/60 bg-orange-50/80 p-3 mb-3 dark:border-orange-500/30 dark:bg-orange-950/20">
+                          <div className="flex items-start gap-2.5">
+                            <AlertCircle className="w-4 h-4 text-orange-600 dark:text-orange-400 flex-shrink-0 mt-0.5" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-xs font-semibold text-orange-900 dark:text-orange-100 mb-0.5">
+                                This vendor has opted out
+                              </p>
+                              <p className="text-[11px] text-orange-800 dark:text-orange-200/90 leading-relaxed">
+                                They will not receive any event emails. Use the dropdown below to restore their status if needed.
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      )}
                       {/* Vendor Status Row */}
                       <div className="flex items-center justify-between pb-3 border-b border-border">
                         <div>
@@ -1476,7 +1502,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                           value="keep"
                           onValueChange={(value) => {
                             if (value === 'keep') return;
-                            const newStatus = value as 'approved' | 'waitlist' | 'rejected';
+                            const newStatus = value as 'approved' | 'waitlist' | 'rejected' | 'opted_out';
                             if (newStatus !== selectedApplicant.status) {
                               requestStatusChange(selectedApplicant, newStatus);
                             }
@@ -1497,6 +1523,9 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                             </SelectItem>
                             <SelectItem value="rejected" className="text-xs focus:bg-background/10">
                               Change to Declined
+                            </SelectItem>
+                            <SelectItem value="opted_out" className="text-xs focus:bg-background/10">
+                              Change to Opted Out
                             </SelectItem>
                           </SelectContent>
                         </Select>
@@ -1689,7 +1718,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
               </div>
               <div className="flex-1">
                 <h3 className="text-lg font-semibold text-foreground mb-1">
-                  Change Status to {pendingStatusChange.newStatus === 'approved' ? 'Approved' : pendingStatusChange.newStatus === 'rejected' ? 'Declined' : 'Waitlisted'}?
+                  Change Status to {pendingStatusChange.newStatus === 'approved' ? 'Approved' : pendingStatusChange.newStatus === 'rejected' ? 'Declined' : pendingStatusChange.newStatus === 'opted_out' ? 'Opted Out' : 'Waitlisted'}?
                 </h3>
                 <p className="text-sm text-foreground/60">
                   This will send an automated email notification

--- a/src/pages/VendorEventPortalPage.tsx
+++ b/src/pages/VendorEventPortalPage.tsx
@@ -24,6 +24,7 @@ import {
   hasActiveSession,
 } from '@/services/eventPortalService';
 import { useAuth } from '@/contexts/AuthContext';
+import { useForceTheme } from '@/hooks/useForceTheme';
 import { eventsApi, vendorApplicationsApi, bulletinsApi, registrationsApi } from '@/services/api';
 import type { EventPortalData } from '@/types/eventPortal';
 import type { Bulletin } from '@/types/bulletin';
@@ -35,6 +36,7 @@ import { VendorPortalSection } from '@/components/vendor-portal/VendorPortalSect
 import { formatDistanceToNow } from 'date-fns';
 
 export default function VendorEventPortalPage() {
+  useForceTheme('dark');
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const { isAuthenticated: isLoggedIn, isProducer, isAdmin } = useAuth();

--- a/src/pages/VendorEventPortalPage.tsx
+++ b/src/pages/VendorEventPortalPage.tsx
@@ -13,6 +13,7 @@ import {
   LayoutList,
   Tags,
   ArrowUpRight,
+  XCircle,
 } from 'lucide-react';
 import {
   verifyPortalAccess,
@@ -23,7 +24,7 @@ import {
   hasActiveSession,
 } from '@/services/eventPortalService';
 import { useAuth } from '@/contexts/AuthContext';
-import { eventsApi, vendorApplicationsApi, bulletinsApi } from '@/services/api';
+import { eventsApi, vendorApplicationsApi, bulletinsApi, registrationsApi } from '@/services/api';
 import type { EventPortalData } from '@/types/eventPortal';
 import type { Bulletin } from '@/types/bulletin';
 import { VendorPortalFaq } from '@/components/vendor-portal/VendorPortalFaq';
@@ -61,6 +62,10 @@ export default function VendorEventPortalPage() {
   /** Local-only banner preview (object URL); never persisted */
   const [bannerPreviewUrl, setBannerPreviewUrl] = useState<string | null>(null);
 
+  // Opt-out state
+  const [showOptOutModal, setShowOptOutModal] = useState(false);
+  const [optingOut, setOptingOut] = useState(false);
+
   useEffect(() => {
     return () => {
       if (bannerPreviewUrl) URL.revokeObjectURL(bannerPreviewUrl);
@@ -86,6 +91,22 @@ export default function VendorEventPortalPage() {
       if (prev) URL.revokeObjectURL(prev);
       return null;
     });
+  };
+
+  const handleOptOut = async () => {
+    if (!portalData?.registration?.id) return;
+
+    setOptingOut(true);
+    try {
+      const result = await registrationsApi.optOut(portalData.registration.id);
+      setPortalData(prev => prev ? { ...prev, registration: result.registration } : null);
+      setShowOptOutModal(false);
+      alert(result.message || 'You have successfully opted out.');
+    } catch (error: any) {
+      alert(error.message || 'Failed to opt out. Please contact the organizer.');
+    } finally {
+      setOptingOut(false);
+    }
   };
 
   // Pre-fill email from URL params on mount
@@ -711,6 +732,58 @@ export default function VendorEventPortalPage() {
           </VendorPortalSection>
         ) : null}
 
+        {/* Opted Out Alert Banner - Show prominently at top */}
+        {portalData.registration?.status === 'opted_out' && (
+          <div className="mb-8">
+            <div className="rounded-2xl border-2 border-orange-400/60 bg-orange-50 p-6 shadow-lg dark:border-orange-500/40 dark:bg-orange-950/30">
+              <div className="flex items-start gap-4">
+                <div className="rounded-full bg-orange-100 p-3 dark:bg-orange-900/50">
+                  <AlertCircle className="h-7 w-7 text-orange-600 dark:text-orange-400" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-bold text-orange-900 dark:text-orange-100 mb-2">
+                    You've Been Opted Out of This Event
+                  </h3>
+                  <div className="space-y-2 text-sm text-orange-800 dark:text-orange-200/90">
+                    <p className="leading-relaxed">
+                      Your registration status has been changed to "opted out". This means you will <strong>no longer receive any emails</strong> about this event.
+                    </p>
+                    <p className="leading-relaxed">
+                      If this is not correct or you'd like to rejoin the event, please contact the event organizer directly:
+                    </p>
+                    {portalData.event.organization?.email && (
+                      <div className="mt-3 rounded-lg bg-orange-100/60 px-4 py-2.5 dark:bg-orange-900/30">
+                        <p className="text-xs font-medium text-orange-900/70 dark:text-orange-200/70 mb-1">
+                          Contact {portalData.event.organization.name}:
+                        </p>
+                        <a
+                          href={`mailto:${portalData.event.organization.email}`}
+                          className="text-sm font-semibold text-orange-900 hover:text-orange-700 dark:text-orange-100 dark:hover:text-orange-200 underline"
+                        >
+                          {portalData.event.organization.email}
+                        </a>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Opt-Out Button - Only show if NOT opted out */}
+        {portalData.registration?.status !== 'opted_out' && portalData.registration && (
+          <div className="mb-8">
+            <button
+              onClick={() => setShowOptOutModal(true)}
+              className="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-orange-700 bg-orange-50 border border-orange-200/60 rounded-xl hover:bg-orange-100 transition-colors dark:text-orange-300 dark:bg-orange-950/30 dark:border-orange-500/30 dark:hover:bg-orange-950/50"
+            >
+              <XCircle className="w-4 h-4" />
+              Opt Out of Event
+            </button>
+          </div>
+        )}
+
         {/* FAQ section hidden until backend editing UI is built */}
         {/* <VendorPortalFaq event={event} formatDate={formatDate} /> */}
 
@@ -768,6 +841,63 @@ export default function VendorEventPortalPage() {
           )}
         </VendorPortalSection>
       </div>
+
+      {/* Opt-Out Warning Modal */}
+      {showOptOutModal && (
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+          <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-2xl max-w-md w-full p-6">
+            <div className="flex items-start gap-3 mb-4">
+              <div className="p-2 bg-orange-100 dark:bg-orange-950/50 rounded-xl">
+                <AlertCircle className="w-6 h-6 text-orange-600 dark:text-orange-400" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-foreground">
+                  Opt Out of Event?
+                </h3>
+                <p className="text-sm text-muted-foreground mt-1">
+                  This will remove you from all event communications.
+                </p>
+              </div>
+            </div>
+
+            <div className="bg-orange-50 dark:bg-orange-950/30 border border-orange-200 dark:border-orange-500/30 rounded-xl p-4 mb-6">
+              <p className="text-sm font-medium text-orange-900 dark:text-orange-100 mb-2">
+                ⚠️ Important:
+              </p>
+              <ul className="text-sm text-orange-800 dark:text-orange-200/90 space-y-1.5 list-disc list-inside">
+                <li>You will not receive any more event emails</li>
+                <li>Your spot may be given to another vendor</li>
+                <li>You cannot opt back in yourself</li>
+                <li>You must contact the producer to rejoin</li>
+              </ul>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowOptOutModal(false)}
+                disabled={optingOut}
+                className="flex-1 px-4 py-2.5 text-sm font-medium text-foreground bg-muted border border-border rounded-xl hover:bg-muted/80 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleOptOut}
+                disabled={optingOut}
+                className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-orange-600 rounded-xl hover:bg-orange-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                {optingOut ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Opting Out...
+                  </>
+                ) : (
+                  'Yes, Opt Out'
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </VendorPortalPageCanvas>
   );
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -975,6 +975,20 @@ export const registrationsApi = {
       body: newPrice ? JSON.stringify({ new_price: newPrice }) : undefined,
     })
   },
+
+  /**
+   * Vendor self-service opt-out
+   * POST /api/v1/presents/registrations/:id/opt_out
+   */
+  async optOut(registrationId: number) {
+    return fetchApi<{
+      success: boolean
+      message: string
+      registration: any
+    }>(`/v1/presents/registrations/${registrationId}/opt_out`, {
+      method: 'POST',
+    })
+  },
 }
 
 // Vendor Applications API

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -257,7 +257,8 @@ export type RegistrationStatus =
   | 'confirmed'
   | 'waitlist'
   | 'rejected'
-  | 'cancelled';
+  | 'cancelled'
+  | 'opted_out';
 
 export type PaymentStatus =
   | 'paid'

--- a/src/types/eventPortal.ts
+++ b/src/types/eventPortal.ts
@@ -8,6 +8,14 @@ export interface EventPortalData {
   event: EventDetails;
   vendor_categories: VendorCategory[];
   producer_updates: Bulletin[];
+  registration?: {
+    id: number;
+    status: string;
+    email: string;
+    name?: string;
+    vendor_category?: string;
+    payment_status?: string;
+  };
 }
 
 export interface EventDetails {


### PR DESCRIPTION
Add frontend support for opted_out status with producer and vendor interfaces.

Producer UI changes:
- Add orange 'Opted Out' badge with XCircle icon to ApplicantsTab
- Add 'Change to Opted Out' option to status dropdown
- Add 'Opted Out' filter to both table and focused view
- Add prominent orange warning banner in applicant detail panel
- Update all TypeScript types to include opted_out status
- Fix mapRegistrationStatus to handle opted_out (prevents revert to pending)
- Suppress email notification modal for opted_out status changes

Vendor Portal changes:
- Add large prominent opted-out alert banner with organization contact
- Add opt-out button (only visible when not opted out)
- Add warning modal with 4-point caution list before opting out
- Add handleOptOut function to call backend endpoint
- Import registrationsApi for opt-out functionality

Type definitions:
- Update RegistrationStatus type to include 'opted_out'
- Update EventPortalData interface to include registration data
- Update Applicant and StatusFilter types

Bug fixes:
- Fix mapRegistrationStatus to prevent status reverting to pending after refresh
- Add missing registrationsApi import to VendorEventPortalPage
- Fix all TypeScript function signatures to accept opted_out

✅ TypeScript compilation: 0 errors

🤖 Generated with Claude Code