### PR TITLE
fix: add 'processing' status support for email batching

### DIFF
--- a/src/components/producer/Email/ScheduledEmailCard.tsx
+++ b/src/components/producer/Email/ScheduledEmailCard.tsx
@@ -62,6 +62,7 @@ export default function ScheduledEmailCard({
   const isSent = email.status === 'sent'
   const isPaused = email.status === 'paused'
   const isScheduled = email.status === 'scheduled'
+  const isProcessingStatus = email.status === 'processing'
   const isFailed = email.status === 'failed'
 
   // Determine if card should be clickable (all scheduled emails are now editable)
@@ -83,9 +84,11 @@ export default function ScheduledEmailCard({
           ? 'bg-yellow-500/10 text-yellow-400'
           : isFailed
             ? 'bg-red-500/10 text-red-400'
-            : isScheduled
-              ? 'bg-blue-500/10 text-blue-400'
-              : 'bg-muted/10 text-muted-foreground'
+            : isProcessingStatus
+              ? 'bg-green-500/10 text-green-400'
+              : isScheduled
+                ? 'bg-blue-500/10 text-blue-400'
+                : 'bg-muted/10 text-muted-foreground'
       }`}
     >
       {email.status.charAt(0).toUpperCase() + email.status.slice(1)}

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -235,6 +235,7 @@ export type TriggerType =
 
 export type ScheduledEmailStatus =
   | 'scheduled'
+  | 'processing'
   | 'paused'
   | 'active'
   | 'sent'


### PR DESCRIPTION
CRITICAL FIX: Backend now uses "processing" status during batch email sends (20-minute window for large campaigns). Frontend types and UI components need to support this status.

CHANGES:
1. TypeScript Types (src/types/email.ts):
   - Add "processing" to ScheduledEmailStatus union type
   - Prevents TypeScript errors when backend returns "processing"

2. UI Component (ScheduledEmailCard.tsx):
   - Add isProcessingStatus check
   - Add green badge for "processing" status (bg-green-500/10)
   - Badge shows "Processing" text during active sends

Impact: Without this fix, frontend would show "processing" as unknown status or crash with TypeScript errors.

Relates to: feature/email-rate-limiting-batching (backend)