### PR TITLE
feat: ApplicantsTab overhaul — pagination fix, hide invited by default, export

### DIFF
--- a/docs/tickets/NETWORK_QUERY_UX_KNOWN_ISSUES.md
+++ b/docs/tickets/NETWORK_QUERY_UX_KNOWN_ISSUES.md
@@ -1,0 +1,63 @@
+# Network Filter → Query UX — KNOWN ISSUES (do not treat as done)
+
+**Status:** ⚠️ Work in progress — shipped prematurely. The feature is wired up and
+compiles/type-checks clean, but has **active, unresolved bugs**. Do not consider
+Epic E1+E2+E4 complete.
+
+**Where it landed:** PR #130 (`fix/applicants-table-styling`), commit
+`98f9d42` — "feat(network): ClickUp-style Filter panel + saved queries".
+
+**Files involved:**
+- `src/components/producer/Network/FilterPanel.tsx` (new — the panel UI + draft state)
+- `src/components/producer/Network/NetworkPage.tsx` — handlers:
+  `handleApplyFilters`, `handleApplyQuery`, `handleSaveQuery`, `handleDeleteQuery`,
+  `loadSavedQueries`, and the social branch in `applyClientSideFilters`
+- `src/components/producer/Network/copy.ts` — query terminology constants
+
+---
+
+## Active bugs
+
+### 1. Severe load-time / performance regression 🔴
+- **Symptom:** Network/contacts page load times got dramatically worse after this
+  change went up to dev.
+- **Status:** NOT root-caused. Needs backend (Render dev API) log review for slow
+  requests around `/contact_lists` and `/vendor_contacts`.
+- **Suspects (unverified):**
+  - Extra `loadSavedQueries()` (`contactListsApi.getAll`) call added on mount.
+  - `handleApplyFilters` sets server-filter state (category/location/tags) which
+    triggers the `fetchContacts` effect; if the contacts/list endpoints are slow,
+    every Apply round-trips and feels broken.
+  - Possible repeated/duplicate fetches from filter state churn — verify the
+    `useEffect` dependency on `locationFilters/categoryFilters/tagFilters` isn't
+    re-firing unnecessarily.
+- **Next step:** Pull Render dev API request logs (timings) and confirm which
+  endpoint/query is the bottleneck before optimizing.
+
+### 2. "Save query" does not persist 🔴
+- **Symptom:** Saving the current filter draft as a query (`handleSaveQuery` →
+  `contactListsApi.create` with `list_type: 'smart'`) does not appear to actually
+  save / surface in the Saved Queries list.
+- **Status:** NOT root-caused. Verify the create request payload/response, that the
+  created list is `list_type: 'smart'`, and that `loadSavedQueries()` re-fetch +
+  the `savedQueries` filter (`l.list_type === 'smart'`) actually includes it.
+
+### 3. "Apply" does not update the table 🔴
+- **Symptom:** Clicking **Apply** in the filter panel does not visibly change the
+  contacts table.
+- **Status:** NOT root-caused. May be the same root cause as #1 (slow/blocked
+  fetch) or a state-wiring bug between `handleApplyFilters` → `activeFilters` /
+  client-side filters → `displayedContacts`. Confirm whether server filters
+  (category/location/tags) refetch and whether client filters (social/updated/
+  shows-attended) recompute `displayedContacts`.
+
+---
+
+## Notes for the next engineer / agent
+- The UI is intentionally "staged draft → Apply" (filters don't apply live; only on
+  Apply). Keep that in mind when debugging #3.
+- Terminology is UI-only "query"; the underlying model is still the smart
+  `ContactList`. No backend changes were made in this PR.
+- If this needs to ship without the query feature, the cleanest path is to revert
+  commit `98f9d42` from this branch (the other epics — E7, E3, tech-debt, E8 — are
+  independent and working).

