### PR TITLE
Centralize user-facing errors (catalog, notify, pilot migrations)

### DIFF
--- a/docs/guides/ERROR_NOTIFICATIONS.md
+++ b/docs/guides/ERROR_NOTIFICATIONS.md
@@ -1,0 +1,61 @@
+# Error notifications
+
+Centralized user-facing errors live under `src/errors/`. No backend changes are required for the initial rollout.
+
+## Quick reference
+
+```ts
+import { notify } from '@/errors/notify'
+import { getApiErrorMessage } from '@/errors/getApiErrorMessage'
+import { getMessage } from '@/errors/catalog'
+
+// Toast (default)
+notify.error({ key: 'network.deleteContactFailed' })
+notify.success({ key: 'network.bulkDeleteSuccess', params: { count: 12 } })
+
+// Inline (forms) — returns the string without showing a toast
+setError(getApiErrorMessage(err, 'auth'))
+
+// API errors with server text as fallback
+notify.error({ key: 'network.saveCategoryFailed', fallback: getApiErrorMessage(err) })
+```
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| `src/errors/catalog/` | Message keys by domain (`global`, `auth`, `network`, `email`, …) |
+| `src/errors/normalizeApiError.ts` | Maps `ApiError` + HTTP status → catalog key or pass-through text |
+| `src/errors/notify.ts` | `notify.error` / `success` / `warning` via Sonner |
+| `src/errors/getApiErrorMessage.ts` | String helper for inline form errors |
+
+## When to use what
+
+| Situation | Approach |
+|-----------|----------|
+| Quick action feedback (save, delete, bulk) | `notify.error` / `notify.success` |
+| Login / signup inline banner | `getApiErrorMessage(err, 'auth')` |
+| Rails 422 field validation | Pass-through: `normalizeApiError` uses `errors[0]` |
+| React render crash | `ErrorBoundary` + `global.boundary*` keys |
+| Unknown server message | `fallback: getApiErrorMessage(err)` |
+
+## Toaster styling
+
+`<Toaster />` lives in `src/App.tsx` (inside `AuthProvider`). Sonner CSS variable overrides in `src/index.css` align toast colors with design tokens where `theme="system"` matches the document class.
+
+## Adding catalog entries
+
+1. Add the string to the right file in `src/errors/catalog/` (e.g. `network.ts`).
+2. Use a dotted key: `domain.actionOutcome`.
+3. For interpolated copy, use a function: `(p) => \`Deleted ${p.count} contacts\``.
+
+## Migration checklist (follow-up PRs)
+
+- [ ] Replace remaining `alert()` call sites (~40 across 12 files)
+- [ ] Route direct `toast.*` from Sonner through `notify` where copy should be cataloged
+- [ ] Consolidate shadcn `useToast` usages if desired
+- [ ] Expand catalogs: events, payments, vendor portal, admin
+
+## Backend (optional later)
+
+Stable `error_code` fields from the API would reduce fragile string matching. Until then, 422 validation messages and known server `message` values are passed through intentionally.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,8 +224,8 @@ export default function App() {
   return (
     <AuthProvider>
       <Router>
-        {/* Toast Notifications - Auto-dismiss after 4 seconds */}
-        <Toaster position="top-right" duration={4000} closeButton richColors theme="system" />
+        {/* Toast Notifications - Auto-dismiss after 3 seconds */}
+        <Toaster position="top-right" duration={3000} closeButton richColors theme="system" />
 
         {/* Debug Panel - Shows on all pages in development */}
         <DebugPanel />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ReactNode } from 'react'
 import { AlertTriangle, RefreshCw, Home } from 'lucide-react'
 import ReportBug from './ReportBug'
+import { getMessage } from '@/errors/catalog'
 
 interface Props {
   children: ReactNode
@@ -87,13 +88,12 @@ class ErrorBoundary extends Component<Props, State> {
 
               {/* Title */}
               <h1 className="text-2xl font-bold text-foreground text-center mb-2">
-                Oops! Something went wrong
+                {getMessage('global.boundaryTitle')}
               </h1>
 
               {/* Description */}
               <p className="text-foreground/70 text-center mb-6">
-                We encountered an unexpected error. Don't worry, your data is safe. Try refreshing
-                the page or returning to the home page.
+                {getMessage('global.boundaryDescription')}
               </p>
 
               {/* Error Details (Collapsible in dev mode) */}

--- a/src/components/producer/Network/NetworkPage.tsx
+++ b/src/components/producer/Network/NetworkPage.tsx
@@ -37,6 +37,8 @@ import SmartListBuilder from './Lists/SmartListBuilder'
 import { BulkActionToolbar } from './BulkActionToolbar'
 import ContactExportModal from './ContactExportModal'
 import type { ActiveFilter, FilterFieldConfig } from '@/components/shared/SearchFilterBar'
+import { notify } from '@/errors/notify'
+import { getApiErrorMessage } from '@/errors/getApiErrorMessage'
 
 type NetworkTab = 'contacts' | 'lists' | 'categories'
 
@@ -464,8 +466,11 @@ export default function NetworkPage({
       await vendorContactsApi.delete(contactId)
       setContacts((prev) => prev.filter((c) => c.id !== contactId))
       setSelectedContacts((prev) => prev.filter((id) => id !== contactId))
-    } catch (err: any) {
-      alert(err.message || 'Failed to delete contact')
+    } catch (err: unknown) {
+      notify.error({
+        key: 'network.deleteContactFailed',
+        fallback: getApiErrorMessage(err),
+      })
     }
   }
 
@@ -481,7 +486,11 @@ export default function NetworkPage({
     try {
       setBulkUpdateLoading(true)
       const result = await vendorContactsApi.bulkDelete(organizationId, selectedContacts)
-      alert(result.message || `Successfully deleted ${result.deleted_count} contacts`)
+      notify.success({
+        key: 'network.bulkDeleteSuccess',
+        params: { count: result.deleted_count },
+        fallback: result.message,
+      })
       await fetchContacts(currentPage)
       try {
         const options = await vendorContactsApi.getFilterOptions(organizationId)
@@ -494,8 +503,11 @@ export default function NetworkPage({
         /* ignore */
       }
       setSelectedContacts([])
-    } catch (error: any) {
-      alert(`Failed to delete contacts: ${error.message || 'Unknown error'}`)
+    } catch (error: unknown) {
+      notify.error({
+        key: 'network.bulkDeleteFailed',
+        fallback: getApiErrorMessage(error),
+      })
     } finally {
       setBulkUpdateLoading(false)
     }
@@ -522,11 +534,18 @@ export default function NetworkPage({
         categories: categoryNames,
         category_mode: categoryMode,
       })
-      alert(result.message || `Successfully updated ${result.updated_count} contacts`)
+      notify.success({
+        key: 'network.bulkUpdateSuccess',
+        params: { count: result.updated_count },
+        fallback: result.message,
+      })
       await fetchContacts(currentPage)
       setSelectedContacts([])
-    } catch (error: any) {
-      alert(`Failed to update contacts: ${error.message || 'Unknown error'}`)
+    } catch (error: unknown) {
+      notify.error({
+        key: 'network.bulkUpdateFailed',
+        fallback: getApiErrorMessage(error),
+      })
     } finally {
       setBulkUpdateLoading(false)
     }
@@ -540,11 +559,18 @@ export default function NetworkPage({
       const result = await vendorContactsApi.bulkUpdate(organizationId, selectedContacts, {
         location,
       })
-      alert(result.message || `Successfully updated ${result.updated_count} contacts`)
+      notify.success({
+        key: 'network.bulkUpdateSuccess',
+        params: { count: result.updated_count },
+        fallback: result.message,
+      })
       await fetchContacts(currentPage)
       setSelectedContacts([])
-    } catch (error: any) {
-      alert(`Failed to update location: ${error.message || 'Unknown error'}`)
+    } catch (error: unknown) {
+      notify.error({
+        key: 'network.bulkLocationUpdateFailed',
+        fallback: getApiErrorMessage(error),
+      })
     } finally {
       setBulkUpdateLoading(false)
     }
@@ -692,7 +718,7 @@ export default function NetworkPage({
 
   const handleSaveCategory = async () => {
     if (!categoryFormData.name.trim()) {
-      alert('Category name is required')
+      notify.error({ key: 'network.categoryNameRequired' })
       return
     }
     const payload = {
@@ -712,10 +738,11 @@ export default function NetworkPage({
       setEditingCategory(null)
       setCategoryFormData({ ...emptyCategory })
       setPaymentPreferences([])
-    } catch (error: any) {
-      alert(
-        `Failed to save category: ${error.response?.data?.error || error.message || 'Please try again.'}`,
-      )
+    } catch (error: unknown) {
+      notify.error({
+        key: 'network.saveCategoryFailed',
+        fallback: getApiErrorMessage(error),
+      })
     }
   }
 
@@ -729,19 +756,21 @@ export default function NetworkPage({
         usageDetails.push(`${stats.email_templates_count} email template(s)`)
       if (stats?.scheduled_emails_count)
         usageDetails.push(`${stats.scheduled_emails_count} scheduled email(s)`)
-      alert(
-        `Cannot delete this category. It is currently being used by:\n\n${usageDetails.join('\n')}\n\nPlease remove these associations first.`,
-      )
+      notify.warning({
+        key: 'network.deleteCategoryBlocked',
+        params: { usageDetails: usageDetails.join('\n') },
+      })
       return
     }
     if (!confirm(`Are you sure you want to delete the category "${category.name}"?`)) return
     try {
       await categoriesApi.delete(category.id)
       await loadCategories()
-    } catch (error: any) {
-      alert(
-        `Failed to delete category: ${error.response?.data?.error || error.message || 'Please try again.'}`,
-      )
+    } catch (error: unknown) {
+      notify.error({
+        key: 'network.deleteCategoryFailed',
+        fallback: getApiErrorMessage(error),
+      })
     }
   }
 
@@ -766,8 +795,11 @@ export default function NetworkPage({
       setListName('')
       setShowSaveInput(false)
       onTabChange?.('lists')
-    } catch (err: any) {
-      alert(err.message || 'Failed to save list')
+    } catch (err: unknown) {
+      notify.error({
+        key: 'network.saveListFailed',
+        fallback: getApiErrorMessage(err),
+      })
     } finally {
       setSavingList(false)
     }
@@ -802,8 +834,11 @@ export default function NetworkPage({
       setCreateListDescription('')
       setCreateListFilters({})
       onTabChange?.('lists')
-    } catch (err: any) {
-      alert(err.message || 'Failed to create list')
+    } catch (err: unknown) {
+      notify.error({
+        key: 'network.createListFailed',
+        fallback: getApiErrorMessage(err),
+      })
     } finally {
       setSavingCreateList(false)
     }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { authApi, getAuthToken, clearAuthToken, ApiError } from '@/services/api'
+import { getApiErrorMessage } from '@/errors/getApiErrorMessage'
+import { getMessage } from '@/errors/catalog'
 import { analytics } from '@/lib/analytics'
 import { getCachedUserProfile, cacheUserProfile, removeCachedUserProfile } from '@/utils/cache'
 import { resetThemePreference, restoreDashboardThemePreference } from '@/contexts/ThemeContext'
@@ -224,13 +226,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
         analytics.trackUserSignIn(user.email, String(user.id), user.role)
       }
     } catch (err) {
-      if (err instanceof ApiError) {
-        // Use the main error message (which is user-friendly)
-        // Don't use err.errors as it contains raw backend validation errors
-        setError(err.message)
-      } else {
-        setError('An unexpected error occurred during sign up')
-      }
+      setError(
+        err instanceof ApiError
+          ? getApiErrorMessage(err, 'auth')
+          : getMessage('auth.signUpFailed')
+      )
       throw err
     }
     // Note: No finally block - don't change loading state for signup
@@ -268,12 +268,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
         confirmed: !!user.confirmed_at,
       })
     } catch (err) {
-      if (err instanceof ApiError) {
-        // Use the main error message (which is user-friendly)
-        setError(err.message)
-      } else {
-        setError('An unexpected error occurred during sign in')
-      }
+      setError(
+        err instanceof ApiError
+          ? getApiErrorMessage(err, 'auth')
+          : getMessage('auth.signInFailed')
+      )
       throw err
     }
     // Note: No finally block - don't change loading state for login
@@ -299,11 +298,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setCurrentUser(null)
       setUserProfile(null)
     } catch (err) {
-      if (err instanceof ApiError) {
-        setError(err.message)
-      } else {
-        setError('An unexpected error occurred during sign out')
-      }
+      setError(
+        err instanceof ApiError
+          ? getApiErrorMessage(err)
+          : getMessage('auth.signOutFailed')
+      )
       throw err
     } finally {
       setLoading(false)
@@ -316,11 +315,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setError(null)
       await authApi.requestPasswordReset(email)
     } catch (err) {
-      if (err instanceof ApiError) {
-        setError(err.message)
-      } else {
-        setError('An unexpected error occurred while resetting password')
-      }
+      setError(
+        err instanceof ApiError
+          ? getApiErrorMessage(err, 'auth')
+          : getMessage('auth.resetPasswordFailed')
+      )
       throw err
     }
   }

--- a/src/errors/catalog/auth.ts
+++ b/src/errors/catalog/auth.ts
@@ -1,0 +1,13 @@
+import type { MessageParams } from './index'
+
+export const authCatalog = {
+  'auth.invalidCredentials': 'Invalid email or password. Please try again.',
+  'auth.sessionExpired': 'Your session has expired. Please sign in again.',
+  'auth.forbidden': "You don't have permission to perform this action.",
+  'auth.signInFailed': 'Sign in failed. Please try again.',
+  'auth.signUpFailed': 'Sign up failed. Please try again.',
+  'auth.signOutFailed': 'Sign out failed. Please try again.',
+  'auth.resetPasswordFailed': 'Could not send password reset email. Please try again.',
+  'auth.devLoginFailed':
+    'Dev login failed. Is the Rails server running on port 3001 with seed data?',
+} as const satisfies Record<string, string | ((params: MessageParams) => string)>

--- a/src/errors/catalog/email.ts
+++ b/src/errors/catalog/email.ts
@@ -1,0 +1,14 @@
+import type { MessageParams } from './index'
+
+export const emailCatalog = {
+  'email.sendFailed': 'Failed to send email.',
+  'email.sendFailedDescription': 'An unexpected error occurred.',
+  'email.sendSuccess': (p: MessageParams) => String(p.message ?? 'Email sent successfully.'),
+  'email.sendSuccessDescription': (p: MessageParams) => {
+    const sent = p.sentCount ?? 0
+    const failed = p.failedCount ?? 0
+    return failed
+      ? `Sent to ${sent} recipients (${failed} failed)`
+      : `Sent to ${sent} recipients`
+  },
+} as const satisfies Record<string, string | ((params: MessageParams) => string)>

--- a/src/errors/catalog/global.ts
+++ b/src/errors/catalog/global.ts
@@ -1,0 +1,10 @@
+import type { MessageParams } from './index'
+
+export const globalCatalog = {
+  'global.network': 'Network error. Please check your connection and try again.',
+  'global.requestFailed': 'Something went wrong. Please try again.',
+  'global.unexpected': 'An unexpected error occurred. Please try again.',
+  'global.boundaryTitle': 'Oops! Something went wrong',
+  'global.boundaryDescription':
+    "We encountered an unexpected error. Don't worry, your data is safe. Try refreshing the page or returning to the home page.",
+} as const satisfies Record<string, string | ((params: MessageParams) => string)>

--- a/src/errors/catalog/index.ts
+++ b/src/errors/catalog/index.ts
@@ -1,0 +1,31 @@
+import { globalCatalog } from './global'
+import { authCatalog } from './auth'
+import { networkCatalog } from './network'
+import { emailCatalog } from './email'
+
+export type MessageParams = Record<string, string | number>
+
+export type CatalogKey =
+  | keyof typeof globalCatalog
+  | keyof typeof authCatalog
+  | keyof typeof networkCatalog
+  | keyof typeof emailCatalog
+
+const catalog: Record<string, string | ((params: MessageParams) => string)> = {
+  ...globalCatalog,
+  ...authCatalog,
+  ...networkCatalog,
+  ...emailCatalog,
+}
+
+export function getMessage(
+  key: string,
+  params: MessageParams = {}
+): string {
+  const entry = catalog[key]
+  if (!entry) {
+    console.warn(`[errors] Missing catalog key: ${key}`)
+    return key
+  }
+  return typeof entry === 'function' ? entry(params) : entry
+}

--- a/src/errors/catalog/network.ts
+++ b/src/errors/catalog/network.ts
@@ -1,0 +1,19 @@
+import type { MessageParams } from './index'
+
+export const networkCatalog = {
+  'network.deleteContactFailed': 'Failed to delete contact.',
+  'network.bulkDeleteSuccess': (p: MessageParams) =>
+    `Successfully deleted ${p.count} contacts`,
+  'network.bulkDeleteFailed': 'Failed to delete contacts.',
+  'network.bulkUpdateSuccess': (p: MessageParams) =>
+    `Successfully updated ${p.count} contacts`,
+  'network.bulkUpdateFailed': 'Failed to update contacts.',
+  'network.bulkLocationUpdateFailed': 'Failed to update location.',
+  'network.categoryNameRequired': 'Category name is required.',
+  'network.saveCategoryFailed': 'Failed to save category.',
+  'network.deleteCategoryBlocked': (p: MessageParams) =>
+    `Cannot delete this category. It is currently being used by:\n\n${p.usageDetails}\n\nPlease remove these associations first.`,
+  'network.deleteCategoryFailed': 'Failed to delete category.',
+  'network.saveListFailed': 'Failed to save list.',
+  'network.createListFailed': 'Failed to create list.',
+} as const satisfies Record<string, string | ((params: MessageParams) => string)>

--- a/src/errors/catalog/network.ts
+++ b/src/errors/catalog/network.ts
@@ -2,11 +2,15 @@ import type { MessageParams } from './index'
 
 export const networkCatalog = {
   'network.deleteContactFailed': 'Failed to delete contact.',
-  'network.bulkDeleteSuccess': (p: MessageParams) =>
-    `Successfully deleted ${p.count} contacts`,
+  'network.bulkDeleteSuccess': (p: MessageParams) => {
+    const count = Number(p.count ?? 0)
+    return `Successfully deleted ${count} contact${count === 1 ? '' : 's'}`
+  },
   'network.bulkDeleteFailed': 'Failed to delete contacts.',
-  'network.bulkUpdateSuccess': (p: MessageParams) =>
-    `Successfully updated ${p.count} contacts`,
+  'network.bulkUpdateSuccess': (p: MessageParams) => {
+    const count = Number(p.count ?? 0)
+    return `Successfully updated ${count} contact${count === 1 ? '' : 's'}`
+  },
   'network.bulkUpdateFailed': 'Failed to update contacts.',
   'network.bulkLocationUpdateFailed': 'Failed to update location.',
   'network.categoryNameRequired': 'Category name is required.',

--- a/src/errors/getApiErrorMessage.ts
+++ b/src/errors/getApiErrorMessage.ts
@@ -1,0 +1,8 @@
+import { normalizeApiError, type NormalizeContext } from './normalizeApiError'
+
+export function getApiErrorMessage(
+  error: unknown,
+  context: NormalizeContext = 'default'
+): string {
+  return normalizeApiError(error, { context }).message
+}

--- a/src/errors/normalizeApiError.test.ts
+++ b/src/errors/normalizeApiError.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { ApiError } from '@/services/api'
+import { normalizeApiError } from './normalizeApiError'
+
+describe('normalizeApiError', () => {
+  it('maps network failures (status 0)', () => {
+    const result = normalizeApiError(new ApiError('Network error: Failed to fetch', 0))
+    expect(result.key).toBe('global.network')
+    expect(result.passThrough).toBe(false)
+  })
+
+  it('passes through 422 validation errors', () => {
+    const result = normalizeApiError(
+      new ApiError('Validation failed', 422, ['Email has already been taken'])
+    )
+    expect(result.message).toBe('Email has already been taken')
+    expect(result.passThrough).toBe(true)
+  })
+
+  it('uses invalid credentials for 401 in auth context without message', () => {
+    const result = normalizeApiError(new ApiError('', 401), { context: 'auth' })
+    expect(result.key).toBe('auth.invalidCredentials')
+  })
+
+  it('passes through server message for 401 in auth context', () => {
+    const result = normalizeApiError(new ApiError('Invalid email or password', 401), {
+      context: 'auth',
+    })
+    expect(result.message).toBe('Invalid email or password')
+    expect(result.passThrough).toBe(true)
+  })
+
+  it('maps 401 outside auth context to session expired', () => {
+    const result = normalizeApiError(new ApiError('Unauthorized', 401))
+    expect(result.key).toBe('auth.sessionExpired')
+  })
+
+  it('falls back to generic message when no details', () => {
+    const result = normalizeApiError(new ApiError('', 500))
+    expect(result.key).toBe('global.requestFailed')
+  })
+
+  it('handles non-Error values', () => {
+    const result = normalizeApiError('oops')
+    expect(result.key).toBe('global.unexpected')
+  })
+})

--- a/src/errors/normalizeApiError.ts
+++ b/src/errors/normalizeApiError.ts
@@ -1,0 +1,107 @@
+import { ApiError } from '@/services/api'
+import { getMessage } from './catalog'
+
+export type NormalizeContext = 'auth' | 'default'
+
+export interface NormalizedError {
+  key?: string
+  message: string
+  status?: number
+  errors?: string[]
+  passThrough: boolean
+}
+
+interface ApiLikeError {
+  message: string
+  status?: number
+  errors?: string[]
+  name?: string
+}
+
+function isApiLikeError(error: unknown): error is ApiLikeError {
+  return error instanceof Error && typeof (error as ApiLikeError).message === 'string'
+}
+
+export function normalizeApiError(
+  error: unknown,
+  options: { context?: NormalizeContext } = {}
+): NormalizedError {
+  const context = options.context ?? 'default'
+
+  if (!isApiLikeError(error)) {
+    return {
+      key: 'global.unexpected',
+      message: getMessage('global.unexpected'),
+      passThrough: false,
+    }
+  }
+
+  const status = error instanceof ApiError ? error.status : error.status
+  const errors = error instanceof ApiError ? error.errors : error.errors
+  const rawMessage = error.message?.trim() ?? ''
+
+  if (status === 0) {
+    return {
+      key: 'global.network',
+      message: getMessage('global.network'),
+      status,
+      passThrough: false,
+    }
+  }
+
+  if (status === 403) {
+    return {
+      key: 'auth.forbidden',
+      message: getMessage('auth.forbidden'),
+      status,
+      errors,
+      passThrough: false,
+    }
+  }
+
+  if (status === 401) {
+    if (context === 'auth') {
+      const message = rawMessage || getMessage('auth.invalidCredentials')
+      return {
+        key: rawMessage ? undefined : 'auth.invalidCredentials',
+        message,
+        status,
+        errors,
+        passThrough: !!rawMessage,
+      }
+    }
+    return {
+      key: 'auth.sessionExpired',
+      message: getMessage('auth.sessionExpired'),
+      status,
+      errors,
+      passThrough: false,
+    }
+  }
+
+  if (status === 422 && errors && errors.length > 0) {
+    return {
+      message: errors[0],
+      status,
+      errors,
+      passThrough: true,
+    }
+  }
+
+  if (rawMessage) {
+    return {
+      message: rawMessage,
+      status,
+      errors,
+      passThrough: true,
+    }
+  }
+
+  return {
+    key: 'global.requestFailed',
+    message: getMessage('global.requestFailed'),
+    status,
+    errors,
+    passThrough: false,
+  }
+}

--- a/src/errors/notify.ts
+++ b/src/errors/notify.ts
@@ -1,0 +1,86 @@
+import { toast } from 'sonner'
+import { getMessage, type MessageParams } from './catalog'
+import { normalizeApiError, type NormalizeContext } from './normalizeApiError'
+
+export type NotifyChannel = 'toast' | 'inline'
+
+export interface NotifyOptions {
+  key?: string
+  params?: MessageParams
+  fallback?: string
+  channel?: NotifyChannel
+  description?: string
+}
+
+function resolveMessage(options: NotifyOptions): string {
+  if (options.fallback) {
+    return options.fallback
+  }
+  if (options.key) {
+    return getMessage(options.key, options.params ?? {})
+  }
+  return getMessage('global.unexpected')
+}
+
+function dispatch(
+  type: 'error' | 'success' | 'warning',
+  options: NotifyOptions
+): string {
+  const message = resolveMessage(options)
+  const channel = options.channel ?? 'toast'
+
+  if (channel === 'inline') {
+    return message
+  }
+
+  const toastOptions = options.description ? { description: options.description } : undefined
+
+  switch (type) {
+    case 'error':
+      toast.error(message, toastOptions)
+      break
+    case 'success':
+      toast.success(message, toastOptions)
+      break
+    case 'warning':
+      toast.warning(message, toastOptions)
+      break
+  }
+
+  return message
+}
+
+export const notify = {
+  error(options: NotifyOptions): string {
+    return dispatch('error', options)
+  },
+  success(options: NotifyOptions): string {
+    return dispatch('success', options)
+  },
+  warning(options: NotifyOptions): string {
+    return dispatch('warning', options)
+  },
+  fromApiError(
+    error: unknown,
+    options: {
+      context?: NormalizeContext
+      key?: string
+      channel?: NotifyChannel
+      showToast?: boolean
+    } = {}
+  ): string {
+    const normalized = normalizeApiError(error, { context: options.context })
+    const notifyOptions: NotifyOptions = {
+      key: options.key ?? normalized.key,
+      fallback: normalized.message,
+      channel: options.showToast === false ? 'inline' : (options.channel ?? 'inline'),
+    }
+    if (options.showToast) {
+      notifyOptions.channel = 'toast'
+      return dispatch('error', notifyOptions)
+    }
+    return resolveMessage(notifyOptions)
+  },
+}
+
+export { normalizeApiError, getMessage }

--- a/src/errors/notify.ts
+++ b/src/errors/notify.ts
@@ -13,11 +13,11 @@ export interface NotifyOptions {
 }
 
 function resolveMessage(options: NotifyOptions): string {
-  if (options.fallback) {
-    return options.fallback
-  }
   if (options.key) {
     return getMessage(options.key, options.params ?? {})
+  }
+  if (options.fallback) {
+    return options.fallback
   }
   return getMessage('global.unexpected')
 }

--- a/src/hooks/useEmailNotifications.ts
+++ b/src/hooks/useEmailNotifications.ts
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { eventsApi, registrationsApi } from '@/services/api'
-import { toast } from 'sonner'
+import { notify } from '@/errors/notify'
+import { getApiErrorMessage } from '@/errors/getApiErrorMessage'
+import { getMessage } from '@/errors/catalog'
 
 interface EmailNotification {
   type: 'event_details_changed' | 'event_canceled' | 'payment_confirmed' | 'category_changed'
@@ -16,7 +18,6 @@ interface EmailNotification {
 }
 
 interface UseEmailNotificationsReturn {
-  // Dialog state
   dialogOpen: boolean
   dialogProps: {
     title: string
@@ -26,7 +27,6 @@ interface UseEmailNotificationsReturn {
     type: EmailNotification['type'] | undefined
     isLoading: boolean
   }
-  // Actions
   handleEmailNotification: (
     notification: EmailNotification | null,
     eventSlug?: string,
@@ -34,6 +34,25 @@ interface UseEmailNotificationsReturn {
   ) => void
   handleConfirmSend: () => void
   closeDialog: () => void
+}
+
+function showEmailSendSuccess(result: {
+  message: string
+  sent_count?: number
+  failed_count?: number
+}) {
+  const hasRecipientStats = result.sent_count !== undefined
+  notify.success({
+    key: 'email.sendSuccess',
+    params: { message: result.message },
+    fallback: result.message,
+    description: hasRecipientStats
+      ? getMessage('email.sendSuccessDescription', {
+          sentCount: result.sent_count ?? 0,
+          failedCount: result.failed_count ?? 0,
+        })
+      : undefined,
+  })
 }
 
 export function useEmailNotifications(): UseEmailNotificationsReturn {
@@ -70,33 +89,25 @@ export function useEmailNotifications(): UseEmailNotificationsReturn {
         case 'event_details_changed':
           if (!eventSlug) throw new Error('Event slug is required')
           result = await eventsApi.sendEventUpdateEmails(eventSlug)
-          toast.success(result.message, {
-            description: `Sent to ${result.sent_count} recipients${
-              result.failed_count ? ` (${result.failed_count} failed)` : ''
-            }`,
-          })
+          showEmailSendSuccess(result)
           break
 
         case 'event_canceled':
           if (!eventSlug) throw new Error('Event slug is required')
           result = await eventsApi.sendCancellationEmails(eventSlug)
-          toast.success(result.message, {
-            description: `Sent to ${result.sent_count} recipients${
-              result.failed_count ? ` (${result.failed_count} failed)` : ''
-            }`,
-          })
+          showEmailSendSuccess(result)
           break
 
         case 'payment_confirmed':
           if (!registrationId) throw new Error('Registration ID is required')
           result = await registrationsApi.sendPaymentConfirmation(registrationId)
-          toast.success(result.message)
+          showEmailSendSuccess(result)
           break
 
         case 'category_changed':
           if (!registrationId) throw new Error('Registration ID is required')
           result = await registrationsApi.sendCategoryChangeNotification(registrationId)
-          toast.success(result.message)
+          showEmailSendSuccess(result)
           break
 
         default:
@@ -105,10 +116,11 @@ export function useEmailNotifications(): UseEmailNotificationsReturn {
 
       setDialogOpen(false)
       setCurrentNotification(null)
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to send email notification:', error)
-      toast.error('Failed to send email', {
-        description: error.message || 'An unexpected error occurred',
+      notify.error({
+        key: 'email.sendFailed',
+        fallback: getApiErrorMessage(error) || getMessage('email.sendFailedDescription'),
       })
     } finally {
       setIsLoading(false)

--- a/src/index.css
+++ b/src/index.css
@@ -989,3 +989,56 @@
 .email-preview-content li {
   color: hsl(var(--foreground) / 0.9);
 }
+
+/* Sonner — align toast colors with Voxxy theme tokens (Toaster in App.tsx) */
+[data-sonner-toaster][data-sonner-theme='light'] {
+  --normal-bg: hsl(var(--card));
+  --normal-border: hsl(var(--border));
+  --normal-text: hsl(var(--card-foreground));
+  --normal-bg-hover: hsl(var(--muted));
+  --normal-border-hover: hsl(var(--border));
+
+  --success-bg: hsl(var(--primary) / 0.12);
+  --success-border: hsl(var(--primary) / 0.35);
+  --success-text: hsl(var(--primary));
+
+  --info-bg: hsl(var(--chart-2) / 0.12);
+  --info-border: hsl(var(--chart-2) / 0.35);
+  --info-text: hsl(var(--chart-2));
+
+  --warning-bg: hsl(var(--chart-3) / 0.14);
+  --warning-border: hsl(var(--chart-3) / 0.4);
+  --warning-text: hsl(31 92% 38%);
+
+  --error-bg: hsl(var(--destructive) / 0.12);
+  --error-border: hsl(var(--destructive) / 0.4);
+  --error-text: hsl(var(--destructive));
+}
+
+[data-sonner-toaster][data-sonner-theme='dark'] {
+  --normal-bg: hsl(var(--card));
+  --normal-border: hsl(var(--border));
+  --normal-text: hsl(var(--card-foreground));
+  --normal-bg-hover: hsl(var(--muted));
+  --normal-border-hover: hsl(var(--border));
+
+  --success-bg: hsl(var(--primary) / 0.2);
+  --success-border: hsl(var(--primary) / 0.45);
+  --success-text: hsl(var(--primary));
+
+  --info-bg: hsl(var(--chart-2) / 0.2);
+  --info-border: hsl(var(--chart-2) / 0.45);
+  --info-text: hsl(var(--chart-2));
+
+  --warning-bg: hsl(var(--chart-3) / 0.18);
+  --warning-border: hsl(var(--chart-3) / 0.45);
+  --warning-text: hsl(var(--chart-3));
+
+  --error-bg: hsl(var(--destructive) / 0.22);
+  --error-border: hsl(var(--destructive) / 0.55);
+  --error-text: hsl(var(--destructive-foreground));
+}
+
+[data-sonner-toast][data-styled='true'] [data-description] {
+  color: hsl(var(--muted-foreground)) !important;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import App from './App.tsx'
 import { ThemeProvider } from '@/contexts/ThemeContext'
 import { validateEnv } from './utils/validateEnv'
 import { initializeErrorMonitoring } from './utils/errorMonitoring'
+import ErrorBoundary from '@/components/ErrorBoundary'
 
 // Validate environment variables before app starts
 validateEnv()
@@ -16,7 +17,9 @@ initializeErrorMonitoring()
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </ThemeProvider>
   </StrictMode>,
 )

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -9,6 +9,9 @@ import { Separator } from '@/components/ui/separator'
 import { ArrowLeft, Sparkles, Eye, EyeOff, Loader2, Mail, Lock, AlertCircle } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { validateEmail } from '@/utils/validation'
+import { ApiError } from '@/services/api'
+import { getApiErrorMessage } from '@/errors/getApiErrorMessage'
+import { getMessage } from '@/errors/catalog'
 import { usePageTracking } from '@/hooks/usePageTracking'
 import { useForceTheme } from '@/hooks/useForceTheme'
 
@@ -26,7 +29,7 @@ interface FormErrors {
 export default function LoginPage() {
   useForceTheme('dark')
   const navigate = useNavigate()
-  const { signIn, loading, error, clearError } = useAuth()
+  const { signIn, refreshUserProfile, loading, error, clearError } = useAuth()
   const [formData, setFormData] = useState<FormData>({
     email: '',
     password: '',
@@ -100,10 +103,10 @@ export default function LoginPage() {
     } catch (err) {
       console.error('Login error:', err)
 
-      let errorMessage = 'Invalid email or password. Please try again.'
-      if (err instanceof Error) {
-        errorMessage = err.message
-      }
+      const errorMessage =
+        err instanceof ApiError
+          ? getApiErrorMessage(err, 'auth')
+          : getMessage('auth.signInFailed')
 
       setErrors((prev) => ({ ...prev, submit: errorMessage }))
       window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -119,17 +122,12 @@ export default function LoginPage() {
 
     try {
       const { authApi } = await import('@/services/api')
-      // devLogin() calls POST /dev_login which returns a token and saves it
-      const data = await authApi.devLogin()
-
-      // Token is already saved by devLogin(). Now use the regular login
-      // with the seed password to go through the normal auth flow.
-      await signIn({ email: data.email, password: 'password123' })
+      // devLogin() returns a JWT and saves it; load profile without re-posting login
+      await authApi.devLogin()
+      await refreshUserProfile()
     } catch (err) {
       console.error('Dev login error:', err)
-      setErrors({
-        submit: 'Dev login failed. Is the Rails server running on port 3001 with seed data?',
-      })
+      setErrors({ submit: getMessage('auth.devLoginFailed') })
     } finally {
       setIsSubmitting(false)
     }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3670,3 +3670,4 @@ export const emailTestsApi = {
 }
 
 export { ApiError }
+export { getApiErrorMessage } from '@/errors/getApiErrorMessage'


### PR DESCRIPTION
## Summary
- Add `src/errors/` infrastructure: message catalog, `normalizeApiError`, `getApiErrorMessage`, and `notify` (Sonner toasts)
- Migrate pilot surfaces off `alert()` / ad-hoc messages: Network page, auth context + login, email notifications, and ErrorBoundary copy
- Mount root `ErrorBoundary`, theme Sonner via CSS variables, and add `docs/guides/ERROR_NOTIFICATIONS.md`

## Test plan
- [ ] Log in with invalid credentials — inline auth error uses catalog message
- [ ] Dev Login button works against local Rails seed data
- [ ] Network page: bulk delete/update, category save/delete, list save — success/error toasts (no `alert()`)
- [ ] Send email notification from event flow — success toast with recipient counts; failure shows normalized error
- [ ] Trigger a React render error in dev — ErrorBoundary shows catalog title/description
- [ ] Verify toasts respect light/dark theme


Made with [Cursor](https://cursor.com)