### PR TITLE
fix: add user_id to Organization interface in IncomingPaymentsPage

### DIFF
--- a/src/pages/IncomingPaymentsPage.tsx
+++ b/src/pages/IncomingPaymentsPage.tsx
@@ -39,6 +39,7 @@ interface Organization {
   id: number;
   slug: string;
   name: string;
+  user_id: number;
 }
 
 export default function IncomingPaymentsPage() {


### PR DESCRIPTION
Fixes TypeScript compilation error where Organization.user_id was accessed but not defined in the interface type.

Error: TS2339: Property 'user_id' does not exist on type 'Organization'

🤖 Generated with [Claude Code](https://claude.com/claude-code)