### PR TITLE
hotfix: editable registration email with confirmation dialog

### DIFF
--- a/src/components/producer/ApplicantsTab.tsx
+++ b/src/components/producer/ApplicantsTab.tsx
@@ -718,6 +718,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
     patch: {
       contact_name: string
       phone: string
+      email?: string
       location?: string
       producer_notes?: string
       tags?: string[]
@@ -1955,7 +1956,7 @@ export default function ApplicantsTab({ eventSlug, event, isAdmin }: ApplicantsT
           initialInstagramHandle={selectedApplicant.instagram_handle}
           initialTiktokHandle={selectedApplicant.tiktok_handle}
           initialWebsite={selectedApplicant.website}
-          emailReadOnly={selectedApplicant.email}
+          initialEmail={selectedApplicant.email}
           onSaved={handleEditVendorSaved}
           initialAffiliation={selectedApplicant.affiliation}
         />

--- a/src/components/producer/EditVendorDetailsModal.tsx
+++ b/src/components/producer/EditVendorDetailsModal.tsx
@@ -6,6 +6,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -29,13 +39,14 @@ export interface EditVendorDetailsModalProps {
   initialTiktokHandle?: string
   initialWebsite?: string
   initialAffiliation?: string
-  /** Shown read-only — not in Rails `update_params` */
-  emailReadOnly: string
+  /** Initial email value — now editable by producers */
+  initialEmail: string
   onSaved: (
     applicantId: string,
     patch: {
       contact_name: string
       phone: string
+      email?: string
       location?: string
       producer_notes?: string
       tags?: string[]
@@ -60,12 +71,13 @@ export function EditVendorDetailsModal({
   initialInstagramHandle,
   initialTiktokHandle,
   initialWebsite,
-  emailReadOnly,
+  initialEmail,
   onSaved,
   initialAffiliation,
 }: EditVendorDetailsModalProps) {
   const [name, setName] = useState(initialContactName)
   const [phone, setPhone] = useState(initialPhone)
+  const [email, setEmail] = useState(initialEmail)
   const [location, setLocation] = useState(initialLocation || '')
   const [producerNotes, setProducerNotes] = useState(initialProducerNotes || '')
   const [tags, setTags] = useState<string[]>(initialTags || [])
@@ -76,11 +88,15 @@ export function EditVendorDetailsModal({
   const [affiliation, setAffiliation] = useState(initialAffiliation || '')
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
+  const [showEmailConfirm, setShowEmailConfirm] = useState(false)
+
+  const emailChanged = email.trim().toLowerCase() !== initialEmail.trim().toLowerCase()
 
   useEffect(() => {
     if (open) {
       setName(initialContactName)
       setPhone(initialPhone || '')
+      setEmail(initialEmail)
       setLocation(initialLocation || '')
       setProducerNotes(initialProducerNotes || '')
       setTags(initialTags || [])
@@ -90,11 +106,13 @@ export function EditVendorDetailsModal({
       setWebsite(initialWebsite || '')
       setAffiliation(initialAffiliation || '')
       setFormError(null)
+      setShowEmailConfirm(false)
     }
   }, [
     open,
     initialContactName,
     initialPhone,
+    initialEmail,
     initialLocation,
     initialProducerNotes,
     initialTags,
@@ -125,11 +143,18 @@ export function EditVendorDetailsModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (emailChanged) {
+      setShowEmailConfirm(true)
+      return
+    }
+    await doSave()
+  }
+
+  const doSave = async () => {
     setFormError(null)
     setSaving(true)
     try {
-      // Send all fields to API, including empty values (to allow clearing)
-      await registrationsApi.update(registrationId, {
+      const payload: Record<string, unknown> = {
         name: name.trim(),
         phone: phone.trim(),
         location: location.trim(),
@@ -139,8 +164,12 @@ export function EditVendorDetailsModal({
         tiktok_handle: tiktokHandle.trim(),
         website: website.trim(),
         affiliation: affiliation.trim(),
-      })
-      onSaved(applicantId, {
+      }
+      if (emailChanged) {
+        payload.email = email.trim()
+      }
+      await registrationsApi.update(registrationId, payload)
+      const patch: Parameters<typeof onSaved>[1] = {
         contact_name: name.trim(),
         phone: phone.trim(),
         location: location.trim(),
@@ -150,7 +179,11 @@ export function EditVendorDetailsModal({
         tiktok_handle: tiktokHandle.trim(),
         website: website.trim(),
         affiliation: affiliation.trim(),
-      })
+      }
+      if (emailChanged) {
+        patch.email = email.trim()
+      }
+      onSaved(applicantId, patch)
       onOpenChange(false)
     } catch (err) {
       if (err instanceof ApiError && err.errors?.length) {
@@ -183,9 +216,11 @@ export function EditVendorDetailsModal({
               </Label>
               <Input
                 id="edit-vendor-email"
-                value={emailReadOnly}
-                disabled
-                className="bg-background/10 border-border text-xs opacity-80"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="bg-background/5 border-border text-xs"
+                required
               />
             </div>
             <div className="space-y-1.5">
@@ -362,6 +397,33 @@ export function EditVendorDetailsModal({
           </DialogFooter>
         </form>
       </DialogContent>
+
+      {/* Email change confirmation dialog */}
+      <AlertDialog open={showEmailConfirm} onOpenChange={setShowEmailConfirm}>
+        <AlertDialogContent className="border-border bg-muted">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-foreground">Change applicant email?</AlertDialogTitle>
+            <AlertDialogDescription className="text-foreground/70">
+              You&apos;re changing this applicant&apos;s email from{' '}
+              <span className="font-medium text-foreground">{initialEmail}</span> to{' '}
+              <span className="font-medium text-foreground">{email.trim()}</span>.
+              All future communications for this event will go to the new address.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="border-border">Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="voxxy-btn-solid"
+              onClick={() => {
+                setShowEmailConfirm(false)
+                doSave()
+              }}
+            >
+              Confirm change
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   )
 }


### PR DESCRIPTION
## Summary
- Makes email field editable in EditVendorDetailsModal (was previously disabled/read-only)
- Shows confirmation AlertDialog when email is changed: warns that all future communications go to the new address
- Only sends email in PATCH payload when actually changed (no-op otherwise)
- Pairs with backend PR: https://github.com/Voxxy-AI/voxxy-rails-react/pull/188

## Changes
- **EditVendorDetailsModal.tsx**: `emailReadOnly` prop → `initialEmail`, added email state + confirmation dialog, split save into handleSubmit/doSave
- **ApplicantsTab.tsx**: Updated prop name and patch type to include `email?`

## Test plan
- [ ] Open Edit Vendor Details modal — email field is now editable
- [ ] Change email, click Save — confirmation dialog appears with old/new emails
- [ ] Click Cancel in dialog — no save, modal stays open
- [ ] Click Confirm — saves successfully, email updates in table
- [ ] Change to duplicate email (same event) — backend returns validation error
- [ ] Edit other fields without changing email — saves normally, no dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing registration email affects automated notifications and identity matching; the UI gates on confirmation but relies on paired backend validation (e.g. duplicate email per event).
> 
> **Overview**
> Producers can **edit applicant email** in **Edit vendor details** instead of a read-only field. **`emailReadOnly`** is replaced with **`initialEmail`**, and **`ApplicantsTab`** passes **`initialEmail`** and can apply an optional **`email`** in the save patch so the list/detail view updates after save.
> 
> Saving when the email changed (case-insensitive) opens an **`AlertDialog`** that shows old vs new and warns that **future event communications** go to the new address; confirm runs the actual save. **`email`** is included in **`registrationsApi.update`** and **`onSaved`** only when it changed; other field edits save without the dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a45b5c801e15b4b8df3b7ed515463d84935d708. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->