--- a/src/components/producer/ApplicantsExportModal.tsx
+++ b/src/components/producer/ApplicantsExportModal.tsx
@@ -16,6 +16,7 @@ interface Applicant {
   tags?: string[]
   producer_notes?: string
   created_at: string
+  ticket_code?: string
   application_code?: string
   instagram_handle?: string
   tiktok_handle?: string
@@ -72,9 +73,9 @@ const EXPORT_COLUMNS: ExportColumn[] = [
     defaultOn: false,
   },
   {
-    key: 'application_code',
+    key: 'ticket_code',
     label: 'Ticket Code',
-    getValue: (a) => a.application_code || '',
+    getValue: (a) => a.ticket_code || a.application_code || '',
     defaultOn: false,
   },
   {

--- a/src/components/producer/ApplicantsExportModal.tsx
+++ b/src/components/producer/ApplicantsExportModal.tsx
@@ -1,0 +1,253 @@
+import { useState } from 'react'
+import { X, Download, Loader2, Check } from 'lucide-react'
+import { csvEscape, formatIsoForCsv } from './Network/unifiedDataExport'
+import { triggerCsvDownload } from './Network/contactsCsvExport'
+
+interface Applicant {
+  id: string
+  business_name: string
+  contact_name?: string
+  email: string
+  phone?: string
+  vendor_category: string
+  status: string
+  payment_status?: string
+  location?: string
+  tags?: string[]
+  producer_notes?: string
+  created_at: string
+  application_code?: string
+  instagram_handle?: string
+  tiktok_handle?: string
+  website?: string
+}
+
+interface ExportColumn {
+  key: string
+  label: string
+  getValue: (a: Applicant) => string
+  defaultOn: boolean
+}
+
+const EXPORT_COLUMNS: ExportColumn[] = [
+  { key: 'contact_name', label: 'Name', getValue: (a) => a.contact_name || '', defaultOn: true },
+  {
+    key: 'business_name',
+    label: 'Business Name',
+    getValue: (a) => a.business_name || '',
+    defaultOn: true,
+  },
+  { key: 'email', label: 'Email', getValue: (a) => a.email || '', defaultOn: true },
+  { key: 'phone', label: 'Phone', getValue: (a) => a.phone || '', defaultOn: true },
+  {
+    key: 'vendor_category',
+    label: 'Vendor Category',
+    getValue: (a) => a.vendor_category || '',
+    defaultOn: true,
+  },
+  { key: 'status', label: 'Status', getValue: (a) => a.status || '', defaultOn: true },
+  {
+    key: 'payment_status',
+    label: 'Payment Status',
+    getValue: (a) => a.payment_status || '',
+    defaultOn: true,
+  },
+  { key: 'location', label: 'Location', getValue: (a) => a.location || '', defaultOn: false },
+  {
+    key: 'tags',
+    label: 'Tags',
+    getValue: (a) => (a.tags || []).join(', '),
+    defaultOn: false,
+  },
+  {
+    key: 'producer_notes',
+    label: 'Producer Notes',
+    getValue: (a) => a.producer_notes || '',
+    defaultOn: false,
+  },
+  {
+    key: 'created_at',
+    label: 'Applied At',
+    getValue: (a) => formatIsoForCsv(a.created_at),
+    defaultOn: false,
+  },
+  {
+    key: 'application_code',
+    label: 'Ticket Code',
+    getValue: (a) => a.application_code || '',
+    defaultOn: false,
+  },
+  {
+    key: 'instagram',
+    label: 'Instagram',
+    getValue: (a) => a.instagram_handle || '',
+    defaultOn: false,
+  },
+  { key: 'tiktok', label: 'TikTok', getValue: (a) => a.tiktok_handle || '', defaultOn: false },
+  { key: 'website', label: 'Website', getValue: (a) => a.website || '', defaultOn: false },
+]
+
+function getDefaultColumnKeys(): Set<string> {
+  return new Set(EXPORT_COLUMNS.filter((c) => c.defaultOn).map((c) => c.key))
+}
+
+function applicantsToCsv(applicants: Applicant[], selectedColumns: Set<string>): string {
+  const cols = EXPORT_COLUMNS.filter((c) => selectedColumns.has(c.key))
+  const headers = cols.map((c) => c.label)
+  const rows = applicants.map((a) => cols.map((col) => csvEscape(col.getValue(a))))
+  return [headers.join(','), ...rows.map((r) => r.join(','))].join('\n')
+}
+
+interface ApplicantsExportModalProps {
+  open: boolean
+  onClose: () => void
+  applicants: Applicant[]
+  eventSlug: string
+}
+
+export default function ApplicantsExportModal({
+  open,
+  onClose,
+  applicants,
+  eventSlug,
+}: ApplicantsExportModalProps) {
+  const [selectedColumns, setSelectedColumns] = useState<Set<string>>(() => getDefaultColumnKeys())
+  const [isExporting, setIsExporting] = useState(false)
+
+  const toggleColumn = (key: string) => {
+    setSelectedColumns((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  const selectAll = () => setSelectedColumns(new Set(EXPORT_COLUMNS.map((c) => c.key)))
+  const selectNone = () => setSelectedColumns(new Set())
+
+  const handleExport = () => {
+    if (selectedColumns.size === 0) return
+    setIsExporting(true)
+    try {
+      const csv = applicantsToCsv(applicants, selectedColumns)
+      const date = new Date().toISOString().slice(0, 10)
+      triggerCsvDownload(csv, `applicants-${eventSlug}-${date}.csv`)
+      onClose()
+    } catch (err: any) {
+      alert(err.message || 'Failed to export applicants')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      className="voxxy-overlay-scrim fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="voxxy-modal-surface w-full max-w-lg rounded-xl overflow-hidden flex flex-col max-h-[80vh]">
+        {/* Header */}
+        <div className="voxxy-gradient-modal-header flex items-center justify-between border-b border-primary/20 px-5 py-3 flex-shrink-0 rounded-t-xl">
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Export Applicants</h2>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {applicants.length} applicant{applicants.length !== 1 ? 's' : ''} will be exported
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-foreground/60 hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Column selection */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-xs font-medium text-foreground/70">
+              Select columns ({selectedColumns.size} of {EXPORT_COLUMNS.length})
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={selectAll}
+                className="text-[11px] text-primary hover:text-primary/80 transition-colors"
+              >
+                All
+              </button>
+              <span className="text-foreground/30">|</span>
+              <button
+                onClick={selectNone}
+                className="text-[11px] text-primary hover:text-primary/80 transition-colors"
+              >
+                None
+              </button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-1.5">
+            {EXPORT_COLUMNS.map((col) => {
+              const isSelected = selectedColumns.has(col.key)
+              return (
+                <button
+                  key={col.key}
+                  type="button"
+                  onClick={() => toggleColumn(col.key)}
+                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs transition-all text-left ${
+                    isSelected
+                      ? 'bg-primary/15 text-foreground border border-primary/30'
+                      : 'bg-card/50 text-foreground/60 border border-border hover:bg-accent/40 hover:text-foreground/80 dark:bg-card/30'
+                  }`}
+                >
+                  <div
+                    className={`w-3.5 h-3.5 rounded border-2 flex items-center justify-center flex-shrink-0 transition-colors ${
+                      isSelected ? 'bg-primary/50 border-primary' : 'border-border'
+                    }`}
+                  >
+                    {isSelected && (
+                      <Check className="w-2.5 h-2.5 text-foreground" strokeWidth={3} />
+                    )}
+                  </div>
+                  <span className="truncate">{col.label}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-border flex-shrink-0">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-xs rounded-lg border border-border text-foreground hover:bg-background/10 transition-all"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={selectedColumns.size === 0 || isExporting}
+            className="flex items-center gap-1.5 px-4 py-2 text-xs font-medium rounded-lg voxxy-btn-cta disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+          >
+            {isExporting ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Exporting...
+              </>
+            ) : (
+              <>
+                <Download className="w-3.5 h-3.5" />
+                Export CSV
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -88,6 +88,7 @@ interface Applicant {
   portfolio_images?: string[]
   producer_notes?: string
   tags?: string[]
+  ticket_code?: string
   application_code?: string
   email_unsubscribed?: boolean
   unsubscribe_status?: {
@@ -273,6 +274,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
           location: submission.location,
           portfolio_images: submission.portfolio_images,
           producer_notes: submission.producer_notes,
+          ticket_code: submission.ticket_code,
           application_code: submission.application_code,
           email_unsubscribed: submission.email_unsubscribed,
           unsubscribe_status: submission.email_unsubscribed
@@ -1515,17 +1517,21 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                         <span>{formatDate(selectedApplicant.created_at)}</span>
                       </div>
                     </div>
-                    {selectedApplicant.application_code && (
+                    {(selectedApplicant.ticket_code || selectedApplicant.application_code) && (
                       <div>
-                        <p className="text-[10px] text-foreground/60 mb-1">App Code</p>
+                        <p className="text-[10px] text-foreground/60 mb-1">Ticket Code</p>
                         <div className="flex items-center gap-1.5">
                           <code className="text-xs text-primary font-mono bg-primary/10 px-2 py-0.5 rounded">
-                            {selectedApplicant.application_code}
+                            {selectedApplicant.ticket_code || selectedApplicant.application_code}
                           </code>
                           <button
                             type="button"
                             onClick={() => {
-                              navigator.clipboard.writeText(selectedApplicant.application_code!)
+                              navigator.clipboard.writeText(
+                                selectedApplicant.ticket_code ||
+                                  selectedApplicant.application_code ||
+                                  '',
+                              )
                               toast.success('Code copied')
                             }}
                             className="p-1 rounded hover:bg-background/10 text-foreground/40 hover:text-foreground transition-colors"

--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -825,7 +825,10 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
   const handleFilterBarChange = (filters: ActiveFilter[]) => {
     const statusLabel = filters.find((f) => f.fieldKey === 'status')?.values[0]
     const matchedStatus = STATUS_FILTER_OPTIONS.find((o) => o.label === statusLabel)
-    setStatusFilter(matchedStatus ? matchedStatus.value : 'all')
+    const newStatus = matchedStatus ? matchedStatus.value : 'all'
+    setStatusFilter(newStatus)
+    // Auto-show invited contacts when the Invited filter is selected
+    if (newStatus === 'invited') setShowInvited(true)
 
     const categoryValue = filters.find((f) => f.fieldKey === 'category')?.values[0]
     setCategoryFilter(categoryValue ?? 'all')

--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -121,14 +121,15 @@ type StatusFilter =
 
 // Status filter values paired with their human-facing labels (used by the
 // shared SearchFilterBar, which works in terms of display labels).
+// 'opted_out' is the representative value for the merged "Opted Out" group,
+// which matches both 'opted_out' and 'cancelled' applicant statuses.
 const STATUS_FILTER_OPTIONS: { value: Exclude<StatusFilter, 'all'>; label: string }[] = [
   { value: 'invited', label: 'Invited' },
   { value: 'pending', label: 'New' },
   { value: 'approved', label: 'Approved' },
-  { value: 'confirmed', label: 'Confirmed' },
+  { value: 'confirmed', label: 'Paid' },
   { value: 'waitlist', label: 'Waitlisted' },
   { value: 'rejected', label: 'Declined' },
-  { value: 'cancelled', label: 'Cancelled' },
   { value: 'opted_out', label: 'Opted Out' },
 ]
 
@@ -682,7 +683,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
         }
       case 'confirmed':
         return {
-          label: 'Confirmed',
+          label: 'Paid',
           variant: 'tintGreenDeep' as BadgeVariant,
           icon: CheckCircle,
         }
@@ -698,12 +699,8 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
           variant: 'tintRed' as BadgeVariant,
           icon: XCircle,
         }
+      // 'cancelled' is merged into the "Opted Out" group, so it shares its label/style.
       case 'cancelled':
-        return {
-          label: 'Cancelled',
-          variant: 'tintMuted' as BadgeVariant,
-          icon: XCircle,
-        }
       case 'opted_out':
         return {
           label: 'Opted Out',
@@ -773,7 +770,14 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
     }
 
     // Status filter
-    if (statusFilter !== 'all' && applicant.status !== statusFilter) return false
+    if (statusFilter !== 'all') {
+      if (statusFilter === 'opted_out') {
+        // Merged group: "Opted Out" covers both opted_out and cancelled.
+        if (applicant.status !== 'opted_out' && applicant.status !== 'cancelled') return false
+      } else if (applicant.status !== statusFilter) {
+        return false
+      }
+    }
 
     // Category filter
     if (categoryFilter !== 'all' && applicant.vendor_category !== categoryFilter) return false

--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -24,6 +24,8 @@ import {
   List,
   ChevronLeft,
   ChevronRight,
+  Download,
+  Users,
 } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import {
@@ -38,6 +40,7 @@ import { EmailConfirmationDialog } from './EmailConfirmationDialog'
 import { EditVendorDetailsModal } from './EditVendorDetailsModal'
 import { Button } from '@/components/ui/button'
 import { DebugPanel } from './DebugPanel'
+import ApplicantsExportModal from './ApplicantsExportModal'
 import { Badge, type BadgeVariant } from '@/components/ui/badge'
 import {
   Select,
@@ -156,26 +159,63 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
 
   const [showEditVendorModal, setShowEditVendorModal] = useState(false)
 
+  // Invited contacts visibility
+  const [showInvited, setShowInvited] = useState(false)
+  const [invitedCount, setInvitedCount] = useState(0)
+
+  // Export modal
+  const [showExportModal, setShowExportModal] = useState(false)
+
   // Email notifications hook
   const { dialogOpen, dialogProps, handleEmailNotification, handleConfirmSend, closeDialog } =
     useEmailNotifications()
 
   useEffect(() => {
     fetchApplicants()
-  }, [eventSlug])
+  }, [eventSlug, showInvited])
 
   useEffect(() => {
     setShowEditVendorModal(false)
   }, [selectedApplicant?.id])
+
+  const fetchAllInvitations = async (slug: string): Promise<any[]> => {
+    const all: any[] = []
+    let page = 1
+    const perPage = 100
+    let hasNextPage = true
+    while (hasNextPage) {
+      const resp = await eventInvitationsApi.getByEvent(slug, page, perPage)
+      all.push(...(resp.invitations || []))
+      hasNextPage = resp.meta?.pagination?.has_next_page ?? false
+      page++
+    }
+    return all
+  }
 
   const fetchApplicants = async () => {
     try {
       setLoading(true)
       setError(null)
 
-      // Fetch invitations (people who were invited)
-      const invitationsResponse = await eventInvitationsApi.getByEvent(eventSlug, 1, 100)
-      const invitations = invitationsResponse.invitations || []
+      // Fetch invitations — always get page 1 for count; paginate fully only when shown
+      const firstPageResp = await eventInvitationsApi.getByEvent(eventSlug, 1, 100)
+      const firstPageInvitations = firstPageResp.invitations || []
+      const pagination = firstPageResp.meta?.pagination
+      const totalInvited =
+        pagination?.total_count ??
+        (pagination?.total_pages != null
+          ? pagination.total_pages > 1
+            ? pagination.total_pages * 100
+            : firstPageInvitations.length
+          : firstPageInvitations.length)
+      setInvitedCount(totalInvited)
+
+      let invitations: any[] = []
+      if (showInvited) {
+        // Paginate through all invitation pages (fixes 100-item cap)
+        invitations = await fetchAllInvitations(eventSlug)
+      }
+      // When showInvited=false, invitations stays [] — invited contacts are hidden
 
       // Fetch all vendor applications for this event
       const applications = await vendorApplicationsApi.getByEvent(eventSlug)
@@ -694,6 +734,9 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
 
   // Filter applicants
   const filteredApplicants = applicants.filter((applicant) => {
+    // Hide invited contacts unless showInvited is on
+    if (!showInvited && applicant.status === 'invited') return false
+
     // Search filter
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase()
@@ -724,7 +767,10 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
   ].sort()
 
   const hasActiveFilters =
-    statusFilter !== 'all' || categoryFilter !== 'all' || searchQuery.trim() !== ''
+    statusFilter !== 'all' ||
+    (statusFilter === 'invited' && !showInvited) ||
+    categoryFilter !== 'all' ||
+    searchQuery.trim() !== ''
 
   const clearFilters = () => {
     setStatusFilter('all')
@@ -818,65 +864,101 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
 
   return (
     <div className="h-full flex flex-col">
-      {/* View Mode Toggle & Header */}
-      <div className="flex items-center justify-between px-3 md:px-4 pt-3 pb-2 border-b border-border">
-        <div>
+      {/* Header row 1: Title + actions + view toggle */}
+      <div className="flex items-center justify-between px-3 md:px-4 pt-3 pb-2 border-b border-border gap-2 flex-wrap">
+        <div className="shrink-0">
           <h2 className="text-2xl font-bold text-foreground">Applicants</h2>
           <p className="text-[10px] text-foreground/60">
-            {filteredApplicants.length} total
+            {filteredApplicants.length} shown
             {statusFilter !== 'all' && ` • ${statusFilter}`}
             {categoryFilter !== 'all' && ` • ${categoryFilter}`}
+            {!showInvited && invitedCount > 0 && ` • ${invitedCount} invited hidden`}
           </p>
         </div>
-        <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
-          <button
-            onClick={() => setViewMode('focused')}
-            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-smooth ${
-              viewMode === 'focused'
-                ? 'voxxy-nav-tab-active'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-            title="Focused view"
-          >
-            <LayoutPanelLeft className="w-3.5 h-3.5" />
-            Focused
-          </button>
-          <button
-            onClick={() => {
-              setViewMode('table')
+
+        {/* Search — flex-1 in the middle */}
+        <div className="relative flex-1 min-w-[160px] max-w-xs">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-foreground/50" />
+          <input
+            type="text"
+            placeholder="Search applicants..."
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value)
               setTablePage(1)
-              clearTableSelection()
             }}
-            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-smooth ${
-              viewMode === 'table'
-                ? 'voxxy-nav-tab-active'
-                : 'text-muted-foreground hover:text-foreground'
+            className="w-full pl-7 pr-2 py-1.5 bg-background/5 border border-border rounded-lg text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary/50"
+          />
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Invited toggle */}
+          <button
+            onClick={() => setShowInvited((v) => !v)}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg border transition-smooth ${
+              showInvited
+                ? 'bg-primary/15 border-primary/30 text-foreground'
+                : 'border-border text-foreground/60 hover:text-foreground'
             }`}
-            title="Table view"
+            title={showInvited ? 'Hide invited contacts' : 'Show invited contacts'}
           >
-            <List className="w-3.5 h-3.5" />
-            Table
+            <Users className="w-3 h-3" />
+            {showInvited
+              ? 'Hide Invited'
+              : invitedCount > 0
+                ? `Invited (${invitedCount})`
+                : 'Invited'}
           </button>
+
+          {/* Export button */}
+          <button
+            onClick={() => setShowExportModal(true)}
+            disabled={filteredApplicants.length === 0}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg border border-border text-foreground/60 hover:text-foreground transition-smooth disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Export applicants as CSV"
+          >
+            <Download className="w-3 h-3" />
+            Export
+          </button>
+
+          {/* View mode toggle */}
+          <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
+            <button
+              onClick={() => setViewMode('focused')}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-smooth ${
+                viewMode === 'focused'
+                  ? 'voxxy-nav-tab-active'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              title="Focused view"
+            >
+              <LayoutPanelLeft className="w-3.5 h-3.5" />
+              Focused
+            </button>
+            <button
+              onClick={() => {
+                setViewMode('table')
+                setTablePage(1)
+                clearTableSelection()
+              }}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-smooth ${
+                viewMode === 'table'
+                  ? 'voxxy-nav-tab-active'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              title="Table view"
+            >
+              <List className="w-3.5 h-3.5" />
+              Table
+            </button>
+          </div>
         </div>
       </div>
       {/* ── TABLE VIEW ── */}
       {viewMode === 'table' && (
         <div className="flex-1 flex flex-col overflow-hidden p-3 md:p-4 gap-3">
-          {/* Filters row (reuse same controls) */}
+          {/* Filters row */}
           <div className="flex flex-wrap gap-2 items-center">
-            <div className="relative flex-1 min-w-[160px]">
-              <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-foreground/50" />
-              <input
-                type="text"
-                placeholder="Search applicants..."
-                value={searchQuery}
-                onChange={(e) => {
-                  setSearchQuery(e.target.value)
-                  setTablePage(1)
-                }}
-                className="w-full pl-7 pr-2 py-1.5 bg-background/5 border border-border rounded-lg text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary/50"
-              />
-            </div>
             <Select
               value={statusFilter}
               onValueChange={(v) => {
@@ -895,7 +977,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                   Invited
                 </SelectItem>
                 <SelectItem value="pending" className="text-xs">
-                  New (Unreviewed)
+                  New
                 </SelectItem>
                 <SelectItem value="approved" className="text-xs">
                   Approved
@@ -904,7 +986,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                   Confirmed
                 </SelectItem>
                 <SelectItem value="waitlist" className="text-xs">
-                  Waitlist
+                  Waitlisted
                 </SelectItem>
                 <SelectItem value="rejected" className="text-xs">
                   Declined
@@ -1143,18 +1225,6 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                 </p>
               </div>
 
-              {/* Search Bar */}
-              <div className="relative mb-2">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-foreground/65 dark:text-foreground/40" />
-                <input
-                  type="text"
-                  placeholder="Search..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full pl-7 pr-2 py-1.5 bg-background/5 border border-border rounded-lg text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary/50"
-                />
-              </div>
-
               {/* Status & Category Filters */}
               <div className="space-y-1.5">
                 <Select
@@ -1169,10 +1239,10 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                       All Status
                     </SelectItem>
                     <SelectItem value="invited" className="text-xs focus:bg-background/10">
-                      Invited (No Application)
+                      Invited
                     </SelectItem>
                     <SelectItem value="pending" className="text-xs focus:bg-background/10">
-                      New (Unreviewed)
+                      New
                     </SelectItem>
                     <SelectItem value="approved" className="text-xs focus:bg-background/10">
                       Approved
@@ -1181,7 +1251,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
                       Confirmed
                     </SelectItem>
                     <SelectItem value="waitlist" className="text-xs focus:bg-background/10">
-                      Waitlist
+                      Waitlisted
                     </SelectItem>
                     <SelectItem value="rejected" className="text-xs focus:bg-background/10">
                       Declined
@@ -2208,6 +2278,14 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
           </div>
         </div>
       )}
+      {/* Export Modal */}
+      <ApplicantsExportModal
+        open={showExportModal}
+        onClose={() => setShowExportModal(false)}
+        applicants={filteredApplicants}
+        eventSlug={eventSlug}
+      />
+
       {/* Admin Debug Panel */}
       <DebugPanel
         title="Applicants Tab"

--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -43,6 +43,11 @@ import { DebugPanel } from './DebugPanel'
 import ApplicantsExportModal from './ApplicantsExportModal'
 import { Badge, type BadgeVariant } from '@/components/ui/badge'
 import {
+  SearchFilterBar,
+  type FilterFieldConfig,
+  type ActiveFilter,
+} from '@/components/shared/SearchFilterBar'
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -113,6 +118,19 @@ type StatusFilter =
   | 'rejected'
   | 'cancelled'
   | 'opted_out'
+
+// Status filter values paired with their human-facing labels (used by the
+// shared SearchFilterBar, which works in terms of display labels).
+const STATUS_FILTER_OPTIONS: { value: Exclude<StatusFilter, 'all'>; label: string }[] = [
+  { value: 'invited', label: 'Invited' },
+  { value: 'pending', label: 'New' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'confirmed', label: 'Confirmed' },
+  { value: 'waitlist', label: 'Waitlisted' },
+  { value: 'rejected', label: 'Declined' },
+  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'opted_out', label: 'Opted Out' },
+]
 
 export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsTabProps) {
   const [applicants, setApplicants] = useState<Applicant[]>([])
@@ -769,15 +787,46 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
   ].sort()
 
   const hasActiveFilters =
-    statusFilter !== 'all' ||
-    (statusFilter === 'invited' && !showInvited) ||
-    categoryFilter !== 'all' ||
-    searchQuery.trim() !== ''
+    statusFilter !== 'all' || categoryFilter !== 'all' || searchQuery.trim() !== ''
 
-  const clearFilters = () => {
-    setStatusFilter('all')
-    setCategoryFilter('all')
-    setSearchQuery('')
+  // --- Shared filter bar (button + applied-chips) config ---
+  const filterFieldConfigs: FilterFieldConfig[] = [
+    {
+      key: 'status',
+      label: 'Status',
+      multi: false,
+      options: STATUS_FILTER_OPTIONS.map((o) => o.label),
+    },
+    ...(uniqueCategories.length > 0
+      ? [
+          {
+            key: 'category',
+            label: 'Category',
+            multi: false,
+            options: uniqueCategories as string[],
+          } as FilterFieldConfig,
+        ]
+      : []),
+  ]
+
+  const filterBarActiveFilters: ActiveFilter[] = []
+  if (statusFilter !== 'all') {
+    const label = STATUS_FILTER_OPTIONS.find((o) => o.value === statusFilter)?.label
+    if (label) filterBarActiveFilters.push({ fieldKey: 'status', values: [label] })
+  }
+  if (categoryFilter !== 'all') {
+    filterBarActiveFilters.push({ fieldKey: 'category', values: [categoryFilter] })
+  }
+
+  const handleFilterBarChange = (filters: ActiveFilter[]) => {
+    const statusLabel = filters.find((f) => f.fieldKey === 'status')?.values[0]
+    const matchedStatus = STATUS_FILTER_OPTIONS.find((o) => o.label === statusLabel)
+    setStatusFilter(matchedStatus ? matchedStatus.value : 'all')
+
+    const categoryValue = filters.find((f) => f.fieldKey === 'category')?.values[0]
+    setCategoryFilter(categoryValue ?? 'all')
+
+    setTablePage(1)
   }
 
   const formatDate = (dateString?: string) => {
@@ -960,79 +1009,13 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
       {viewMode === 'table' && (
         <div className="flex-1 flex flex-col overflow-hidden p-3 md:p-4 gap-3">
           {/* Filters row */}
-          <div className="flex flex-wrap gap-2 items-center">
-            <Select
-              value={statusFilter}
-              onValueChange={(v) => {
-                setStatusFilter(v as StatusFilter)
-                setTablePage(1)
-              }}
-            >
-              <SelectTrigger className="h-8 w-36 rounded-lg border border-border bg-background/5 px-2 text-xs text-foreground focus:ring-1 focus:ring-primary/50">
-                <SelectValue placeholder="All Status" />
-              </SelectTrigger>
-              <SelectContent className="border-border bg-muted text-foreground shadow-xl">
-                <SelectItem value="all" className="text-xs">
-                  All Status
-                </SelectItem>
-                <SelectItem value="invited" className="text-xs">
-                  Invited
-                </SelectItem>
-                <SelectItem value="pending" className="text-xs">
-                  New
-                </SelectItem>
-                <SelectItem value="approved" className="text-xs">
-                  Approved
-                </SelectItem>
-                <SelectItem value="confirmed" className="text-xs">
-                  Confirmed
-                </SelectItem>
-                <SelectItem value="waitlist" className="text-xs">
-                  Waitlisted
-                </SelectItem>
-                <SelectItem value="rejected" className="text-xs">
-                  Declined
-                </SelectItem>
-                <SelectItem value="cancelled" className="text-xs">
-                  Cancelled
-                </SelectItem>
-                <SelectItem value="opted_out" className="text-xs">
-                  Opted Out
-                </SelectItem>
-              </SelectContent>
-            </Select>
-            {uniqueCategories.length > 0 && (
-              <Select
-                value={categoryFilter}
-                onValueChange={(v) => {
-                  setCategoryFilter(v)
-                  setTablePage(1)
-                }}
-              >
-                <SelectTrigger className="h-8 w-40 rounded-lg border border-border bg-background/5 px-2 text-xs text-foreground focus:ring-1 focus:ring-primary/50">
-                  <SelectValue placeholder="All Categories" />
-                </SelectTrigger>
-                <SelectContent className="border-border bg-muted text-foreground shadow-xl">
-                  <SelectItem value="all" className="text-xs">
-                    All Categories
-                  </SelectItem>
-                  {uniqueCategories.map((cat) => (
-                    <SelectItem key={cat} value={cat} className="text-xs">
-                      {cat}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            {hasActiveFilters && (
-              <button
-                onClick={clearFilters}
-                className="px-2 py-1.5 rounded-lg bg-background/5 text-foreground/60 hover:text-foreground text-xs transition-smooth"
-              >
-                Clear filters
-              </button>
-            )}
-          </div>
+          <SearchFilterBar
+            variant="button"
+            showSearch={false}
+            filterFields={filterFieldConfigs}
+            activeFilters={filterBarActiveFilters}
+            onFiltersChange={handleFilterBarChange}
+          />
 
           {/* Select-all banner */}
           {allCurrentPageSelected &&
@@ -1228,74 +1211,13 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
               </div>
 
               {/* Status & Category Filters */}
-              <div className="space-y-1.5">
-                <Select
-                  value={statusFilter}
-                  onValueChange={(value) => setStatusFilter(value as StatusFilter)}
-                >
-                  <SelectTrigger className="voxxy-hover-row h-8 w-full rounded-lg border border-border bg-background/5 px-2 text-xs text-foreground transition-smooth focus:ring-1 focus:ring-primary/50">
-                    <SelectValue placeholder="All Status" />
-                  </SelectTrigger>
-                  <SelectContent className="border-border bg-muted text-foreground shadow-xl">
-                    <SelectItem value="all" className="text-xs focus:bg-background/10">
-                      All Status
-                    </SelectItem>
-                    <SelectItem value="invited" className="text-xs focus:bg-background/10">
-                      Invited
-                    </SelectItem>
-                    <SelectItem value="pending" className="text-xs focus:bg-background/10">
-                      New
-                    </SelectItem>
-                    <SelectItem value="approved" className="text-xs focus:bg-background/10">
-                      Approved
-                    </SelectItem>
-                    <SelectItem value="confirmed" className="text-xs focus:bg-background/10">
-                      Confirmed
-                    </SelectItem>
-                    <SelectItem value="waitlist" className="text-xs focus:bg-background/10">
-                      Waitlisted
-                    </SelectItem>
-                    <SelectItem value="rejected" className="text-xs focus:bg-background/10">
-                      Declined
-                    </SelectItem>
-                    <SelectItem value="cancelled" className="text-xs focus:bg-background/10">
-                      Cancelled
-                    </SelectItem>
-                    <SelectItem value="opted_out" className="text-xs focus:bg-background/10">
-                      Opted Out
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                {uniqueCategories.length > 0 && (
-                  <Select value={categoryFilter} onValueChange={setCategoryFilter}>
-                    <SelectTrigger className="voxxy-hover-row h-8 w-full rounded-lg border border-border bg-background/5 px-2 text-xs text-foreground transition-smooth focus:ring-1 focus:ring-primary/50">
-                      <SelectValue placeholder="All Categories" />
-                    </SelectTrigger>
-                    <SelectContent className="border-border bg-muted text-foreground shadow-xl">
-                      <SelectItem value="all" className="text-xs focus:bg-background/10">
-                        All Categories
-                      </SelectItem>
-                      {uniqueCategories.map((cat) => (
-                        <SelectItem
-                          key={cat}
-                          value={cat}
-                          className="text-xs focus:bg-background/10"
-                        >
-                          {cat}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-                {hasActiveFilters && (
-                  <button
-                    onClick={clearFilters}
-                    className="w-full px-2 py-1.5 rounded-lg bg-background/5 text-foreground dark:text-foreground/60 hover:text-foreground hover:bg-background/10 text-xs transition-smooth"
-                  >
-                    Clear filters
-                  </button>
-                )}
-              </div>
+              <SearchFilterBar
+                variant="button"
+                showSearch={false}
+                filterFields={filterFieldConfigs}
+                activeFilters={filterBarActiveFilters}
+                onFiltersChange={handleFilterBarChange}
+              />
             </div>
 
             {/* Applicant List */}

--- a/src/components/producer/EventSettings.tsx
+++ b/src/components/producer/EventSettings.tsx
@@ -1103,11 +1103,6 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
                         <div className="flex-1">
                           <div className="flex items-center gap-3 mb-0.5">
                             <h4 className="text-sm text-foreground font-semibold">{app.name}</h4>
-                            {app.pricing?.booth_price != null && (
-                              <span className="text-xs font-semibold text-emerald-800 dark:text-green-400">
-                                ${app.pricing.booth_price.toFixed(0)}
-                              </span>
-                            )}
                             <span
                               className={`text-[10px] font-medium ${app.status === 'active' ? 'text-emerald-800 dark:text-green-400' : 'text-muted-foreground'}`}
                             >
@@ -1142,43 +1137,18 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
                             </div>
                           )}
 
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                            <div>
-                              <label className="block text-xs text-foreground dark:text-foreground/60 mb-1">
-                                Category Name *
-                              </label>
-                              <input
-                                type="text"
-                                value={editFormData.name}
-                                onChange={(e) =>
-                                  setEditFormData({ ...editFormData, name: e.target.value })
-                                }
-                                className={inputClasses}
-                              />
-                            </div>
-                            <div>
-                              <label className="block text-xs text-foreground dark:text-foreground/60 mb-1">
-                                Booth Price *
-                              </label>
-                              <div className="relative">
-                                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-foreground/60 text-sm">
-                                  $
-                                </span>
-                                <input
-                                  type="number"
-                                  min="0"
-                                  step="0.01"
-                                  value={editFormData.booth_price ?? ''}
-                                  onChange={(e) =>
-                                    setEditFormData({
-                                      ...editFormData,
-                                      booth_price: parseFloat(e.target.value) || 0,
-                                    })
-                                  }
-                                  className={`${inputClasses} pl-7`}
-                                />
-                              </div>
-                            </div>
+                          <div>
+                            <label className="block text-xs text-foreground dark:text-foreground/60 mb-1">
+                              Category Name *
+                            </label>
+                            <input
+                              type="text"
+                              value={editFormData.name}
+                              onChange={(e) =>
+                                setEditFormData({ ...editFormData, name: e.target.value })
+                              }
+                              className={inputClasses}
+                            />
                           </div>
 
                           <div>

--- a/src/components/producer/Network/FilterPanel.tsx
+++ b/src/components/producer/Network/FilterPanel.tsx
@@ -1,3 +1,6 @@
+// ⚠️ WIP — shipped prematurely. This Filter → Query UX has ACTIVE KNOWN BUGS
+// (load-time regression, "Save query" not persisting, "Apply" not updating the
+// table). See docs/tickets/NETWORK_QUERY_UX_KNOWN_ISSUES.md before relying on it.
 import { useState, useEffect } from 'react'
 import {
   X,

--- a/src/components/shared/SearchFilterBar.tsx
+++ b/src/components/shared/SearchFilterBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Search, X, Check, ChevronDown } from 'lucide-react'
+import { Search, X, Check, ChevronDown, Filter } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 // --- Types ---
@@ -19,9 +19,20 @@ export interface ActiveFilter {
 
 interface SearchFilterBarProps {
   searchPlaceholder?: string
-  searchValue: string
-  onSearchChange: (value: string) => void
+  searchValue?: string
+  onSearchChange?: (value: string) => void
   onSearchSubmit?: () => void
+  /** Hide the search input (e.g. when the parent already renders one). Defaults to true. */
+  showSearch?: boolean
+  /**
+   * Layout for the filter controls:
+   * - 'inline' (default): one always-visible dropdown button per field.
+   * - 'button': a single "Filter" button that opens a panel of all fields,
+   *   with applied filters shown as removable chips below.
+   */
+  variant?: 'inline' | 'button'
+  /** Label for the collapsed filter button (button variant only). Defaults to 'Filter'. */
+  filterButtonLabel?: string
   filterFields: FilterFieldConfig[]
   activeFilters: ActiveFilter[]
   onFiltersChange: (filters: ActiveFilter[]) => void
@@ -56,12 +67,17 @@ function FilterDropdown({
   }, [])
 
   const filtered = field.options.filter((opt) => opt.toLowerCase().includes(search.toLowerCase()))
+  const isMulti = field.multi !== false
 
   const handleToggle = (value: string) => {
     if (selectedValues.includes(value)) {
       onChange(selectedValues.filter((v) => v !== value))
-    } else {
+    } else if (isMulti) {
       onChange([...selectedValues, value])
+    } else {
+      onChange([value])
+      setOpen(false)
+      setSearch('')
     }
   }
 
@@ -116,15 +132,20 @@ function FilterDropdown({
                   className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-foreground/90 dark:text-foreground/80 hover:bg-background/10 rounded transition-colors"
                 >
                   <div
-                    className={`w-3.5 h-3.5 rounded border-2 flex items-center justify-center flex-shrink-0 transition-colors ${
+                    className={`w-3.5 h-3.5 border-2 flex items-center justify-center flex-shrink-0 transition-colors ${
+                      isMulti ? 'rounded' : 'rounded-full'
+                    } ${
                       selectedValues.includes(option)
                         ? 'bg-primary/50 border-primary'
                         : 'border-border'
                     }`}
                   >
-                    {selectedValues.includes(option) && (
-                      <Check className="w-2.5 h-2.5 text-foreground" strokeWidth={3} />
-                    )}
+                    {selectedValues.includes(option) &&
+                      (isMulti ? (
+                        <Check className="w-2.5 h-2.5 text-foreground" strokeWidth={3} />
+                      ) : (
+                        <div className="w-1.5 h-1.5 rounded-full bg-foreground" />
+                      ))}
                   </div>
                   <span className="truncate text-left">{option}</span>
                 </button>
@@ -147,19 +168,132 @@ function FilterDropdown({
   )
 }
 
+// --- Collapsed Filter Button + Panel (button variant) ---
+
+function FilterButtonPanel({
+  label,
+  filterFields,
+  activeFilters,
+  activeFilterCount,
+  onToggleValue,
+  onClearAll,
+}: {
+  label: string
+  filterFields: FilterFieldConfig[]
+  activeFilters: ActiveFilter[]
+  activeFilterCount: number
+  onToggleValue: (field: FilterFieldConfig, value: string) => void
+  onClearAll: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className={`flex items-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-1.5 text-xs font-semibold transition-all ${
+          activeFilterCount > 0
+            ? 'border-primary/40 bg-primary/20 text-violet-950 dark:border-primary/30 dark:text-primary'
+            : 'border-border bg-card/80 text-foreground hover:bg-accent/60 dark:bg-card/50 dark:text-foreground/80 dark:border-white/10'
+        }`}
+      >
+        <Filter className="h-3.5 w-3.5" />
+        <span>{label}</span>
+        {activeFilterCount > 0 && (
+          <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary/50 text-[10px] font-bold text-primary-foreground">
+            {activeFilterCount}
+          </span>
+        )}
+        <ChevronDown className={`h-3 w-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 z-50 mt-1 w-64 overflow-hidden rounded-lg border border-border bg-muted shadow-xl">
+          <div className="max-h-96 space-y-3 overflow-y-auto p-3">
+            {filterFields.map((field) => {
+              const selectedValues =
+                activeFilters.find((f) => f.fieldKey === field.key)?.values || []
+              const isMulti = field.multi !== false
+              const Icon = field.icon
+              return (
+                <div key={field.key}>
+                  <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                    {Icon && <Icon className="h-3.5 w-3.5" />}
+                    {field.label}
+                  </div>
+                  <div className="space-y-0.5">
+                    {field.options.map((option) => {
+                      const selected = selectedValues.includes(option)
+                      return (
+                        <button
+                          key={option}
+                          onClick={() => onToggleValue(field, option)}
+                          className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-xs text-foreground/90 transition-colors hover:bg-background/10 dark:text-foreground/80"
+                        >
+                          <div
+                            className={`flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center border-2 transition-colors ${
+                              isMulti ? 'rounded' : 'rounded-full'
+                            } ${selected ? 'border-primary bg-primary/50' : 'border-border'}`}
+                          >
+                            {selected &&
+                              (isMulti ? (
+                                <Check className="h-2.5 w-2.5 text-foreground" strokeWidth={3} />
+                              ) : (
+                                <div className="h-1.5 w-1.5 rounded-full bg-foreground" />
+                              ))}
+                          </div>
+                          <span className="truncate text-left">{option}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          {activeFilterCount > 0 && (
+            <div className="border-t border-border p-1.5">
+              <button
+                onClick={onClearAll}
+                className="w-full py-1 text-xs text-foreground/75 transition-colors hover:text-foreground dark:text-muted-foreground"
+              >
+                Clear all filters
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // --- Main Component ---
 
 export function SearchFilterBar({
   searchPlaceholder = 'Search...',
-  searchValue,
+  searchValue = '',
   onSearchChange,
   onSearchSubmit,
+  showSearch = true,
+  variant = 'inline',
+  filterButtonLabel = 'Filter',
   filterFields,
   activeFilters,
   onFiltersChange,
   extraFilters,
 }: SearchFilterBarProps) {
-  const activeFilterCount = activeFilters.filter((f) => f.values.length > 0).length
+  const activeFilterCount = activeFilters.reduce((sum, f) => sum + f.values.length, 0)
 
   const handleUpdateFilterValues = (fieldKey: string, values: string[]) => {
     const existing = activeFilters.find((f) => f.fieldKey === fieldKey)
@@ -175,24 +309,100 @@ export function SearchFilterBar({
     }
   }
 
+  const handleToggleValue = (field: FilterFieldConfig, value: string) => {
+    const current = activeFilters.find((f) => f.fieldKey === field.key)?.values || []
+    if (current.includes(value)) {
+      handleUpdateFilterValues(field.key, current.filter((v) => v !== value))
+    } else if (field.multi !== false) {
+      handleUpdateFilterValues(field.key, [...current, value])
+    } else {
+      handleUpdateFilterValues(field.key, [value])
+    }
+  }
+
   const handleClearAll = () => {
     onFiltersChange([])
   }
 
+  // Flatten active filters into chips, keeping a reference to their field for labels.
+  const appliedChips = activeFilters.flatMap((f) => {
+    const field = filterFields.find((ff) => ff.key === f.fieldKey)
+    return f.values.map((value) => ({ fieldKey: f.fieldKey, field, value }))
+  })
+
+  // --- Button variant: single Filter button + applied-filter chips below ---
+  if (variant === 'button') {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          {showSearch && (
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-foreground/55 dark:text-foreground/40" />
+              <input
+                type="text"
+                value={searchValue}
+                onChange={(e) => onSearchChange?.(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && onSearchSubmit?.()}
+                placeholder={searchPlaceholder}
+                className="w-full rounded-lg border border-border bg-background/5 py-2.5 pl-10 pr-3 text-sm text-foreground placeholder:text-muted-foreground transition-all focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+          )}
+          {filterFields.length > 0 && (
+            <FilterButtonPanel
+              label={filterButtonLabel}
+              filterFields={filterFields}
+              activeFilters={activeFilters}
+              activeFilterCount={activeFilterCount}
+              onToggleValue={handleToggleValue}
+              onClearAll={handleClearAll}
+            />
+          )}
+          {extraFilters}
+        </div>
+
+        {appliedChips.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {appliedChips.map(({ fieldKey, field, value }) => (
+              <button
+                key={`${fieldKey}:${value}`}
+                onClick={() => field && handleToggleValue(field, value)}
+                className="flex items-center gap-1 rounded-full border border-primary/30 bg-primary/15 px-2.5 py-1 text-xs font-medium text-violet-950 transition-colors hover:bg-primary/25 dark:text-primary"
+              >
+                {field && <span className="text-foreground/60 dark:text-foreground/50">{field.label}:</span>}
+                <span>{value}</span>
+                <X className="h-3 w-3" />
+              </button>
+            ))}
+            <button
+              onClick={handleClearAll}
+              className="flex items-center gap-1 px-2 py-1 text-xs text-foreground/75 transition-colors hover:text-foreground dark:text-muted-foreground"
+            >
+              Clear all
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // --- Inline variant (default): one dropdown button per field ---
   return (
     <div className="space-y-2">
       {/* Search bar */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground/55 dark:text-foreground/40" />
-        <input
-          type="text"
-          value={searchValue}
-          onChange={(e) => onSearchChange(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && onSearchSubmit?.()}
-          placeholder={searchPlaceholder}
-          className="w-full pl-10 pr-3 py-2.5 bg-background/5 border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50 transition-all"
-        />
-      </div>
+      {showSearch && (
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground/55 dark:text-foreground/40" />
+          <input
+            type="text"
+            value={searchValue}
+            onChange={(e) => onSearchChange?.(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && onSearchSubmit?.()}
+            placeholder={searchPlaceholder}
+            className="w-full pl-10 pr-3 py-2.5 bg-background/5 border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50 transition-all"
+          />
+        </div>
+      )}
 
       {/* Filter dropdowns - always visible underneath */}
       {(filterFields.length > 0 || extraFilters) && (

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -42,7 +42,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-hidden data-[state=open]:overflow-visible text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     {...props}
   >
     <div className={cn('pb-4 pt-0', className)}>{children}</div>

--- a/src/pages/ApplicationConfirmationPage.tsx
+++ b/src/pages/ApplicationConfirmationPage.tsx
@@ -9,7 +9,8 @@ export default function ApplicationConfirmationPage() {
   const [eventSlug, setEventSlug] = useState('')
 
   useEffect(() => {
-    const code = searchParams.get('application_code')
+    // ticket_code is unique per registration; fall back to legacy application_code param
+    const code = searchParams.get('ticket_code') || searchParams.get('application_code')
     const event = searchParams.get('event')
 
     if (code) setApplicationCode(code)
@@ -38,12 +39,12 @@ export default function ApplicationConfirmationPage() {
           {/* Application Code */}
           {applicationCode && (
             <div className="bg-primary/10 dark:bg-primary/20/20 border border-primary/30 rounded-lg p-6 mb-8">
-              <p className="text-sm text-foreground/70 mb-2">Your Application Code</p>
+              <p className="text-sm text-foreground/70 mb-2">Your Ticket Code</p>
               <p className="text-2xl font-mono font-bold text-violet-900 dark:text-primary tracking-wider">
                 {applicationCode}
               </p>
               <p className="text-xs text-foreground/40 mt-2">
-                Save this code to track your application status
+                Save this code — it's your unique reference for this application
               </p>
             </div>
           )}

--- a/src/pages/VendorApplicationForm.tsx
+++ b/src/pages/VendorApplicationForm.tsx
@@ -364,10 +364,9 @@ export default function VendorApplicationForm() {
         clearFormData(formId)
       }
 
-      // Redirect to confirmation page with application code
-      navigate(
-        `/applications/success?application_code=${response.application_code}&event=${event.slug}`,
-      )
+      // Redirect to confirmation page with unique ticket code (falls back to shared application code)
+      const confirmationCode = response.ticket_code || response.application_code
+      navigate(`/applications/success?ticket_code=${confirmationCode}&event=${event.slug}`)
     } catch (err: any) {
       console.log('Failed to submit application:', err)
 


### PR DESCRIPTION
## What was broken

- **100-invitation cap:** `fetchApplicants()` hardcoded `page=1, per_page=100` for the invitation fetch. Events with >100 invited contacts (confirmed: Justin's Brooklyn show) silently truncated the list, causing wrong total counts and incorrect filter results.
- **Invited contacts in default view:** Invited-but-not-applied contacts inflated counts and confused status filters since they show as a separate status (`invited`) mixed in with actual applicants.
- **No export:** No way to download the applicant list.
- **Status label mismatches:** Dropdown options showed "New (Unreviewed)" and "Waitlist" while badges showed "New" and "Waitlisted".

## What changed

### `ApplicantsTab.tsx`
- **Pagination fix:** Added `fetchAllInvitations()` that loops through all pages using `meta.pagination.has_next_page`. Only runs when the invited toggle is on — avoids fetching thousands of contacts on every load.
- **Hide invited by default:** `showInvited` state (default `false`). Page 1 of invitations is always fetched for the count; full pagination only fires when the user toggles invited on.
- **Header redesign:** Search bar moved into the shared header row (removed duplicate search inputs from table view and focused view sidebar). Added "Invited (N)" toggle button and "Export" button.
- **Export modal:** Opens `ApplicantsExportModal` with the current `filteredApplicants` array — no backend endpoint needed.
- **Status labels:** "New (Unreviewed)" → "New", "Waitlist" → "Waitlisted" in all dropdowns (both table view and focused view).

### `ApplicantsExportModal.tsx` (new)
- Mirrors `ContactExportModal.tsx` from the Network tab exactly.
- 15 export columns: Name, Business Name, Email, Phone, Vendor Category, Status, Payment Status (default on); Location, Tags, Producer Notes, Applied At, Ticket Code, Instagram, TikTok, Website (optional).
- Client-side CSV generation using `csvEscape` / `formatIsoForCsv` / `triggerCsvDownload` from existing Network tab utilities.
- Downloads as `applicants-{eventSlug}-{date}.csv`.

## What to test

- [ ] Event with >100 invited contacts — toggle "Invited (N)", confirm all load (not capped at 100)
- [ ] Default view — invited contacts hidden, count shown in toggle button
- [ ] Filter by status (New, Approved, Waitlisted, etc.) — results match expected
- [ ] Export CSV — opens modal, column selection works, file downloads correctly
- [ ] Status dropdown labels match badge labels (New / Waitlisted)

## What's NOT in this PR

- Backend CSV export endpoint (not needed — client-side)
- Secondary email / email editing (future sprint)
- Email rate limiting (Beau's weekend work — on `dev`, not this branch)