### PR TITLE
fix(applicants): prevent Command Center crash when searching applicants with null fields

### DIFF
--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -697,11 +697,15 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
     // Search filter
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase()
+      // Guard every field: business_name (and others) can be null now that
+      // business name was removed from the application form. Calling
+      // .toLowerCase() on a null field throws during render and trips the
+      // ErrorBoundary (see Sentry REACT-FRONT-END-8).
       const matches =
-        applicant.business_name.toLowerCase().includes(query) ||
+        applicant.business_name?.toLowerCase().includes(query) ||
         applicant.contact_name?.toLowerCase().includes(query) ||
-        applicant.email.toLowerCase().includes(query) ||
-        applicant.vendor_category.toLowerCase().includes(query)
+        applicant.email?.toLowerCase().includes(query) ||
+        applicant.vendor_category?.toLowerCase().includes(query)
       if (!matches) return false
     }
 


### PR DESCRIPTION
## Summary
- Fixes the Command Center **Applicants** search crash where typing a single character blanked the screen with the "Oops, something's wrong" `ErrorBoundary` page.
- Root cause: `business_name` is now `null` for applicants created after business name was removed from the application form. The search filter called `.toLowerCase()` on unguarded fields, throwing a `TypeError` during render. Optional-chained every searchable field (`business_name`, `email`, `vendor_category`; `contact_name` was already guarded).
- Confirmed with production **Sentry** runtime evidence (`REACT-FRONT-END-8`): `TypeError: Cannot read properties of null (reading 'toLowerCase')`, `handled: no`, triggered from the applicants search `input`, stack ending in `Array.filter`.

Did not reproduce locally because local data still has `business_name` populated; only deployments (dev + production/main) have the null rows.

## Test plan
- [ ] Deploy to dev; open a Command Center event → Applicants tab.
- [ ] Type characters (including `.`) in the search bar → no crash; results filter correctly.
- [ ] Rows with no business name simply don't match on that field.
- [ ] No new `REACT-FRONT-END-8` events appear in Sentry after deploy.

Fixes REACT-FRONT-END-8

Made with [Cursor](https://cursor.com)