### PR TITLE
feat: Add MXN (Mexican Peso) currency support

### DIFF
--- a/src/components/producer/CreateEventWizard/types.ts
+++ b/src/components/producer/CreateEventWizard/types.ts
@@ -38,7 +38,7 @@ export interface PaymentEngineConfig {
   collect_app_code: boolean;   // Whether to prompt artists to include app code in payment
 }
 
-export type CurrencyCode = 'USD' | 'EUR' | 'GBP' | 'CAD' | 'AUD';
+export type CurrencyCode = 'USD' | 'EUR' | 'GBP' | 'CAD' | 'AUD' | 'MXN';
 
 // ─── Payment Constants ───────────────────────────────────────────────────────
 
@@ -48,6 +48,7 @@ export const SUPPORTED_CURRENCIES: { code: CurrencyCode; label: string; symbol: 
   { code: 'GBP', label: 'British Pound', symbol: '£' },
   { code: 'CAD', label: 'Canadian Dollar', symbol: 'CA$' },
   { code: 'AUD', label: 'Australian Dollar', symbol: 'A$' },
+  { code: 'MXN', label: 'Mexican Peso', symbol: 'MX$' },
 ];
 
 export const PAYMENT_PRICE_TYPES: { value: PaymentPriceType; label: string; description: string; isPercentage: boolean }[] = [


### PR DESCRIPTION
## Summary
- Adds Mexican Peso (MXN) to the `CurrencyCode` type union and `SUPPORTED_CURRENCIES` array
- Single file change, 2 lines — no conflict with existing staging work

## Context
Needed before the upcoming Mexico City show. Same change as PR #108 (targeting main), applied to staging as well.

## Test plan
- [ ] Verify MXN appears in the currency dropdown during event creation (Step 3)
- [ ] Confirm MX$ symbol renders correctly in pricing displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)