### PR TITLE
docs: Update onboarding docs for 3-stage pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# Voxxy Presents Client
+
+React 18 + TypeScript frontend for **Voxxy Presents** — event management and vendor coordination for venues, markets, and festivals.
+
+## Branch Strategy
+
+```
+feature/* → dev → staging → main (production)
+```
+
+- **dev**: Integration testing (Render dev service)
+- **staging**: Pre-production (Render staging service)
+- **main**: Production (https://voxxypresents.com)
+
+Always branch from `dev`. PRs to `main` require review + green CI.
+
+## Local Development
+
+```bash
+npm install
+npm run dev          # http://localhost:5173
+```
+
+Requires the Rails API backend running on port 3001. See [voxxy-rails-react](https://github.com/Voxxy-AI/voxxy-rails-react) for backend setup.
+
+API base URLs are configured in `src/config/environments.ts`.
+
+## Tech Stack
+
+- **Framework**: React 18 + TypeScript
+- **Build**: Vite 6
+- **Styling**: Tailwind CSS 3
+- **UI Components**: Radix UI (shadcn/ui), Lucide Icons, Sonner (toasts)
+- **Forms**: React Hook Form + Zod validation
+- **Rich Text**: TipTap (email editor)
+- **Auth**: JWT from Rails backend
+- **Error Monitoring**: Sentry
+- **Analytics**: Mixpanel (production only)
+- **Testing**: Vitest 3 + @testing-library/react
+
+## Key Directories
+
+```
+src/
+  components/
+    producer/           # Event management, email automation, network, payments
+      Network/          # Vendor CRM, contact management, data export
+      Email/            # Email campaign editor, sequences, templates
+      EventSettings.tsx # Event configuration
+    vendor/             # Vendor portal components
+    admin/              # Admin tools (email testing, bug reports)
+    auth/               # Login, signup, protected routes
+    ui/                 # shadcn/Radix base components
+    shared/             # Cross-role components
+  services/
+    api.ts              # Central API client (all backend calls)
+    stripeService.ts    # Stripe payment integration
+  contexts/
+    AuthContext.tsx      # Auth state + role helpers
+  pages/                # Route-level page components
+  hooks/                # useAuth, useEmailNotifications, etc.
+  types/                # TypeScript type definitions
+  utils/                # Helpers (date, email variables, validation, cache)
+  config/
+    environments.ts     # Dev/staging/prod API URL config
+```
+
+## API Integration
+
+All API endpoints are namespaced under `/api/v1/presents/`. The central API client is `src/services/api.ts` (~3000 lines). Auth tokens are managed via `AuthContext.tsx`.
+
+## User Roles
+
+- **Producer** (venue_owner): Full event management, email automation, vendor CRM
+- **Vendor**: Vendor portal, application submissions
+- **Admin**: All producer features + admin tools
+
+## Commands
+
+```bash
+npm run dev           # Start dev server
+npm run build         # Production build
+npm run test          # Tests in watch mode
+npm run test:run      # Tests once (CI mode)
+npm run typecheck     # TypeScript checking
+npm run lint          # ESLint
+npm run preview       # Preview production build
+```

--- a/README.md
+++ b/README.md
@@ -14,24 +14,28 @@
 |--------|-------------|-----|-------------|
 | `main` | Production | https://voxxypresents.com | Yes -- on merge via Render |
 | `staging` | Pre-production | Render staging service | Yes -- on merge via Render |
-
-> `develop` was retired in April 2026 during the org transfer to Voxxy-AI.
+| `dev` | Integration testing | Render dev service | Yes -- on merge via Render |
 
 ---
 
 ## Team Swim Lanes -- How We Ship Code
 
-Every change follows this path. **No direct pushes to `staging` or `main`.**
+Every change follows this path. **No direct pushes to `dev`, `staging`, or `main`.**
 
 ```
   Your local branch
          |
          | git push origin <branch>
          v
-  Open PR -> staging
+  Open PR -> dev
          |
          | CI must pass (typecheck + lint + test + build)
          | Self-merge allowed after green CI
+         v
+       dev  -->  Render dev deploy (automatic)
+         |
+         | Integration testing on dev environment
+         | Open PR -> staging
          v
       staging  -->  Render staging deploy (automatic)
          |
@@ -44,7 +48,7 @@ Every change follows this path. **No direct pushes to `staging` or `main`.**
 
 ### Branch Naming Conventions
 
-Always branch off `staging`. Use one of these prefixes:
+Always branch off `dev`. Use one of these prefixes:
 
 | Prefix | When to use | Example |
 |--------|-------------|---------|
@@ -56,9 +60,10 @@ Always branch off `staging`. Use one of these prefixes:
 
 ### PR Rules (enforced by branch protection)
 
+- PRs into `dev`: CI must pass. Self-merge allowed.
 - PRs into `staging`: CI must pass. Self-merge allowed.
 - PRs into `main`: CI must pass + minimum 1 approving review required.
-- Never force-push to `staging` or `main`.
+- Never force-push to `dev`, `staging`, or `main`.
 - Delete your branch after it merges.
 
 ---
@@ -103,6 +108,8 @@ Always branch off `staging`. Use one of these prefixes:
 npm install
 npm run dev
 ```
+
+The frontend connects to the Rails API backend. For local development, the backend must be running on port 3001. See the [backend repo](https://github.com/Voxxy-AI/voxxy-rails-react) README for setup instructions. API base URLs are configured in `src/config/environments.ts`.
 
 ### Commands
 ```bash
@@ -165,4 +172,4 @@ All API endpoints are namespaced under `/api/v1/presents/`.
 
 ---
 
-Last updated: April 28, 2026
+Last updated: June 2, 2026

--- a/docs/SESSION_GUIDE.md
+++ b/docs/SESSION_GUIDE.md
@@ -67,9 +67,9 @@
 | ID | Rule | Source |
 |------|------|--------|
 | RL-020 | Use conventional commit format: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`. | [CONTRIBUTING.md](./CONTRIBUTING.md) |
-| RL-021 | Feature branches rebase onto `staging`. Hotfix branches are based on `main`. Never merge directly to `main`. | [BRANCHING_STRATEGY.md](./development/BRANCHING_STRATEGY.md) |
-| RL-022 | Use the batch release process: feature → staging → release branch → main. Do not deploy individual features to main. | [CONTRIBUTING.md](./CONTRIBUTING.md) |
-| RL-023 | Never push directly to `main`, `staging`, or `develop`. Always open a PR into active branches. Force-push is only acceptable on your own feature/fix branch to update an open PR. | SESSION_GUIDE §1 |
+| RL-021 | Feature branches rebase onto `dev`. Hotfix branches are based on `main`. Never merge directly to `main`. | [BRANCHING_STRATEGY.md](./development/BRANCHING_STRATEGY.md) |
+| RL-022 | Use the 3-stage pipeline: feature → dev → staging → main. Do not deploy individual features directly to main. | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| RL-023 | Never push directly to `main`, `staging`, or `dev`. Always open a PR into active branches. Force-push is only acceptable on your own feature/fix branch to update an open PR. | SESSION_GUIDE §1 |
 
 ---
 
@@ -111,16 +111,16 @@ CURRENT_BRANCH=$(git branch --show-current)
 git fetch origin
 
 # Show incoming changes
-echo "=== Incoming from staging ==="
-git log --oneline HEAD..origin/staging 2>/dev/null | head -10
+echo "=== Incoming from dev ==="
+git log --oneline HEAD..origin/dev 2>/dev/null | head -10
 echo "=== Incoming from main ==="
 git log --oneline HEAD..origin/main 2>/dev/null | head -10
 
-# Rebase onto staging (or main for hotfix branches)
+# Rebase onto dev (or main for hotfix branches)
 if [[ "$CURRENT_BRANCH" == hotfix/* ]]; then
   git rebase origin/main
 else
-  git rebase origin/staging
+  git rebase origin/dev
 fi
 
 if [ $? -eq 0 ]; then
@@ -140,10 +140,10 @@ cd ~/Development/voxxy-rails-react
 BACKEND_BRANCH=$(git branch --show-current)
 git fetch origin
 
-echo "=== Incoming from main ==="
-git log --oneline HEAD..origin/main 2>/dev/null | head -10
+echo "=== Incoming from dev ==="
+git log --oneline HEAD..origin/dev 2>/dev/null | head -10
 
-git rebase origin/main
+git rebase origin/dev
 
 if [ $? -eq 0 ]; then
   echo "BACKEND REBASE: SUCCESS — $BACKEND_BRANCH is up to date."
@@ -240,7 +240,7 @@ docs(scope): description
 
 Review with:
 ```bash
-git log --oneline staging..HEAD
+git log --oneline dev..HEAD
 ```
 
 ### Step 6: Produce pre-PR summary
@@ -355,8 +355,8 @@ After completing SESSION_START mode, output this:
 - Backend: SUCCESS | CONFLICT (list files) | SKIPPED | N/A
 
 ### Incoming Changes
-- Frontend: <N> new commits from origin/staging since last session
-- Backend: <N> new commits from origin/main since last session
+- Frontend: <N> new commits from origin/dev since last session
+- Backend: <N> new commits from origin/dev since last session
 
 ### Tests After Rebase
 - Frontend: <N> passed, <N> failed | SKIPPED (conflict blocks tests)
@@ -424,3 +424,4 @@ After completing PRE_PR mode, output this:
 | Date | Change | Author |
 |------|--------|--------|
 | 2026-05-07 | Initial creation with 22 rules seeded from STYLE_GUIDE, HANDOFF, TESTING_ROADMAP, CONTRIBUTING | Team |
+| 2026-06-02 | Updated git workflow references from staging to dev (3-stage pipeline: dev → staging → main) | Team |


### PR DESCRIPTION
## Summary
- **README**: Add `dev` branch to active branches table, update pipeline diagram to 3-stage (`dev → staging → main`), change "branch off staging" to "branch off dev", add backend connection note for local dev
- **CLAUDE.md**: New AI context file for Claude Code sessions
- **SESSION_GUIDE**: Update git workflow rules and rebase scripts from staging to dev

## Why
Documentation still referenced the old 2-stage pipeline (`staging → main`). New engineers need to know about the `dev` environment and branch from `dev`, not `staging`.

## Test plan
- [ ] Verify README pipeline diagram matches backend's DEPLOYMENT_WORKFLOW.md
- [ ] Verify SESSION_GUIDE rebase scripts reference `origin/dev`
- [ ] Review CLAUDE.md loads correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)