### PR TITLE
feat(network): bulk edit redesign — category/tags/location (E3)

### DIFF
--- a/src/components/producer/Network/BulkEditModal.tsx
+++ b/src/components/producer/Network/BulkEditModal.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react'
-import { X, Tag, List, Trash2 } from 'lucide-react'
+import { X, Tag, MapPin, Hash, Plus, Trash2 } from 'lucide-react'
 import type { Category } from '@/types/category'
-import type { ContactList } from '@/services/api'
 import {
   BULK_EDIT_EMPTY_HINT,
   BULK_EDIT_LABEL,
-  BULK_EDIT_NO_LISTS_HINT,
-  BULK_EDIT_FILTER_LIST_HINT,
-  BULK_EDIT_MANUAL_LIST_HINT,
+  BULK_EDIT_TAGS_HINT,
+  BULK_EDIT_LOCATION_HINT,
 } from './copy'
 
 interface BulkEditModalProps {
@@ -15,9 +13,10 @@ interface BulkEditModalProps {
   onClose: () => void
   selectedCount: number
   categories: Category[]
-  lists: ContactList[]
-  onAddCategory: (categoryNames: string[]) => void
-  onAddToList: (listId: number) => void
+  availableTags?: string[]
+  onApplyCategory: (categoryNames: string[]) => void
+  onApplyTags: (tags: string[]) => void
+  onApplyLocation: (location: string) => void
   onDelete: () => void
   onClearSelection: () => void
   loading?: boolean
@@ -28,35 +27,58 @@ export default function BulkEditModal({
   onClose,
   selectedCount,
   categories,
-  lists,
-  onAddCategory,
-  onAddToList,
+  availableTags = [],
+  onApplyCategory,
+  onApplyTags,
+  onApplyLocation,
   onDelete,
   onClearSelection,
   loading = false,
 }: BulkEditModalProps) {
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null)
-  const [selectedListId, setSelectedListId] = useState<number | null>(null)
+  const [tags, setTags] = useState<string[]>([])
+  const [tagInput, setTagInput] = useState('')
+  const [location, setLocation] = useState('')
 
-  const selectedList = lists.find((l) => l.id === selectedListId)
-
-  const handleAddCategory = () => {
+  const handleApplyCategory = () => {
     if (!selectedCategoryId) return
     const category = categories.find((c) => c.id === selectedCategoryId)
     if (!category) return
-    onAddCategory([category.name])
+    onApplyCategory([category.name])
     setSelectedCategoryId(null)
   }
 
-  const handleAddToList = () => {
-    if (!selectedListId) return
-    onAddToList(selectedListId)
-    setSelectedListId(null)
+  const handleAddTag = (raw?: string) => {
+    const tag = (raw ?? tagInput).trim().toLowerCase()
+    if (tag && !tags.includes(tag)) {
+      setTags((prev) => [...prev, tag])
+    }
+    setTagInput('')
+  }
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags((prev) => prev.filter((t) => t !== tagToRemove))
+  }
+
+  const handleApplyTags = () => {
+    if (tags.length === 0) return
+    onApplyTags(tags)
+    setTags([])
+  }
+
+  const handleApplyLocation = () => {
+    const value = location.trim()
+    if (!value) return
+    onApplyLocation(value)
+    setLocation('')
   }
 
   if (!open) return null
 
   const hasSelection = selectedCount > 0
+  const tagSuggestions = availableTags
+    .filter((t) => t.toLowerCase().includes(tagInput.toLowerCase()) && !tags.includes(t))
+    .slice(0, 5)
 
   return (
     <div
@@ -89,6 +111,7 @@ export default function BulkEditModal({
             <p className="text-sm text-foreground/70">{BULK_EDIT_EMPTY_HINT}</p>
           ) : (
             <>
+              {/* Category */}
               <div className="space-y-2">
                 <label className="flex items-center gap-1.5 text-xs font-medium text-foreground/80">
                   <Tag className="w-3.5 h-3.5" />
@@ -111,57 +134,123 @@ export default function BulkEditModal({
                     ))}
                   </select>
                   <button
-                    onClick={handleAddCategory}
+                    onClick={handleApplyCategory}
                     disabled={!selectedCategoryId || loading}
                     className="px-4 py-2 voxxy-btn-solid disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium rounded-lg transition-colors whitespace-nowrap"
                   >
-                    {loading ? 'Adding...' : 'Add'}
+                    {loading ? 'Applying...' : 'Apply'}
                   </button>
                 </div>
               </div>
 
+              {/* Tags */}
               <div className="space-y-2">
                 <label className="flex items-center gap-1.5 text-xs font-medium text-foreground/80">
-                  <List className="w-3.5 h-3.5" />
-                  List
+                  <Hash className="w-3.5 h-3.5" />
+                  Tags
                 </label>
-                {lists.length === 0 ? (
-                  <p className="text-xs text-foreground/50">{BULK_EDIT_NO_LISTS_HINT}</p>
-                ) : (
-                  <>
-                    <div className="flex items-center gap-2">
-                      <select
-                        value={selectedListId || ''}
-                        onChange={(e) =>
-                          setSelectedListId(e.target.value ? Number(e.target.value) : null)
+                <div className="relative">
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={tagInput}
+                      onChange={(e) => setTagInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          handleAddTag()
                         }
-                        className="flex-1 px-3 py-2 bg-background/10 border border-border rounded-lg text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer"
-                        disabled={loading}
-                      >
-                        <option value="">Select list...</option>
-                        {lists.map((list) => (
-                          <option key={list.id} value={list.id}>
-                            {list.name}
-                          </option>
-                        ))}
-                      </select>
-                      <button
-                        onClick={handleAddToList}
-                        disabled={!selectedListId || loading}
-                        className="px-4 py-2 voxxy-btn-solid disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium rounded-lg transition-colors whitespace-nowrap"
-                      >
-                        {loading ? 'Adding...' : 'Add'}
-                      </button>
+                      }}
+                      placeholder="Add tag..."
+                      disabled={loading}
+                      className="flex-1 px-3 py-2 bg-background/10 border border-border rounded-lg text-sm text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary"
+                    />
+                    <button
+                      onClick={() => handleAddTag()}
+                      disabled={!tagInput.trim() || loading}
+                      className="flex items-center gap-1 px-3 py-2 bg-primary/20 hover:bg-primary/30 text-violet-950 dark:text-primary disabled:opacity-50 disabled:cursor-not-allowed text-sm rounded-lg transition-colors border border-primary/30 whitespace-nowrap"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                      Add
+                    </button>
+                  </div>
+                  {tagInput.length > 0 && tagSuggestions.length > 0 && (
+                    <div className="absolute left-0 right-16 z-10 mt-1 bg-muted border border-border rounded-lg shadow-xl max-h-32 overflow-y-auto">
+                      {tagSuggestions.map((tag) => (
+                        <button
+                          key={tag}
+                          type="button"
+                          onClick={() => handleAddTag(tag)}
+                          className="w-full text-left px-3 py-2 text-sm text-foreground/80 hover:bg-background/10 transition-colors"
+                        >
+                          #{tag}
+                        </button>
+                      ))}
                     </div>
-                    {selectedList && (
-                      <p className="text-[11px] text-foreground/50">
-                        {selectedList.list_type === 'manual'
-                          ? BULK_EDIT_MANUAL_LIST_HINT
-                          : BULK_EDIT_FILTER_LIST_HINT}
-                      </p>
-                    )}
-                  </>
+                  )}
+                </div>
+                {tags.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="px-2.5 py-0.5 bg-primary/20 text-violet-950 dark:text-primary rounded-full text-xs flex items-center gap-1.5 border border-primary/30"
+                      >
+                        #{tag}
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveTag(tag)}
+                          className="hover:opacity-80"
+                          aria-label={`Remove ${tag}`}
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
                 )}
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-[11px] text-foreground/50">{BULK_EDIT_TAGS_HINT}</p>
+                  <button
+                    onClick={handleApplyTags}
+                    disabled={tags.length === 0 || loading}
+                    className="px-4 py-1.5 voxxy-btn-solid disabled:opacity-50 disabled:cursor-not-allowed text-xs font-medium rounded-lg transition-colors whitespace-nowrap"
+                  >
+                    {loading ? 'Applying...' : 'Apply tags'}
+                  </button>
+                </div>
+              </div>
+
+              {/* Location */}
+              <div className="space-y-2">
+                <label className="flex items-center gap-1.5 text-xs font-medium text-foreground/80">
+                  <MapPin className="w-3.5 h-3.5" />
+                  Location
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={location}
+                    onChange={(e) => setLocation(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        handleApplyLocation()
+                      }
+                    }}
+                    placeholder="City, State, ZIP"
+                    disabled={loading}
+                    className="flex-1 px-3 py-2 bg-background/10 border border-border rounded-lg text-sm text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                  <button
+                    onClick={handleApplyLocation}
+                    disabled={!location.trim() || loading}
+                    className="px-4 py-2 voxxy-btn-solid disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium rounded-lg transition-colors whitespace-nowrap"
+                  >
+                    {loading ? 'Applying...' : 'Apply'}
+                  </button>
+                </div>
+                <p className="text-[11px] text-foreground/50">{BULK_EDIT_LOCATION_HINT}</p>
               </div>
 
               <div className="flex items-center justify-between gap-3 pt-2 border-t border-border">

--- a/src/components/producer/Network/NetworkPage.tsx
+++ b/src/components/producer/Network/NetworkPage.tsx
@@ -24,7 +24,6 @@ import {
   categoriesApi,
   eventsApi,
   VendorContact,
-  ContactList,
 } from '@/services/api'
 import type { Category, CategoryFeePreference } from '@/types/category'
 import { PAYMENT_PRICE_TYPES } from '@/components/producer/CreateEventWizard/types'
@@ -257,8 +256,6 @@ export default function NetworkPage({
   // Post-import session + saved lists (for one-click list creation)
   const [importSession, setImportSession] = useState<ImportSession | null>(null)
   const [viewingImportBatch, setViewingImportBatch] = useState(false)
-  const [savedLists, setSavedLists] = useState<ContactList[]>([])
-
   // Derive filter arrays from activeFilters
   const locationFilters = activeFilters.find((f) => f.fieldKey === 'location')?.values || []
   const categoryFilters = activeFilters.find((f) => f.fieldKey === 'category')?.values || []
@@ -312,28 +309,12 @@ export default function NetworkPage({
     }
   }
 
-  const refreshSavedLists = async () => {
-    try {
-      const response = await contactListsApi.getAll(organizationId)
-      setSavedLists(response.contact_lists || [])
-    } catch (err) {
-      console.error('Failed to load saved lists:', err)
-    }
-  }
-
   // Fetch filter options on mount
   useEffect(() => {
     refreshFilterOptions()
-    refreshSavedLists()
     const stored = loadImportSession(organizationId)
     if (stored) setImportSession(stored)
   }, [organizationId])
-
-  useEffect(() => {
-    if (showBulkEditModal) {
-      refreshSavedLists()
-    }
-  }, [showBulkEditModal, organizationId])
 
   const handleImportSuccess = async (session: ImportSession) => {
     saveImportSession(organizationId, session)
@@ -626,86 +607,54 @@ export default function NetworkPage({
     }
   }
 
-  const handleBulkAddToList = async (listId: number) => {
-    if (selectedContacts.length === 0) return
-
-    const list = savedLists.find((l) => l.id === listId)
-    if (!list) return
+  const handleBulkTags = async (tags: string[]) => {
+    if (selectedContacts.length === 0 || tags.length === 0) return
 
     try {
       setBulkUpdateLoading(true)
-
-      if (list.list_type === 'manual') {
-        const existingIds = list.contact_ids || []
-        const mergedIds = [...new Set([...existingIds, ...selectedContacts])]
-        await contactListsApi.update(listId, { contact_ids: mergedIds })
-        await refreshSavedLists()
-        notify.success({
-          key: 'network.bulkAddToListSuccess',
-          params: { count: selectedContacts.length, listName: list.name },
-        })
-      } else {
-        const filters = list.filters || {}
-        const filterTags = filters.tags || []
-        const filterCategories = filters.categories || []
-        const filterLocations = filters.locations || []
-
-        if (
-          filterTags.length === 0 &&
-          filterCategories.length === 0 &&
-          filterLocations.length === 0
-        ) {
-          notify.error({
-            key: 'network.bulkApplyListNoFilters',
-            params: { listName: list.name },
-          })
-          return
-        }
-
-        if (filterCategories.length > 0) {
-          await vendorContactsApi.bulkUpdate(organizationId, selectedContacts, {
-            categories: filterCategories,
-            category_mode: 'append',
-          })
-        }
-
-        if (filterTags.length > 0) {
-          await Promise.all(
-            selectedContacts.map((contactId) =>
-              Promise.all(filterTags.map((tag) => vendorContactsApi.addTag(contactId, tag)))
-            )
-          )
-        }
-
-        if (filterLocations.length === 1) {
-          await vendorContactsApi.bulkUpdate(organizationId, selectedContacts, {
-            location: filterLocations[0],
-          })
-        }
-
-        const appliedParts = [
-          filterCategories.length > 0 ? 'categories' : null,
-          filterTags.length > 0 ? 'tags' : null,
-          filterLocations.length === 1 ? 'location' : null,
-        ].filter(Boolean)
-
-        notify.success({
-          key: 'network.bulkApplyListSuccess',
-          params: {
-            applied: appliedParts.join(', '),
-            listName: list.name,
-            count: selectedContacts.length,
-          },
-        })
-
-        await refreshFilterOptions()
-        await fetchContacts(currentPage)
-      }
-
+      // Append tags without clobbering existing ones (bulkUpdate replaces the tag set).
+      await Promise.all(
+        selectedContacts.map((contactId) =>
+          Promise.all(tags.map((tag) => vendorContactsApi.addTag(contactId, tag))),
+        ),
+      )
+      notify.success({
+        key: 'network.bulkUpdateSuccess',
+        params: { count: selectedContacts.length },
+        fallback: `Added ${tags.length} tag${tags.length === 1 ? '' : 's'} to ${selectedContacts.length} contact${selectedContacts.length === 1 ? '' : 's'}.`,
+      })
+      await refreshFilterOptions()
+      await fetchContacts(currentPage)
       setSelectedContacts([])
     } catch (error: unknown) {
       notify.error({
-        key: 'network.bulkAddToListFailed',
+        key: 'network.bulkUpdateFailed',
+        fallback: getApiErrorMessage(error),
+      })
+    } finally {
+      setBulkUpdateLoading(false)
+    }
+  }
+
+  const handleBulkLocation = async (location: string) => {
+    if (selectedContacts.length === 0 || !location.trim()) return
+
+    try {
+      setBulkUpdateLoading(true)
+      const result = await vendorContactsApi.bulkUpdate(organizationId, selectedContacts, {
+        location: location.trim(),
+      })
+      notify.success({
+        key: 'network.bulkUpdateSuccess',
+        params: { count: result.updated_count },
+        fallback: result.message,
+      })
+      await refreshFilterOptions()
+      await fetchContacts(currentPage)
+      setSelectedContacts([])
+    } catch (error: unknown) {
+      notify.error({
+        key: 'network.bulkUpdateFailed',
         fallback: getApiErrorMessage(error),
       })
     } finally {
@@ -1113,178 +1062,178 @@ export default function NetworkPage({
 
             {/* Unified filter bar */}
             <div className="flex items-center gap-2 flex-wrap">
-                {/* 1. Category */}
-                {(() => {
-                  const field = filterFieldConfigs.find((f) => f.key === 'category')
-                  if (!field) return null
-                  const selectedValues =
-                    activeFilters.find((f) => f.fieldKey === 'category')?.values || []
-                  return (
-                    <FilterDropdownButton
-                      field={field}
-                      selectedValues={selectedValues}
-                      onChange={(values) => {
-                        const existing = activeFilters.find((f) => f.fieldKey === 'category')
-                        if (existing) {
-                          if (values.length === 0)
-                            setActiveFilters(activeFilters.filter((f) => f.fieldKey !== 'category'))
-                          else
-                            setActiveFilters(
-                              activeFilters.map((f) =>
-                                f.fieldKey === 'category' ? { ...f, values } : f,
-                              ),
-                            )
-                        } else if (values.length > 0) {
-                          setActiveFilters([...activeFilters, { fieldKey: 'category', values }])
-                        }
-                      }}
-                    />
-                  )
-                })()}
+              {/* 1. Category */}
+              {(() => {
+                const field = filterFieldConfigs.find((f) => f.key === 'category')
+                if (!field) return null
+                const selectedValues =
+                  activeFilters.find((f) => f.fieldKey === 'category')?.values || []
+                return (
+                  <FilterDropdownButton
+                    field={field}
+                    selectedValues={selectedValues}
+                    onChange={(values) => {
+                      const existing = activeFilters.find((f) => f.fieldKey === 'category')
+                      if (existing) {
+                        if (values.length === 0)
+                          setActiveFilters(activeFilters.filter((f) => f.fieldKey !== 'category'))
+                        else
+                          setActiveFilters(
+                            activeFilters.map((f) =>
+                              f.fieldKey === 'category' ? { ...f, values } : f,
+                            ),
+                          )
+                      } else if (values.length > 0) {
+                        setActiveFilters([...activeFilters, { fieldKey: 'category', values }])
+                      }
+                    }}
+                  />
+                )
+              })()}
 
-                {/* 2. Location */}
-                {(() => {
-                  const field = filterFieldConfigs.find((f) => f.key === 'location')
-                  if (!field) return null
-                  const selectedValues =
-                    activeFilters.find((f) => f.fieldKey === 'location')?.values || []
-                  return (
-                    <FilterDropdownButton
-                      field={field}
-                      selectedValues={selectedValues}
-                      onChange={(values) => {
-                        const existing = activeFilters.find((f) => f.fieldKey === 'location')
-                        if (existing) {
-                          if (values.length === 0)
-                            setActiveFilters(activeFilters.filter((f) => f.fieldKey !== 'location'))
-                          else
-                            setActiveFilters(
-                              activeFilters.map((f) =>
-                                f.fieldKey === 'location' ? { ...f, values } : f,
-                              ),
-                            )
-                        } else if (values.length > 0) {
-                          setActiveFilters([...activeFilters, { fieldKey: 'location', values }])
-                        }
-                      }}
-                    />
-                  )
-                })()}
+              {/* 2. Location */}
+              {(() => {
+                const field = filterFieldConfigs.find((f) => f.key === 'location')
+                if (!field) return null
+                const selectedValues =
+                  activeFilters.find((f) => f.fieldKey === 'location')?.values || []
+                return (
+                  <FilterDropdownButton
+                    field={field}
+                    selectedValues={selectedValues}
+                    onChange={(values) => {
+                      const existing = activeFilters.find((f) => f.fieldKey === 'location')
+                      if (existing) {
+                        if (values.length === 0)
+                          setActiveFilters(activeFilters.filter((f) => f.fieldKey !== 'location'))
+                        else
+                          setActiveFilters(
+                            activeFilters.map((f) =>
+                              f.fieldKey === 'location' ? { ...f, values } : f,
+                            ),
+                          )
+                      } else if (values.length > 0) {
+                        setActiveFilters([...activeFilters, { fieldKey: 'location', values }])
+                      }
+                    }}
+                  />
+                )
+              })()}
 
-                {/* 3. Tags */}
-                {(() => {
-                  const field = filterFieldConfigs.find((f) => f.key === 'tags')
-                  if (!field) return null
-                  const selectedValues =
-                    activeFilters.find((f) => f.fieldKey === 'tags')?.values || []
-                  return (
-                    <FilterDropdownButton
-                      field={field}
-                      selectedValues={selectedValues}
-                      onChange={(values) => {
-                        const existing = activeFilters.find((f) => f.fieldKey === 'tags')
-                        if (existing) {
-                          if (values.length === 0)
-                            setActiveFilters(activeFilters.filter((f) => f.fieldKey !== 'tags'))
-                          else
-                            setActiveFilters(
-                              activeFilters.map((f) =>
-                                f.fieldKey === 'tags' ? { ...f, values } : f,
-                              ),
-                            )
-                        } else if (values.length > 0) {
-                          setActiveFilters([...activeFilters, { fieldKey: 'tags', values }])
-                        }
-                      }}
-                    />
-                  )
-                })()}
+              {/* 3. Tags */}
+              {(() => {
+                const field = filterFieldConfigs.find((f) => f.key === 'tags')
+                if (!field) return null
+                const selectedValues =
+                  activeFilters.find((f) => f.fieldKey === 'tags')?.values || []
+                return (
+                  <FilterDropdownButton
+                    field={field}
+                    selectedValues={selectedValues}
+                    onChange={(values) => {
+                      const existing = activeFilters.find((f) => f.fieldKey === 'tags')
+                      if (existing) {
+                        if (values.length === 0)
+                          setActiveFilters(activeFilters.filter((f) => f.fieldKey !== 'tags'))
+                        else
+                          setActiveFilters(
+                            activeFilters.map((f) =>
+                              f.fieldKey === 'tags' ? { ...f, values } : f,
+                            ),
+                          )
+                      } else if (values.length > 0) {
+                        setActiveFilters([...activeFilters, { fieldKey: 'tags', values }])
+                      }
+                    }}
+                  />
+                )
+              })()}
 
-                {filterOptions.tags.length === 0 && (
-                  <p className="text-[10px] text-foreground/50 w-full">{TAGS_EMPTY_HINT}</p>
+              {filterOptions.tags.length === 0 && (
+                <p className="text-[10px] text-foreground/50 w-full">{TAGS_EMPTY_HINT}</p>
+              )}
+
+              <button
+                type="button"
+                onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
+                className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-all ${
+                  hasAdvancedFilters
+                    ? 'bg-primary/20 text-violet-950 border border-primary/40 dark:text-primary dark:border-primary/30'
+                    : 'bg-card/80 text-foreground dark:bg-card/50 dark:text-foreground/80 border border-border hover:bg-accent/60 dark:border-white/10'
+                }`}
+              >
+                More filters
+                {showAdvancedFilters ? (
+                  <ChevronUp className="w-3 h-3" />
+                ) : (
+                  <ChevronDown className="w-3 h-3" />
                 )}
+              </button>
 
-                <button
-                  type="button"
-                  onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
-                  className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium transition-all ${
-                    hasAdvancedFilters
-                      ? 'bg-primary/20 text-violet-950 border border-primary/40 dark:text-primary dark:border-primary/30'
-                      : 'bg-card/80 text-foreground dark:bg-card/50 dark:text-foreground/80 border border-border hover:bg-accent/60 dark:border-white/10'
-                  }`}
-                >
-                  More filters
-                  {showAdvancedFilters ? (
-                    <ChevronUp className="w-3 h-3" />
-                  ) : (
-                    <ChevronDown className="w-3 h-3" />
-                  )}
-                </button>
-
-                {showAdvancedFilters && (
-                  <>
-                {/* Updated */}
-                <select
-                  value={updatedAtRange}
-                  onChange={(e) => setUpdatedAtRange(e.target.value as typeof updatedAtRange)}
-                  className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-all cursor-pointer ${
-                    updatedAtRange !== 'all'
-                      ? 'bg-primary/20 text-violet-950 border border-primary/40 dark:text-primary dark:border-primary/30'
-                      : 'bg-card/80 text-foreground dark:bg-card/50 dark:text-foreground/80 border border-border dark:border-white/10'
-                  }`}
-                >
-                  <option value="all">Updated</option>
-                  <option value="24h">Last 24h</option>
-                  <option value="48h">Last 48h</option>
-                  <option value="7d">Last 7 days</option>
-                  <option value="30d">Last 30 days</option>
-                </select>
-
-                {/* Shows Attended */}
-                <select
-                  value={eventFilter}
-                  onChange={(e) => {
-                    setEventFilter(e.target.value)
-                    if (e.target.value === 'all' || e.target.value === 'none')
-                      setEventStatusFilter('all')
-                  }}
-                  className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-all cursor-pointer max-w-[180px] truncate ${
-                    eventFilter !== 'all'
-                      ? 'bg-primary/20 text-violet-950 border border-primary/40 dark:text-primary dark:border-primary/30'
-                      : 'bg-card/80 text-foreground dark:bg-card/50 dark:text-foreground/80 border border-border dark:border-white/10'
-                  }`}
-                >
-                  <option value="all">Shows Attended</option>
-                  <option value="none">No Shows</option>
-                  {orgEvents.map((ev) => (
-                    <option key={ev.id} value={String(ev.id)}>
-                      {ev.title}
-                    </option>
-                  ))}
-                </select>
-
-                {/* App Status (contextual — shows when a specific show is selected) */}
-                {eventFilter !== 'all' && eventFilter !== 'none' && (
+              {showAdvancedFilters && (
+                <>
+                  {/* Updated */}
                   <select
-                    value={eventStatusFilter}
-                    onChange={(e) => setEventStatusFilter(e.target.value)}
+                    value={updatedAtRange}
+                    onChange={(e) => setUpdatedAtRange(e.target.value as typeof updatedAtRange)}
                     className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-all cursor-pointer ${
-                      eventStatusFilter !== 'all'
+                      updatedAtRange !== 'all'
                         ? 'bg-primary/20 text-violet-950 border border-primary/40 dark:text-primary dark:border-primary/30'
                         : 'bg-card/80 text-foreground dark:bg-card/50 dark:text-foreground/80 border border-border dark:border-white/10'
                     }`}
                   >
-                    <option value="all">App Status</option>
-                    <option value="approved">Approved</option>
-                    <option value="pending">Pending</option>
-                    <option value="confirmed">Confirmed</option>
-                    <option value="rejected">Rejected</option>
-                    <option value="waitlist">Waitlist</option>
-                    <option value="cancelled">Cancelled</option>
+                    <option value="all">Updated</option>
+                    <option value="24h">Last 24h</option>
+                    <option value="48h">Last 48h</option>
+                    <option value="7d">Last 7 days</option>
+                    <option value="30d">Last 30 days</option>
                   </select>
-                )}
-                  </>
-                )}
+
+                  {/* Shows Attended */}
+                  <select
+                    value={eventFilter}
+                    onChange={(e) => {
+                      setEventFilter(e.target.value)
+                      if (e.target.value === 'all' || e.target.value === 'none')
+                        setEventStatusFilter('all')
+                    }}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-all cursor-pointer max-w-[180px] truncate ${
+                      eventFilter !== 'all'
+                        ? 'bg-primary/20 text-violet-950 border border-primary/40 dark:text-primary dark:border-primary/30'
+                        : 'bg-card/80 text-foreground dark:bg-card/50 dark:text-foreground/80 border border-border dark:border-white/10'
+                    }`}
+                  >
+                    <option value="all">Shows Attended</option>
+                    <option value="none">No Shows</option>
+                    {orgEvents.map((ev) => (
+                      <option key={ev.id} value={String(ev.id)}>
+                        {ev.title}
+                      </option>
+                    ))}
+                  </select>
+
+                  {/* App Status (contextual — shows when a specific show is selected) */}
+                  {eventFilter !== 'all' && eventFilter !== 'none' && (
+                    <select
+                      value={eventStatusFilter}
+                      onChange={(e) => setEventStatusFilter(e.target.value)}
+                      className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-all cursor-pointer ${
+                        eventStatusFilter !== 'all'
+                          ? 'bg-primary/20 text-violet-950 border border-primary/40 dark:text-primary dark:border-primary/30'
+                          : 'bg-card/80 text-foreground dark:bg-card/50 dark:text-foreground/80 border border-border dark:border-white/10'
+                      }`}
+                    >
+                      <option value="all">App Status</option>
+                      <option value="approved">Approved</option>
+                      <option value="pending">Pending</option>
+                      <option value="confirmed">Confirmed</option>
+                      <option value="rejected">Rejected</option>
+                      <option value="waitlist">Waitlist</option>
+                      <option value="cancelled">Cancelled</option>
+                    </select>
+                  )}
+                </>
+              )}
 
               <div className="ml-auto flex items-center gap-2 flex-wrap">
                 {hasActiveFilters && (
@@ -1365,7 +1314,9 @@ export default function NetworkPage({
                       .map((tag) => `${tag}: ${importSession.tagCounts?.[tag] ?? 0}`)
                       .join(' · ')}
                   </p>
-                  <p className="text-[10px] text-foreground/50 mt-1">{IMPORT_TAG_COUNTS_FOOTNOTE}</p>
+                  <p className="text-[10px] text-foreground/50 mt-1">
+                    {IMPORT_TAG_COUNTS_FOOTNOTE}
+                  </p>
                 </div>
               )}
 
@@ -1507,9 +1458,10 @@ export default function NetworkPage({
             onClose={() => setShowBulkEditModal(false)}
             selectedCount={selectedContacts.length}
             categories={categories}
-            lists={savedLists}
-            onAddCategory={handleBulkCategoryUpdate}
-            onAddToList={handleBulkAddToList}
+            availableTags={filterOptions.tags}
+            onApplyCategory={handleBulkCategoryUpdate}
+            onApplyTags={handleBulkTags}
+            onApplyLocation={handleBulkLocation}
             onDelete={handleBulkDelete}
             onClearSelection={() => setSelectedContacts([])}
             loading={bulkUpdateLoading}
@@ -1871,7 +1823,6 @@ export default function NetworkPage({
           </div>
         </div>
       )}
-
     </div>
   )
 }

--- a/src/components/producer/Network/copy.ts
+++ b/src/components/producer/Network/copy.ts
@@ -3,7 +3,8 @@ export const LISTS_ARE_SAVED_FILTERS =
 
 export const CONTACTS_ALWAYS_IN_ALL = 'Contacts are always stored in All Contacts.'
 
-export const TAGS_ARE_LABELS = 'Tags (like "Seattle" or "Oklahoma City") are labels on those contacts.'
+export const TAGS_ARE_LABELS =
+  'Tags (like "Seattle" or "Oklahoma City") are labels on those contacts.'
 
 export const LISTS_FROM_TAGS =
   'Lists are saved filters on tags. You can create or update lists now.'
@@ -25,15 +26,13 @@ export const NEW_LIST_LABEL = 'New List'
 export const BULK_EDIT_LABEL = 'Edit Selected Contacts'
 
 export const BULK_EDIT_EMPTY_HINT =
-  'Select contacts using the checkboxes in the table, then add a category or list here.'
+  'Select contacts using the checkboxes in the table, then update their category, tags, or location here.'
 
-export const BULK_EDIT_NO_LISTS_HINT = 'No lists yet. Create one on the Lists tab.'
+export const BULK_EDIT_TAGS_HINT =
+  'Added tags are appended to each contact; existing tags are kept.'
 
-export const BULK_EDIT_FILTER_LIST_HINT =
-  "This list's tags, categories, and location will be applied to selected contacts."
-
-export const BULK_EDIT_MANUAL_LIST_HINT =
-  'Selected contacts will be added to this list.'
+export const BULK_EDIT_LOCATION_HINT =
+  'Location replaces the existing location on each selected contact.'
 
 export const FILTER_BAR_HINT =
   'Category, location, and tags narrow All Contacts. Save active filters as a list.'


### PR DESCRIPTION
## Summary
PR2 of the Network/Applicants batch (Epic 3 — Bulk edit redesign).

- Reworks the **Edit Selected Contacts** modal from `{category, add-to-list, delete}` to `{category, tags, location}` + delete.
- **Tags**: type-to-add with suggestions from existing tags; applies via the existing `add_tag` endpoint so tags **append** to each contact (the `bulk_update` endpoint replaces the whole tag set, which would wipe existing tags).
- **Location**: single input applied via `bulk_update` (replaces each contact's location).
- **Category**: unchanged behavior (append/replace confirm).
- Removes the unused Add-to-List flow (`handleBulkAddToList`) and the now-dead `savedLists` state / refresh in `NetworkPage`. No backend changes.

## Test plan
- [ ] Select contacts → Actions → Edit selected: Category / Tags / Location sections render; no List section.
- [ ] Apply a category (append vs replace prompt when some already have categories).
- [ ] Add multiple tags, Apply tags → existing tags preserved, new ones added; tag filter options refresh.
- [ ] Apply a location → location updated on all selected.
- [ ] Delete selected + Clear selection still work.
- [ ] `npm run typecheck` / `npm run lint` clean (verified locally).

Made with [Cursor](https://cursor.com)