### PR TITLE
fix: correct Paid filter — check payment_status not legacy confirmed status

### DIFF
--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -113,7 +113,7 @@ type StatusFilter =
   | 'invited'
   | 'pending'
   | 'approved'
-  | 'confirmed'
+  | 'paid'
   | 'waitlist'
   | 'rejected'
   | 'cancelled'
@@ -127,7 +127,7 @@ const STATUS_FILTER_OPTIONS: { value: Exclude<StatusFilter, 'all'>; label: strin
   { value: 'invited', label: 'Invited' },
   { value: 'pending', label: 'New' },
   { value: 'approved', label: 'Approved' },
-  { value: 'confirmed', label: 'Paid' },
+  { value: 'paid', label: 'Paid' },
   { value: 'waitlist', label: 'Waitlisted' },
   { value: 'rejected', label: 'Declined' },
   { value: 'opted_out', label: 'Opted Out' },
@@ -681,12 +681,6 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
           variant: 'tintGreen' as BadgeVariant,
           icon: CheckCircle,
         }
-      case 'confirmed':
-        return {
-          label: 'Paid',
-          variant: 'tintGreenDeep' as BadgeVariant,
-          icon: CheckCircle,
-        }
       case 'waitlist':
         return {
           label: 'Waitlisted',
@@ -774,6 +768,9 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
       if (statusFilter === 'opted_out') {
         // Merged group: "Opted Out" covers both opted_out and cancelled.
         if (applicant.status !== 'opted_out' && applicant.status !== 'cancelled') return false
+      } else if (statusFilter === 'paid') {
+        // "Paid" filters by payment_status — a vendor can be approved+paid regardless of status value.
+        if (applicant.payment_status !== 'paid' && applicant.payment_status !== 'confirmed') return false
       } else if (applicant.status !== statusFilter) {
         return false
       }

--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -676,6 +676,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
           icon: Clock,
         }
       case 'approved':
+      case 'confirmed': // legacy — confirm_payment! now sets status='approved'; treat as Approved
         return {
           label: 'Approved',
           variant: 'tintGreen' as BadgeVariant,


### PR DESCRIPTION
## Summary
- The Paid filter option mapped to `status='confirmed'` — a legacy value no longer written by current backend code (`confirm_payment!` sets `status='approved'` + `payment_status='confirmed'`)
- Result: Paid filter always returned 0 results in dev (caught by Ariel in QA)
- Fix: filter now checks `payment_status === 'paid' || payment_status === 'confirmed'`

## Root cause
`STATUS_FILTER_OPTIONS` had `{ value: 'confirmed', label: 'Paid' }` which compared against `applicant.status`. No active vendor has `status='confirmed'` so the filter was always empty.

## Test plan
- [ ] Filter by Paid → vendors with `payment_status='paid'` appear regardless of application status
- [ ] Filter by Approved → still works as before
- [ ] All other status filters unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)