### PR TITLE
feat: CSV import UX overhaul — column mapping, preview editing, virtualized table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.0",
         "@sentry/react": "^10.40.0",
+        "@tanstack/react-virtual": "^3.14.6",
         "@tiptap/extension-link": "^2.11.4",
         "@tiptap/pm": "^2.11.4",
         "@tiptap/react": "^2.11.4",
@@ -3157,6 +3158,33 @@
       "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.0",
     "@sentry/react": "^10.40.0",
+    "@tanstack/react-virtual": "^3.14.6",
     "@tiptap/extension-link": "^2.11.4",
     "@tiptap/pm": "^2.11.4",
     "@tiptap/react": "^2.11.4",

--- a/src/components/producer/Email/EmailEditorPage.tsx
+++ b/src/components/producer/Email/EmailEditorPage.tsx
@@ -719,7 +719,7 @@ export function EmailEditorPage({
       if (
         !eventData &&
         !varName.match(
-          /\[firstName\]|\[lastName\]|\[fullName\]|\[greetingName\]|\[businessName\]|\[email\]|\[vendorCategory\]|\[boothNumber\]|\[applicationDate\]|\[installDate\]|\[installTime\]|\[installStartTime\]|\[installEndTime\]/,
+          /\[firstName\]|\[lastName\]|\[fullName\]|\[greetingName\]|\[businessName\]|\[affiliation\]|\[ticketCode\]|\[email\]|\[vendorCategory\]|\[boothNumber\]|\[applicationDate\]|\[installDate\]|\[installTime\]|\[installStartTime\]|\[installEndTime\]/,
         )
       ) {
         return varName // No event data, return as-is

--- a/src/components/producer/Network/CSVUploadModal.tsx
+++ b/src/components/producer/Network/CSVUploadModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo } from 'react'
+import { useMemo, useCallback } from 'react'
 import Papa from 'papaparse'
 import {
   Dialog,
@@ -7,30 +7,23 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Checkbox } from '@/components/ui/checkbox'
+import { Loader2 } from 'lucide-react'
+import { vendorContactsApi, contactListsApi } from '@/services/api'
+
+import { useImportState } from './csvImport/useImportState'
+import { autoDetectMappings, buildImportRows } from './csvImport/columnMapping'
+import { validateAllRows, revalidateRow } from './csvImport/clientValidation'
+import { prepareSubmission } from './csvImport/csvRewriter'
+import { RECOGNIZED_FIELD_KEYS } from './csvImport/constants'
+import type { CSVUploadModalProps } from './csvImport/types'
+
+import { StepUpload } from './csvImport/StepUpload'
+import { StepColumnMapping } from './csvImport/StepColumnMapping'
+import { StepPreviewEdit } from './csvImport/StepPreviewEdit'
+import { StepValidationResult } from './csvImport/StepValidationResult'
+import { StepReviewLists } from './csvImport/StepReviewLists'
+
 import {
-  Upload,
-  Download,
-  FileText,
-  CheckCircle2,
-  XCircle,
-  AlertCircle,
-  Loader2,
-} from 'lucide-react'
-import { vendorContactsApi, contactListsApi, BulkImportResult } from '@/services/api'
-import { downloadCSVTemplate, downloadErrorReport } from '@/utils/csvTemplateGenerator'
-import {
-  CONTACTS_ALWAYS_IN_ALL,
-  LISTS_FROM_TAGS,
-  PRIMARY_TAG_HELPER,
-  TAGS_ARE_LABELS,
-} from './copy'
-import {
-  type ImportSession,
   buildImportSession,
   countTagsFromRows,
   defaultListNameForTag,
@@ -39,240 +32,182 @@ import {
   parseTagsFromValue,
 } from './importSession'
 
-interface CSVUploadModalProps {
-  open: boolean
-  onClose: () => void
-  onSuccess: (session: ImportSession) => void
-  organizationId: number
-}
-
-type UploadState =
-  | 'idle'
-  | 'file_selected'
-  | 'validating'
-  | 'server_validating'
-  | 'validated'
-  | 'uploading'
-  | 'review_lists'
-  | 'creating_lists'
-  | 'error'
-
-interface CSVPreviewData {
-  headers: string[]
-  rows: Record<string, string>[]
-  totalRows: number
-}
-
-interface ListDraft {
-  tag: string
-  name: string
-  checked: boolean
-}
-
 export function CSVUploadModal({
   open,
   onClose,
   onSuccess,
   organizationId,
 }: CSVUploadModalProps) {
-  const [state, setState] = useState<UploadState>('idle')
-  const [selectedFile, setSelectedFile] = useState<File | null>(null)
-  const [previewData, setPreviewData] = useState<CSVPreviewData | null>(null)
-  const [fullCsvRows, setFullCsvRows] = useState<Record<string, string>[]>([])
-  const [skipDuplicates, setSkipDuplicates] = useState(true)
-  const [updateExisting, setUpdateExisting] = useState(false)
-  const [bulkTags, setBulkTags] = useState('')
-  const [errorMessage, setErrorMessage] = useState('')
-  const [importResult, setImportResult] = useState<BulkImportResult | null>(null)
-  const [validationResult, setValidationResult] = useState<BulkImportResult | null>(null)
-  const [listDrafts, setListDrafts] = useState<ListDraft[]>([])
-  const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const requiredHeaders = ['name', 'email']
-  const optionalHeaders = [
-    'phone',
-    'affiliation',
-    'instagram_handle',
-    'tiktok_handle',
-    'website',
-    'location',
-    'tags',
-  ]
-  const hiddenPreviewColumns = ['notes', 'featured', 'status', 'job_title', 'job title']
+  const { state, dispatch, reset } = useImportState()
 
   const discoveredTags = useMemo(
-    () => discoverTagsFromRows(fullCsvRows, parseTagsFromValue(bulkTags)),
-    [fullCsvRows, bulkTags],
+    () => discoverTagsFromRows(state.rawRows, parseTagsFromValue(state.bulkTags)),
+    [state.rawRows, state.bulkTags],
   )
 
-  const primaryTag = getPrimaryTag(bulkTags)
+  const primaryTag = getPrimaryTag(state.bulkTags)
 
   const tagCounts = useMemo(
-    () => countTagsFromRows(fullCsvRows, parseTagsFromValue(bulkTags)),
-    [fullCsvRows, bulkTags],
+    () => countTagsFromRows(state.rawRows, parseTagsFromValue(state.bulkTags)),
+    [state.rawRows, state.bulkTags],
   )
 
-  const initListDrafts = (tags: string[]) => {
-    const primary = getPrimaryTag(bulkTags)
-    setListDrafts(
-      tags.map((tag) => ({
-        tag,
-        name: defaultListNameForTag(tag),
-        checked: tag === primary,
-      })),
-    )
-  }
+  const visibleFields = useMemo(
+    () =>
+      state.columnMappings
+        .filter((m) => m.mappedTo !== null && RECOGNIZED_FIELD_KEYS.includes(m.mappedTo!))
+        .map((m) => m.mappedTo!),
+    [state.columnMappings],
+  )
 
-  const handleFileSelect = (file: File) => {
-    if (!file.name.endsWith('.csv')) {
-      setErrorMessage('Please select a CSV file')
-      setState('error')
-      return
-    }
+  // ─── Handlers ────────────────────────────────────────────────────
 
-    setSelectedFile(file)
-    setState('validating')
-    setErrorMessage('')
-    setFullCsvRows([])
+  const handleFileSelect = useCallback(
+    (file: File) => {
+      if (!file.name.endsWith('.csv')) {
+        dispatch({ type: 'ERROR', message: 'Please select a CSV file' })
+        return
+      }
 
-    Papa.parse(file, {
-      header: true,
-      skipEmptyLines: true,
-      transformHeader: (header: string) =>
-        header
-          .trim()
-          .toLowerCase()
-          .replace(/^\uFEFF/, ''),
-      preview: 10,
-      complete: (results) => {
-        const headers = results.meta.fields || []
-        const normalizedHeaders = headers.map((h) => h.replace(/\s+/g, '_'))
-        const missingHeaders = requiredHeaders.filter((h) => !normalizedHeaders.includes(h))
-        if (missingHeaders.length > 0) {
-          setErrorMessage(
-            `Missing required columns: ${missingHeaders.join(', ')}. Found columns: ${headers.join(', ')}`,
-          )
-          setState('error')
-          return
-        }
+      Papa.parse(file, {
+        header: true,
+        skipEmptyLines: true,
+        transformHeader: (h: string) =>
+          h.trim().toLowerCase().replace(/^\uFEFF/, ''),
+        complete: (results) => {
+          const headers = results.meta.fields || []
+          const rows = results.data as Record<string, string>[]
 
-        Papa.parse(file, {
-          header: true,
-          skipEmptyLines: true,
-          transformHeader: (header: string) =>
-            header
-              .trim()
-              .toLowerCase()
-              .replace(/^\uFEFF/, ''),
-          complete: (fullResults) => {
-            const allRows = fullResults.data as Record<string, string>[]
-            setFullCsvRows(allRows)
-            setPreviewData({
-              headers,
-              rows: results.data as Record<string, string>[],
-              totalRows: allRows.length,
-            })
-            setState('file_selected')
-          },
-          error: (fullError) => {
-            setErrorMessage(`Failed to parse CSV: ${fullError.message}`)
-            setState('error')
-          },
-        })
-      },
-      error: (error) => {
-        setErrorMessage(`Failed to parse CSV: ${error.message}`)
-        setState('error')
-      },
-    })
-  }
+          dispatch({ type: 'FILE_PARSED', file, headers, rows })
 
-  const handleFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    e.stopPropagation()
-    const file = e.dataTransfer.files[0]
-    if (file) handleFileSelect(file)
-  }
+          // Auto-detect column mappings
+          const mappings = autoDetectMappings(headers, rows)
+          dispatch({ type: 'SET_COLUMN_MAPPINGS', mappings })
+        },
+        error: (error) => {
+          dispatch({ type: 'ERROR', message: `Failed to parse CSV: ${error.message}` })
+        },
+      })
+    },
+    [dispatch],
+  )
 
-  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (file) handleFileSelect(file)
-  }
+  const handleConfirmMappings = useCallback(() => {
+    const importRows = buildImportRows(state.rawRows, state.columnMappings)
+    validateAllRows(importRows)
+    dispatch({ type: 'CONFIRM_MAPPINGS', importRows })
+  }, [state.rawRows, state.columnMappings, dispatch])
 
-  const getImportTags = () => parseTagsFromValue(bulkTags)
+  const handleEditCell = useCallback(
+    (rowIndex: number, fieldKey: string, value: string) => {
+      dispatch({ type: 'EDIT_CELL', rowIndex, fieldKey, value })
 
-  const handleValidate = async () => {
-    if (!selectedFile) return
-    setState('server_validating')
-    setErrorMessage('')
+      // Re-validate the edited row
+      const updatedRow = { ...state.importRows[rowIndex], [fieldKey]: value }
+      const { errors, status } = revalidateRow(updatedRow)
+      dispatch({ type: 'UPDATE_ROW_ERRORS', rowIndex, errors, status })
+    },
+    [state.importRows, dispatch],
+  )
+
+  const handleValidate = useCallback(async () => {
+    if (!state.file) return
+    dispatch({ type: 'SERVER_VALIDATING' })
 
     try {
-      const result = await vendorContactsApi.bulkImport(selectedFile, {
-        skipDuplicates,
-        updateExisting,
-        tags: getImportTags(),
+      const { file, columnMapping } = prepareSubmission(
+        state.file,
+        state.columnMappings,
+        state.importRows,
+        state.cellsEdited,
+      )
+
+      const result = await vendorContactsApi.bulkImport(file, {
+        skipDuplicates: state.skipDuplicates,
+        updateExisting: state.updateExisting,
+        tags: parseTagsFromValue(state.bulkTags),
         validateOnly: true,
+        columnMapping: columnMapping ?? undefined,
       })
-      setValidationResult(result)
-      setState('validated')
+      dispatch({ type: 'VALIDATION_COMPLETE', result })
     } catch (error) {
-      setErrorMessage(
-        error instanceof Error
-          ? error.message
-          : 'Validation failed. Please check your file and try again.',
-      )
-      setState('error')
+      dispatch({
+        type: 'ERROR',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Validation failed. Please check your file and try again.',
+      })
     }
-  }
+  }, [state, dispatch])
 
-  const handleUpload = async () => {
-    if (!selectedFile) return
-    setState('uploading')
-    setErrorMessage('')
+  const handleImport = useCallback(async () => {
+    if (!state.file) return
+    dispatch({ type: 'UPLOADING' })
 
     try {
-      const result = await vendorContactsApi.bulkImport(selectedFile, {
-        skipDuplicates,
-        updateExisting,
-        tags: getImportTags(),
-      })
-      setImportResult(result)
-      initListDrafts(discoveredTags)
-      setState('review_lists')
-    } catch (error) {
-      setErrorMessage(
-        error instanceof Error
-          ? error.message
-          : 'Upload failed. Please check your file and try again.',
+      const { file, columnMapping } = prepareSubmission(
+        state.file,
+        state.columnMappings,
+        state.importRows,
+        state.cellsEdited,
       )
-      setState('error')
+
+      const result = await vendorContactsApi.bulkImport(file, {
+        skipDuplicates: state.skipDuplicates,
+        updateExisting: state.updateExisting,
+        tags: parseTagsFromValue(state.bulkTags),
+        columnMapping: columnMapping ?? undefined,
+      })
+      dispatch({ type: 'UPLOAD_COMPLETE', result })
+
+      // Initialize list drafts
+      const primary = getPrimaryTag(state.bulkTags)
+      dispatch({
+        type: 'SET_LIST_DRAFTS',
+        drafts: discoveredTags.map((tag) => ({
+          tag,
+          name: defaultListNameForTag(tag),
+          checked: tag === primary,
+        })),
+      })
+    } catch (error) {
+      dispatch({
+        type: 'ERROR',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Upload failed. Please check your file and try again.',
+      })
     }
-  }
+  }, [state, dispatch, discoveredTags])
 
-  const finishImport = (listsCreated: string[]) => {
-    const summary = importResult?.summary
-    const session = buildImportSession({
-      created: summary?.created ?? 0,
-      updated: summary?.updated ?? 0,
-      tags: discoveredTags,
-      primaryTag,
-      listsCreated,
-      tagCounts,
-    })
-    onSuccess(session)
-    handleClose()
-  }
+  const finishImport = useCallback(
+    (listsCreated: string[]) => {
+      const summary = state.importResult?.summary
+      const session = buildImportSession({
+        created: summary?.created ?? 0,
+        updated: summary?.updated ?? 0,
+        tags: discoveredTags,
+        primaryTag,
+        listsCreated,
+        tagCounts,
+      })
+      onSuccess(session)
+      reset()
+      onClose()
+    },
+    [state.importResult, discoveredTags, primaryTag, tagCounts, onSuccess, reset, onClose],
+  )
 
-  const handleSkipLists = () => finishImport([])
-
-  const handleCreateLists = async () => {
-    const selected = listDrafts.filter((d) => d.checked && d.name.trim())
+  const handleCreateLists = useCallback(async () => {
+    const selected = state.listDrafts.filter((d) => d.checked && d.name.trim())
     if (selected.length === 0) {
       finishImport([])
       return
     }
 
-    setState('creating_lists')
+    dispatch({ type: 'SET_LIST_DRAFTS', drafts: state.listDrafts }) // keep state while creating
     try {
       await Promise.all(
         selected.map((draft) =>
@@ -285,431 +220,132 @@ export function CSVUploadModal({
       )
       finishImport(selected.map((d) => d.name.trim()))
     } catch (error) {
-      setErrorMessage(
-        error instanceof Error ? error.message : 'Failed to create one or more lists.',
-      )
-      setState('review_lists')
+      dispatch({
+        type: 'ERROR',
+        message: error instanceof Error ? error.message : 'Failed to create one or more lists.',
+      })
     }
-  }
-
-  const handleReset = () => {
-    setState('idle')
-    setSelectedFile(null)
-    setPreviewData(null)
-    setFullCsvRows([])
-    setImportResult(null)
-    setValidationResult(null)
-    setListDrafts([])
-    setErrorMessage('')
-    setBulkTags('')
-    if (fileInputRef.current) fileInputRef.current.value = ''
-  }
+  }, [state.listDrafts, organizationId, finishImport, dispatch])
 
   const handleClose = () => {
-    handleReset()
+    reset()
     onClose()
   }
 
-  const renderIdleState = () => (
-    <div className="space-y-3">
-      <Alert>
-        <FileText className="h-3.5 w-3.5" />
-        <AlertDescription className="text-xs">
-          First time importing?{' '}
-          <button
-            onClick={downloadCSVTemplate}
-            className="font-medium text-primary hover:underline"
-          >
-            Download our CSV template
-          </button>{' '}
-          to get started.
-        </AlertDescription>
-      </Alert>
+  // ─── Render ──────────────────────────────────────────────────────
 
-      <div
-        onDrop={handleFileDrop}
-        onDragOver={(e) => e.preventDefault()}
-        className="border-2 border-dashed border-primary/40 bg-background/5 rounded-lg p-6 text-center hover:border-primary hover:bg-background/10 transition-all cursor-pointer"
-        onClick={() => fileInputRef.current?.click()}
-      >
-        <Upload className="mx-auto h-8 w-8 text-primary" />
-        <p className="mt-1.5 text-xs text-foreground/80">
-          Drag and drop your CSV file here, or click to browse
-        </p>
-        <p className="mt-0.5 text-[11px] text-foreground/50">CSV files only</p>
-      </div>
+  const renderStep = () => {
+    switch (state.step) {
+      case 'idle':
+        return <StepUpload onFileSelect={handleFileSelect} errorMessage={state.errorMessage} />
 
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept=".csv"
-        onChange={handleFileInputChange}
-        className="hidden"
-      />
-    </div>
-  )
-
-  const renderFileSelectedState = () => (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2 px-3 py-2 bg-background/5 border border-primary/20 rounded-lg">
-        <FileText className="h-3.5 w-3.5 text-primary shrink-0" />
-        <span className="text-xs text-foreground/90 truncate">
-          <strong>{selectedFile?.name}</strong> — {previewData?.totalRows} contacts
-        </span>
-      </div>
-
-      {(() => {
-        const visibleHeaders =
-          previewData?.headers.filter((h) => !hiddenPreviewColumns.includes(h.toLowerCase())) || []
+      case 'parsing':
         return (
-          <div className="border border-primary/20 rounded-lg overflow-hidden bg-background/5">
-            <div className="bg-primary/10 px-3 py-1.5 border-b border-primary/20">
-              <h4 className="text-[11px] font-medium text-foreground/70 uppercase tracking-wide">
-                Preview (first 10 rows)
-              </h4>
-            </div>
-            <div className="overflow-x-auto max-h-[40vh]">
-              <table className="w-full text-[11px]">
-                <thead className="bg-background/5 sticky top-0">
-                  <tr>
-                    {visibleHeaders.map((header) => (
-                      <th
-                        key={header}
-                        className="px-2 py-1 text-left font-medium text-foreground/80 border-b border-primary/20 whitespace-nowrap"
-                      >
-                        <div className="flex items-center gap-1">
-                          <span className="truncate max-w-[100px]" title={header}>
-                            {header}
-                          </span>
-                          {requiredHeaders.includes(header) && (
-                            <span className="text-red-400">*</span>
-                          )}
-                        </div>
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {previewData?.rows.map((row, idx) => (
-                    <tr key={idx} className="border-b border-primary/10 hover:bg-background/5">
-                      {visibleHeaders.map((header) => (
-                        <td key={header} className="px-2 py-1 text-foreground/60">
-                          <div className="truncate max-w-[150px]" title={row[header] || ''}>
-                            {row[header] || <span className="text-foreground/30">—</span>}
-                          </div>
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+          <div className="flex justify-center py-6">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" />
           </div>
         )
-      })()}
 
-      <div className="space-y-2">
-        <div className="flex items-end gap-3 max-w-md">
-          <div className="flex-1">
-            <Label htmlFor="bulk-tags" className="text-[11px] text-foreground/70 mb-1 block">
-              Primary tag for this import
-            </Label>
-            <Input
-              id="bulk-tags"
-              placeholder="e.g., Seattle, Oklahoma City"
-              value={bulkTags}
-              onChange={(e) => setBulkTags(e.target.value)}
-              className="h-8 text-xs"
-            />
-            <p className="text-[10px] text-foreground/50 mt-1">{PRIMARY_TAG_HELPER}</p>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Button onClick={handleValidate} size="sm" className="text-xs h-8">
-            Validate {previewData?.totalRows} Contacts
-          </Button>
-          <Button variant="outline" onClick={handleReset} size="sm" className="text-xs h-8">
-            Choose Different File
-          </Button>
-        </div>
-      </div>
-    </div>
-  )
+      case 'column_mapping':
+        return (
+          <StepColumnMapping
+            fileName={state.file?.name ?? ''}
+            totalRows={state.rawRows.length}
+            mappings={state.columnMappings}
+            onUpdateMapping={(idx, mappedTo) =>
+              dispatch({ type: 'UPDATE_COLUMN_MAPPING', index: idx, mappedTo })
+            }
+            onConfirm={handleConfirmMappings}
+            onBack={reset}
+          />
+        )
 
-  const renderUploadingState = () => (
-    <div className="flex flex-col items-center justify-center py-8">
-      <Loader2 className="h-8 w-8 animate-spin text-primary mb-3" />
-      <p className="text-sm font-medium">Importing contacts...</p>
-      <p className="text-xs text-foreground/50 mt-1">This may take a moment for large files</p>
-    </div>
-  )
+      case 'preview_editing':
+        return (
+          <StepPreviewEdit
+            fileName={state.file?.name ?? ''}
+            rows={state.importRows}
+            visibleFields={visibleFields}
+            bulkTags={state.bulkTags}
+            onEditCell={handleEditCell}
+            onToggleSkip={(idx) => dispatch({ type: 'TOGGLE_ROW_SKIP', rowIndex: idx })}
+            onSetBulkTags={(tags) => dispatch({ type: 'SET_BULK_TAGS', tags })}
+            onValidate={handleValidate}
+            onBack={() => dispatch({ type: 'SET_COLUMN_MAPPINGS', mappings: state.columnMappings })}
+          />
+        )
 
-  const renderCreatingListsState = () => (
-    <div className="flex flex-col items-center justify-center py-8">
-      <Loader2 className="h-8 w-8 animate-spin text-primary mb-3" />
-      <p className="text-sm font-medium">Creating lists...</p>
-    </div>
-  )
-
-  const renderReviewListsState = () => {
-    const created = importResult?.summary.created ?? 0
-    const updated = importResult?.summary.updated ?? 0
-    const importedTotal = created + updated
-
-    return (
-      <div className="space-y-4">
-        <div className="text-center py-1">
-          <CheckCircle2 className="h-7 w-7 text-green-400 mx-auto mb-2" />
-          <h3 className="text-sm font-semibold text-foreground">Review & Create Lists</h3>
-          <p className="text-xs text-foreground/60 mt-1">Contacts imported successfully</p>
-          <p className="text-[11px] text-foreground/50 mt-1">
-            You can also save filters later from All Contacts.
-          </p>
-        </div>
-
-        <ul className="text-xs text-foreground/70 space-y-1 list-disc list-inside bg-background/5 rounded-lg p-3 border border-border">
-          <li>{CONTACTS_ALWAYS_IN_ALL}</li>
-          <li>{TAGS_ARE_LABELS}</li>
-          <li>{LISTS_FROM_TAGS}</li>
-        </ul>
-
-        <p className="text-xs text-foreground/80 text-center">
-          You just imported: <strong>{importedTotal}</strong> contact
-          {importedTotal === 1 ? '' : 's'}
-          {updated > 0 && (
-            <span className="text-foreground/60">
-              {' '}
-              ({created} created, {updated} updated)
-            </span>
-          )}
-        </p>
-
-        {discoveredTags.length > 0 && (
-          <div>
-            <p className="text-[11px] font-medium text-foreground/70 mb-2">
-              New or updated tags found:{' '}
-              <span className="font-normal text-foreground/80">{discoveredTags.join(', ')}</span>
+      case 'server_validating':
+        return (
+          <div className="flex flex-col items-center justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-primary mb-3" />
+            <p className="text-sm font-medium">Validating contacts...</p>
+            <p className="text-xs text-foreground/50 mt-1">
+              Checking for errors before importing
             </p>
           </div>
-        )}
+        )
 
-        {listDrafts.length > 0 && (
-          <div className="space-y-2">
-            <p className="text-[11px] font-medium text-foreground/70">Create lists from tags</p>
-            <div className="space-y-2 max-h-48 overflow-y-auto border border-border rounded-lg p-2">
-              {listDrafts.map((draft, index) => (
-                <div
-                  key={draft.tag}
-                  className="flex items-start gap-2 p-2 rounded-md bg-background/5"
-                >
-                  <Checkbox
-                    id={`list-draft-${draft.tag}`}
-                    checked={draft.checked}
-                    onCheckedChange={(checked) => {
-                      setListDrafts((prev) =>
-                        prev.map((d, i) => (i === index ? { ...d, checked: !!checked } : d)),
-                      )
-                    }}
-                    className="mt-1"
-                  />
-                  <div className="flex-1 min-w-0">
-                    <label
-                      htmlFor={`list-draft-${draft.tag}`}
-                      className="text-[11px] text-foreground/80 block mb-1 cursor-pointer"
-                    >
-                      Create a list &lsquo;{draft.name}&rsquo; (tag = {draft.tag})
-                    </label>
-                    <Input
-                      value={draft.name}
-                      onChange={(e) => {
-                        const value = e.target.value
-                        setListDrafts((prev) =>
-                          prev.map((d, i) => (i === index ? { ...d, name: value } : d)),
-                        )
-                      }}
-                      className="h-7 text-xs"
-                      disabled={!draft.checked}
-                      aria-label={`List name for tag ${draft.tag}`}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
+      case 'validated':
+        return state.validationResult ? (
+          <StepValidationResult
+            result={state.validationResult}
+            discoveredTags={discoveredTags}
+            onImport={handleImport}
+            onBack={handleConfirmMappings}
+          />
+        ) : null
+
+      case 'uploading':
+        return (
+          <div className="flex flex-col items-center justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-primary mb-3" />
+            <p className="text-sm font-medium">Importing contacts...</p>
+            <p className="text-xs text-foreground/50 mt-1">
+              This may take a moment for large files
+            </p>
           </div>
-        )}
+        )
 
-        {importResult && importResult.errors.length > 0 && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-3.5 w-3.5" />
-            <AlertDescription className="text-[11px]">
-              {importResult.errors.length} row(s) had errors during import.
-            </AlertDescription>
-          </Alert>
-        )}
+      case 'review_lists':
+        return state.importResult ? (
+          <StepReviewLists
+            importResult={state.importResult}
+            discoveredTags={discoveredTags}
+            listDrafts={state.listDrafts}
+            onUpdateDraft={(idx, changes) =>
+              dispatch({ type: 'UPDATE_LIST_DRAFT', index: idx, changes })
+            }
+            onCreateLists={handleCreateLists}
+            onSkipLists={() => finishImport([])}
+          />
+        ) : null
 
-        <div className="flex justify-between pt-1">
-          <Button variant="outline" onClick={handleSkipLists} size="sm" className="text-xs h-8">
-            Skip for now
-          </Button>
-          <Button onClick={handleCreateLists} size="sm" className="text-xs h-8">
-            {listDrafts.some((d) => d.checked)
-              ? 'Create lists & finish'
-              : 'Finish'}
-          </Button>
-        </div>
-      </div>
-    )
-  }
-
-  const renderServerValidatingState = () => (
-    <div className="flex flex-col items-center justify-center py-8">
-      <Loader2 className="h-8 w-8 animate-spin text-primary mb-3" />
-      <p className="text-sm font-medium">Validating contacts...</p>
-      <p className="text-xs text-foreground/50 mt-1">Checking for errors before importing</p>
-    </div>
-  )
-
-  const renderValidatedState = () => {
-    const hasErrors = (validationResult?.errors.length || 0) > 0
-    const wouldCreate = validationResult?.summary.would_create || 0
-    const wouldUpdate = validationResult?.summary.would_update || 0
-    const wouldSkip = validationResult?.summary.would_skip || 0
-    const failed = validationResult?.summary.failed || 0
-
-    return (
-      <div className="space-y-3">
-        <div className="flex items-center gap-2 justify-center py-2">
-          {hasErrors ? (
-            <AlertCircle className="h-6 w-6 text-yellow-400" />
-          ) : (
-            <CheckCircle2 className="h-6 w-6 text-green-400" />
-          )}
-          <h3 className="text-sm font-semibold text-foreground">
-            {hasErrors ? 'Validation Found Issues' : 'Validation Passed'}
-          </h3>
-        </div>
-
-        {discoveredTags.length > 0 && (
-          <p className="text-xs text-foreground/70 text-center">
-            Tags found in this file:{' '}
-            <span className="text-foreground">{discoveredTags.join(', ')}</span>
-          </p>
-        )}
-
-        <div className="grid grid-cols-2 gap-2">
-          {wouldCreate > 0 && (
-            <div className="border border-green-500/30 bg-green-500/10 rounded-lg p-2.5 text-center">
-              <div className="text-lg font-bold text-green-400">{wouldCreate}</div>
-              <div className="text-[11px] text-foreground/60">Will be created</div>
-            </div>
-          )}
-          {wouldUpdate > 0 && (
-            <div className="border border-blue-500/30 bg-blue-500/10 rounded-lg p-2.5 text-center">
-              <div className="text-lg font-bold text-blue-400">{wouldUpdate}</div>
-              <div className="text-[11px] text-foreground/60">Will be updated</div>
-            </div>
-          )}
-          {wouldSkip > 0 && (
-            <div className="border border-yellow-500/30 bg-yellow-500/10 rounded-lg p-2.5 text-center">
-              <div className="text-lg font-bold text-yellow-400">{wouldSkip}</div>
-              <div className="text-[11px] text-foreground/60">Duplicates (skipped)</div>
-            </div>
-          )}
-          {failed > 0 && (
-            <div className="border border-red-500/30 bg-red-500/10 rounded-lg p-2.5 text-center">
-              <div className="text-lg font-bold text-red-400">{failed}</div>
-              <div className="text-[11px] text-foreground/60">Invalid rows</div>
-            </div>
-          )}
-        </div>
-
-        {hasErrors && validationResult && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-3.5 w-3.5" />
-            <AlertDescription>
-              <div className="space-y-1.5">
-                <p className="text-xs font-medium">
-                  {validationResult.errors.length} row(s) have errors and will be skipped:
-                </p>
-                <div className="max-h-24 overflow-y-auto text-[11px] space-y-0.5">
-                  {validationResult.errors.slice(0, 5).map((error, idx) => (
-                    <div key={idx}>
-                      Row {error.row}: {error.message}
-                    </div>
-                  ))}
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => downloadErrorReport(validationResult.errors)}
-                  className="mt-1 h-7 text-[11px]"
-                >
-                  <Download className="h-3 w-3 mr-1.5" />
-                  Download Error Report
-                </Button>
-              </div>
-            </AlertDescription>
-          </Alert>
-        )}
-
-        <div className="flex justify-between pt-1">
-          <Button variant="outline" onClick={handleReset} size="sm" className="text-xs h-8">
-            Fix &amp; Re-upload
-          </Button>
-          <Button onClick={handleUpload} size="sm" className="text-xs h-8">
-            {hasErrors
-              ? `Import Anyway (${wouldCreate + wouldUpdate} valid)`
-              : `Import ${wouldCreate + wouldUpdate} Contacts`}
-          </Button>
-        </div>
-      </div>
-    )
-  }
-
-  const renderErrorState = () => (
-    <div className="space-y-3">
-      <Alert variant="destructive">
-        <XCircle className="h-3.5 w-3.5" />
-        <AlertDescription>
-          <div className="space-y-1.5">
-            <p className="text-xs font-medium">Import Failed</p>
-            <p className="text-xs">{errorMessage}</p>
+      case 'creating_lists':
+        return (
+          <div className="flex flex-col items-center justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-primary mb-3" />
+            <p className="text-sm font-medium">Creating lists...</p>
           </div>
-        </AlertDescription>
-      </Alert>
-      <div className="flex justify-end">
-        <Button onClick={handleReset} size="sm" className="text-xs h-8">
-          Try Again
-        </Button>
-      </div>
-    </div>
-  )
+        )
+
+      default:
+        return null
+    }
+  }
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="voxxy-modal-surface max-h-[85vh] w-[95vw] max-w-5xl overflow-y-auto p-5">
         <DialogHeader className="mb-2">
-          <DialogTitle className="text-base text-foreground">Import Contacts from CSV</DialogTitle>
+          <DialogTitle className="text-base text-foreground">
+            Import Contacts from CSV
+          </DialogTitle>
           <DialogDescription className="text-foreground/60 text-xs">
             Upload a CSV file to bulk import vendor contacts into All Contacts
           </DialogDescription>
         </DialogHeader>
-
-        <div>
-          {state === 'idle' && renderIdleState()}
-          {state === 'validating' && (
-            <div className="flex justify-center py-6">
-              <Loader2 className="h-6 w-6 animate-spin text-primary" />
-            </div>
-          )}
-          {state === 'file_selected' && renderFileSelectedState()}
-          {state === 'server_validating' && renderServerValidatingState()}
-          {state === 'validated' && renderValidatedState()}
-          {state === 'uploading' && renderUploadingState()}
-          {state === 'review_lists' && renderReviewListsState()}
-          {state === 'creating_lists' && renderCreatingListsState()}
-          {state === 'error' && renderErrorState()}
-        </div>
+        <div>{renderStep()}</div>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/producer/Network/CSVUploadModal.tsx
+++ b/src/components/producer/Network/CSVUploadModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useState } from 'react'
 import Papa from 'papaparse'
 import {
   Dialog,
@@ -7,6 +7,16 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Loader2 } from 'lucide-react'
 import { vendorContactsApi, contactListsApi } from '@/services/api'
 
@@ -14,7 +24,7 @@ import { useImportState } from './csvImport/useImportState'
 import { autoDetectMappings, buildImportRows } from './csvImport/columnMapping'
 import { validateAllRows, revalidateRow } from './csvImport/clientValidation'
 import { prepareSubmission } from './csvImport/csvRewriter'
-import { RECOGNIZED_FIELD_KEYS } from './csvImport/constants'
+import { RECOGNIZED_FIELD_KEYS, MERGE_FIELDS } from './csvImport/constants'
 import type { CSVUploadModalProps } from './csvImport/types'
 
 import { StepUpload } from './csvImport/StepUpload'
@@ -40,25 +50,36 @@ export function CSVUploadModal({
 }: CSVUploadModalProps) {
   const { state, dispatch, reset } = useImportState()
 
+  // Use importRows (canonical field keys) when available, rawRows as fallback
+  const tagSourceRows = state.importRows.length > 0
+    ? (state.importRows as unknown as Record<string, string>[])
+    : state.rawRows
+
   const discoveredTags = useMemo(
-    () => discoverTagsFromRows(state.rawRows, parseTagsFromValue(state.bulkTags)),
-    [state.rawRows, state.bulkTags],
+    () => discoverTagsFromRows(tagSourceRows, parseTagsFromValue(state.bulkTags)),
+    [tagSourceRows, state.bulkTags],
   )
 
   const primaryTag = getPrimaryTag(state.bulkTags)
 
   const tagCounts = useMemo(
-    () => countTagsFromRows(state.rawRows, parseTagsFromValue(state.bulkTags)),
-    [state.rawRows, state.bulkTags],
+    () => countTagsFromRows(tagSourceRows, parseTagsFromValue(state.bulkTags)),
+    [tagSourceRows, state.bulkTags],
   )
 
-  const visibleFields = useMemo(
-    () =>
-      state.columnMappings
-        .filter((m) => m.mappedTo !== null && RECOGNIZED_FIELD_KEYS.includes(m.mappedTo!))
-        .map((m) => m.mappedTo!),
-    [state.columnMappings],
-  )
+  const visibleFields = useMemo(() => {
+    const fields = state.columnMappings
+      .filter((m) => m.mappedTo !== null && RECOGNIZED_FIELD_KEYS.includes(m.mappedTo!))
+      .map((m) => m.mappedTo!)
+    // If name was created via merge (first_name+last_name), ensure it appears
+    const hasMerge = state.columnMappings.some(
+      (m) => m.mappedTo !== null && MERGE_FIELDS[m.mappedTo!] !== undefined,
+    )
+    if (hasMerge && !fields.includes('name')) {
+      fields.unshift('name')
+    }
+    return fields
+  }, [state.columnMappings])
 
   // ─── Handlers ────────────────────────────────────────────────────
 
@@ -104,8 +125,8 @@ export function CSVUploadModal({
 
       // Re-validate the edited row
       const updatedRow = { ...state.importRows[rowIndex], [fieldKey]: value }
-      const { errors, status } = revalidateRow(updatedRow)
-      dispatch({ type: 'UPDATE_ROW_ERRORS', rowIndex, errors, status })
+      const { errors, warnings, status } = revalidateRow(updatedRow)
+      dispatch({ type: 'UPDATE_ROW_ERRORS', rowIndex, errors, warnings, status })
     },
     [state.importRows, dispatch],
   )
@@ -227,9 +248,28 @@ export function CSVUploadModal({
     }
   }, [state.listDrafts, organizationId, finishImport, dispatch])
 
+  const [confirmExitOpen, setConfirmExitOpen] = useState(false)
+
+  // Steps where the user has meaningful work in progress that would be lost on close.
+  const SAFE_TO_EXIT_STEPS = new Set(['idle', 'review_lists', 'creating_lists'])
+  const hasActiveWork = !SAFE_TO_EXIT_STEPS.has(state.step)
+
   const handleClose = () => {
     reset()
     onClose()
+  }
+
+  const handleAttemptClose = (requestedOpen: boolean) => {
+    if (!requestedOpen && hasActiveWork) {
+      setConfirmExitOpen(true)
+      return
+    }
+    if (!requestedOpen) handleClose()
+  }
+
+  const handleConfirmExit = () => {
+    setConfirmExitOpen(false)
+    handleClose()
   }
 
   // ─── Render ──────────────────────────────────────────────────────
@@ -252,8 +292,8 @@ export function CSVUploadModal({
             fileName={state.file?.name ?? ''}
             totalRows={state.rawRows.length}
             mappings={state.columnMappings}
-            onUpdateMapping={(idx, mappedTo) =>
-              dispatch({ type: 'UPDATE_COLUMN_MAPPING', index: idx, mappedTo })
+            onAssignField={(fieldKey, csvHeader) =>
+              dispatch({ type: 'ASSIGN_FIELD', fieldKey, csvHeader })
             }
             onConfirm={handleConfirmMappings}
             onBack={reset}
@@ -292,7 +332,7 @@ export function CSVUploadModal({
             result={state.validationResult}
             discoveredTags={discoveredTags}
             onImport={handleImport}
-            onBack={handleConfirmMappings}
+            onBack={() => dispatch({ type: 'GO_TO_PREVIEW' })}
           />
         ) : null
 
@@ -335,18 +375,49 @@ export function CSVUploadModal({
   }
 
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="voxxy-modal-surface max-h-[85vh] w-[95vw] max-w-5xl overflow-y-auto p-5">
-        <DialogHeader className="mb-2">
-          <DialogTitle className="text-base text-foreground">
-            Import Contacts from CSV
-          </DialogTitle>
-          <DialogDescription className="text-foreground/60 text-xs">
-            Upload a CSV file to bulk import vendor contacts into All Contacts
-          </DialogDescription>
-        </DialogHeader>
-        <div>{renderStep()}</div>
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog open={open} onOpenChange={handleAttemptClose}>
+        <DialogContent
+          className="voxxy-modal-surface voxxy-modal-workspace"
+          onInteractOutside={(e) => {
+            if (hasActiveWork) e.preventDefault()
+          }}
+          onEscapeKeyDown={(e) => {
+            if (hasActiveWork) e.preventDefault()
+          }}
+        >
+          <DialogHeader className="mb-2">
+            <DialogTitle className="text-base text-foreground">
+              Import Contacts from CSV
+            </DialogTitle>
+            <DialogDescription className="text-foreground/60 text-xs">
+              Upload a CSV file to bulk import vendor contacts into All Contacts
+            </DialogDescription>
+          </DialogHeader>
+          <div>{renderStep()}</div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmExitOpen} onOpenChange={setConfirmExitOpen}>
+        <AlertDialogContent className="voxxy-modal-surface max-w-sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-base">Leave import?</AlertDialogTitle>
+            <AlertDialogDescription className="text-xs">
+              Your progress will be lost — the uploaded file and any edits you've made won't be
+              saved.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="text-xs h-8">Stay</AlertDialogCancel>
+            <AlertDialogAction
+              className="text-xs h-8 bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleConfirmExit}
+            >
+              Leave anyway
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }

--- a/src/components/producer/Network/csvImport/EditableCell.tsx
+++ b/src/components/producer/Network/csvImport/EditableCell.tsx
@@ -1,17 +1,23 @@
 import { useState, useRef, useEffect } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface EditableCellProps {
   value: string
   fieldKey: string
+  /** Blocking issues — row cannot be imported until fixed or skipped */
   errors?: string[]
+  /** Non-blocking formatting issues — row will be skipped on import unless fixed */
+  warnings?: string[]
   onCommit: (value: string) => void
 }
 
-export function EditableCell({ value, fieldKey, errors, onCommit }: EditableCellProps) {
+export function EditableCell({ value, fieldKey, errors, warnings, onCommit }: EditableCellProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(value)
   const inputRef = useRef<HTMLInputElement>(null)
-  const hasErrors = errors && errors.length > 0
+  const hasErrors = !!errors && errors.length > 0
+  const hasWarnings = !!warnings && warnings.length > 0
+  const hasIssues = hasErrors || hasWarnings
 
   useEffect(() => {
     if (editing && inputRef.current) {
@@ -47,30 +53,73 @@ export function EditableCell({ value, fieldKey, errors, onCommit }: EditableCell
         className={`w-full px-1.5 py-0.5 text-[11px] rounded border bg-background/80 outline-none ${
           hasErrors
             ? 'border-red-500/60 focus:border-red-400'
-            : 'border-primary/30 focus:border-primary'
+            : hasWarnings
+              ? 'border-yellow-500/60 focus:border-yellow-400'
+              : 'border-primary/30 focus:border-primary'
         }`}
         aria-label={`Edit ${fieldKey}`}
       />
     )
   }
 
-  return (
+  const cell = (
     <div
       className={`truncate cursor-pointer px-1 py-0.5 rounded transition-colors hover:bg-background/10 ${
-        hasErrors ? 'text-red-300' : ''
+        hasErrors
+          ? 'text-red-300 bg-red-500/10'
+          : hasWarnings
+            ? 'text-yellow-300 bg-yellow-500/10'
+            : ''
       }`}
       onClick={() => {
         setDraft(value)
         setEditing(true)
       }}
-      title={hasErrors ? errors.join('; ') : value || undefined}
+      title={value || undefined}
     >
       {value || <span className="text-foreground/25">—</span>}
       {hasErrors && (
-        <span className="ml-1 text-[9px] text-red-400" aria-label="Validation error">
-          !
+        <span className="ml-1 text-[9px] text-red-400" aria-label="Blocking error">
+          ●
+        </span>
+      )}
+      {!hasErrors && hasWarnings && (
+        <span className="ml-1 text-[9px] text-yellow-400" aria-label="Warning">
+          ●
         </span>
       )}
     </div>
+  )
+
+  if (!hasIssues) return cell
+
+  const borderColor = hasErrors ? '#ef4444' : '#eab308'
+
+  return (
+    <Tooltip delayDuration={150}>
+      <TooltipTrigger asChild>{cell}</TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        avoidCollisions
+        collisionPadding={8}
+        style={{
+          background: '#ffffff',
+          border: `1px solid ${borderColor}`,
+          color: '#111111',
+          zIndex: 9999,
+        }}
+        className="max-w-xs shadow-2xl"
+      >
+        <ul className="text-[11px] space-y-0.5 list-disc list-inside">
+          {(errors ?? []).map((err, idx) => (
+            <li key={`e-${idx}`} style={{ color: '#dc2626' }}>{err}</li>
+          ))}
+          {(warnings ?? []).map((warn, idx) => (
+            <li key={`w-${idx}`} style={{ color: '#854d0e' }}>{warn}</li>
+          ))}
+        </ul>
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/src/components/producer/Network/csvImport/EditableCell.tsx
+++ b/src/components/producer/Network/csvImport/EditableCell.tsx
@@ -1,0 +1,76 @@
+import { useState, useRef, useEffect } from 'react'
+
+interface EditableCellProps {
+  value: string
+  fieldKey: string
+  errors?: string[]
+  onCommit: (value: string) => void
+}
+
+export function EditableCell({ value, fieldKey, errors, onCommit }: EditableCellProps) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const hasErrors = errors && errors.length > 0
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [editing])
+
+  const commit = () => {
+    setEditing(false)
+    if (draft !== value) {
+      onCommit(draft)
+    }
+  }
+
+  const cancel = () => {
+    setEditing(false)
+    setDraft(value)
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') commit()
+          if (e.key === 'Escape') cancel()
+        }}
+        className={`w-full px-1.5 py-0.5 text-[11px] rounded border bg-background/80 outline-none ${
+          hasErrors
+            ? 'border-red-500/60 focus:border-red-400'
+            : 'border-primary/30 focus:border-primary'
+        }`}
+        aria-label={`Edit ${fieldKey}`}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={`truncate cursor-pointer px-1 py-0.5 rounded transition-colors hover:bg-background/10 ${
+        hasErrors ? 'text-red-300' : ''
+      }`}
+      onClick={() => {
+        setDraft(value)
+        setEditing(true)
+      }}
+      title={hasErrors ? errors.join('; ') : value || undefined}
+    >
+      {value || <span className="text-foreground/25">—</span>}
+      {hasErrors && (
+        <span className="ml-1 text-[9px] text-red-400" aria-label="Validation error">
+          !
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/StepColumnMapping.tsx
+++ b/src/components/producer/Network/csvImport/StepColumnMapping.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, AlertCircle, MinusCircle } from 'lucide-react'
+import { CheckCircle2 } from 'lucide-react'
 import {
   Select,
   SelectContent,
@@ -8,150 +8,125 @@ import {
 } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
 import type { ColumnMapping } from './types'
-import { RECOGNIZED_FIELDS, FIELD_LABELS } from './constants'
+import { RECOGNIZED_FIELDS } from './constants'
 import { isNameMapped } from './columnMapping'
 
 interface StepColumnMappingProps {
   fileName: string
   totalRows: number
   mappings: ColumnMapping[]
-  onUpdateMapping: (index: number, mappedTo: string | null) => void
+  onAssignField: (fieldKey: string, csvHeader: string | null) => void
   onConfirm: () => void
   onBack: () => void
 }
+
+const NONE_VALUE = '__none__'
 
 export function StepColumnMapping({
   fileName,
   totalRows,
   mappings,
-  onUpdateMapping,
+  onAssignField,
   onConfirm,
   onBack,
 }: StepColumnMappingProps) {
-  const mapped = mappings.filter((m) => m.mappedTo !== null)
-  const unmapped = mappings.filter((m) => m.mappedTo === null)
   const nameMapped = isNameMapped(mappings)
   const emailMapped = mappings.some((m) => m.mappedTo === 'email')
-
-  // Get already-claimed field keys to prevent double-mapping
-  const claimedFields = new Set(mappings.filter((m) => m.mappedTo).map((m) => m.mappedTo!))
+  const unusedColumns = mappings.filter((m) => m.mappedTo === null)
 
   return (
     <div className="space-y-4">
       {/* File info */}
-      <div className="flex items-center justify-between px-3 py-2 bg-background/5 border border-primary/20 rounded-lg">
-        <span className="text-xs text-foreground/90">
+      <div className="flex flex-wrap items-center justify-between gap-1 px-3 py-2 bg-background/5 border border-primary/20 rounded-lg">
+        <span className="text-xs text-foreground/90 break-words">
           <strong>{fileName}</strong> — {totalRows} rows, {mappings.length} columns
         </span>
-      </div>
-
-      {/* Summary bar */}
-      <div className="flex items-center gap-3 text-[11px] text-foreground/70">
-        <span className="text-green-400">{mapped.length} mapped</span>
-        <span className="text-foreground/40">·</span>
-        {unmapped.length > 0 && (
-          <>
-            <span className="text-yellow-400">{unmapped.length} skipped</span>
-            <span className="text-foreground/40">·</span>
-          </>
-        )}
-        <span>{mappings.length} total columns</span>
       </div>
 
       {/* Validation warnings */}
       {!nameMapped && (
         <div className="flex items-center gap-2 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg">
-          <AlertCircle className="h-3.5 w-3.5 text-red-400 shrink-0" />
           <span className="text-xs text-red-300">
-            <strong>Name</strong> column is required. Map a column to &quot;Name&quot; to continue.
+            <strong>Name</strong> is required. Choose a CSV column for it below to continue.
           </span>
         </div>
       )}
-      {nameMapped && !emailMapped && (
-        <div className="flex items-center gap-2 px-3 py-2 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
-          <AlertCircle className="h-3.5 w-3.5 text-yellow-400 shrink-0" />
-          <span className="text-xs text-yellow-300">
-            No <strong>Email</strong> column mapped. Contacts without emails cannot receive messages.
+      {!emailMapped && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <span className="text-xs text-red-300">
+            <strong>Email</strong> is required — it&apos;s the unique identifier used to match
+            existing contacts and reach imported ones. Choose a CSV column for it below to continue.
           </span>
         </div>
       )}
 
-      {/* Column mapping list */}
-      <div className="space-y-2 max-h-[45vh] overflow-y-auto pr-1">
-        {mappings.map((mapping, index) => {
-          const icon =
-            mapping.mappedTo !== null ? (
-              <CheckCircle2 className="h-4 w-4 text-green-400 shrink-0" />
-            ) : (
-              <MinusCircle className="h-4 w-4 text-foreground/30 shrink-0" />
-            )
+      {/* Field mapping table */}
+      <div className="border border-border rounded-lg overflow-hidden">
+        <div className="grid grid-cols-[minmax(100px,1.2fr)_28px_minmax(140px,1fr)_minmax(140px,1.6fr)] items-center gap-2 px-3 py-1.5 bg-primary/10 border-b border-primary/20 text-[10px] font-semibold uppercase tracking-wide text-foreground/60">
+          <span>Field</span>
+          <span />
+          <span>CSV Column</span>
+          <span>Example Data</span>
+        </div>
 
-          return (
-            <div
-              key={mapping.csvHeader}
-              className="flex items-center gap-3 px-3 py-2 bg-background/5 border border-border rounded-lg"
-            >
-              {icon}
+        <div className="divide-y divide-border max-h-[45vh] overflow-y-auto">
+          {RECOGNIZED_FIELDS.map((field) => {
+            const assigned = mappings.find((m) => m.mappedTo === field.key)
 
-              {/* CSV header name + samples */}
-              <div className="flex-1 min-w-0">
-                <p className="text-xs font-medium text-foreground truncate">
-                  {mapping.csvHeader}
-                </p>
-                {mapping.sampleValues.length > 0 && (
-                  <p className="text-[10px] text-foreground/50 truncate">
-                    {mapping.sampleValues.slice(0, 3).join(' · ')}
-                  </p>
-                )}
-              </div>
-
-              {/* Dropdown */}
-              <Select
-                value={mapping.mappedTo ?? '__skip__'}
-                onValueChange={(val) =>
-                  onUpdateMapping(index, val === '__skip__' ? null : val)
-                }
+            return (
+              <div
+                key={field.key}
+                className="grid grid-cols-[minmax(100px,1.2fr)_28px_minmax(140px,1fr)_minmax(140px,1.6fr)] items-center gap-2 px-3 py-2"
               >
-                <SelectTrigger className="w-40 h-8 text-xs">
-                  <SelectValue placeholder="Skip column" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__skip__">
-                    <span className="text-foreground/50">Skip column</span>
-                  </SelectItem>
-                  {RECOGNIZED_FIELDS.map((field) => {
-                    const disabled =
-                      claimedFields.has(field.key) && mapping.mappedTo !== field.key
-                    return (
-                      <SelectItem
-                        key={field.key}
-                        value={field.key}
-                        disabled={disabled}
-                      >
-                        {field.label}
-                        {field.required && ' *'}
-                      </SelectItem>
-                    )
-                  })}
-                </SelectContent>
-              </Select>
-
-              {/* Confidence badge */}
-              {mapping.mappedTo !== null && mapping.confidence !== 'exact' && (
-                <span
-                  className={`text-[9px] px-1.5 py-0.5 rounded ${
-                    mapping.confidence === 'alias'
-                      ? 'bg-blue-500/20 text-blue-300'
-                      : 'bg-yellow-500/20 text-yellow-300'
-                  }`}
-                >
-                  {mapping.confidence}
+                <span className="text-xs text-foreground/90 truncate">
+                  {field.label}
+                  {field.required && <span className="text-red-400"> *</span>}
                 </span>
-              )}
-            </div>
-          )
-        })}
+
+                <span className="flex justify-center">
+                  {assigned && <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />}
+                </span>
+
+                <Select
+                  value={assigned?.csvHeader ?? NONE_VALUE}
+                  onValueChange={(val) =>
+                    onAssignField(field.key, val === NONE_VALUE ? null : val)
+                  }
+                >
+                  <SelectTrigger className="h-8 text-xs">
+                    <SelectValue placeholder="Select column" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NONE_VALUE}>
+                      <span className="text-foreground/50">Select column</span>
+                    </SelectItem>
+                    {mappings.map((m) => {
+                      const disabled = m.mappedTo !== null && m.mappedTo !== field.key
+                      return (
+                        <SelectItem key={m.csvHeader} value={m.csvHeader} disabled={disabled}>
+                          {m.csvHeader}
+                        </SelectItem>
+                      )
+                    })}
+                  </SelectContent>
+                </Select>
+
+                <span className="text-[10px] text-foreground/50 truncate">
+                  {assigned?.sampleValues.length ? assigned.sampleValues.slice(0, 3).join('; ') : '—'}
+                </span>
+              </div>
+            )
+          })}
+        </div>
       </div>
+
+      {/* Unused columns note */}
+      {unusedColumns.length > 0 && (
+        <p className="text-[10px] text-foreground/40 truncate">
+          {unusedColumns.length} column{unusedColumns.length !== 1 ? 's' : ''} not mapped to a field
+          will be ignored: {unusedColumns.map((m) => m.csvHeader).join(', ')}
+        </p>
+      )}
 
       {/* Actions */}
       <div className="flex justify-between pt-1">
@@ -162,7 +137,7 @@ export function StepColumnMapping({
           onClick={onConfirm}
           size="sm"
           className="text-xs h-8"
-          disabled={!nameMapped}
+          disabled={!nameMapped || !emailMapped}
         >
           Continue to Preview
         </Button>

--- a/src/components/producer/Network/csvImport/StepColumnMapping.tsx
+++ b/src/components/producer/Network/csvImport/StepColumnMapping.tsx
@@ -1,0 +1,172 @@
+import { CheckCircle2, AlertCircle, MinusCircle } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import type { ColumnMapping } from './types'
+import { RECOGNIZED_FIELDS, FIELD_LABELS } from './constants'
+import { isNameMapped } from './columnMapping'
+
+interface StepColumnMappingProps {
+  fileName: string
+  totalRows: number
+  mappings: ColumnMapping[]
+  onUpdateMapping: (index: number, mappedTo: string | null) => void
+  onConfirm: () => void
+  onBack: () => void
+}
+
+export function StepColumnMapping({
+  fileName,
+  totalRows,
+  mappings,
+  onUpdateMapping,
+  onConfirm,
+  onBack,
+}: StepColumnMappingProps) {
+  const mapped = mappings.filter((m) => m.mappedTo !== null)
+  const unmapped = mappings.filter((m) => m.mappedTo === null)
+  const nameMapped = isNameMapped(mappings)
+  const emailMapped = mappings.some((m) => m.mappedTo === 'email')
+
+  // Get already-claimed field keys to prevent double-mapping
+  const claimedFields = new Set(mappings.filter((m) => m.mappedTo).map((m) => m.mappedTo!))
+
+  return (
+    <div className="space-y-4">
+      {/* File info */}
+      <div className="flex items-center justify-between px-3 py-2 bg-background/5 border border-primary/20 rounded-lg">
+        <span className="text-xs text-foreground/90">
+          <strong>{fileName}</strong> — {totalRows} rows, {mappings.length} columns
+        </span>
+      </div>
+
+      {/* Summary bar */}
+      <div className="flex items-center gap-3 text-[11px] text-foreground/70">
+        <span className="text-green-400">{mapped.length} mapped</span>
+        <span className="text-foreground/40">·</span>
+        {unmapped.length > 0 && (
+          <>
+            <span className="text-yellow-400">{unmapped.length} skipped</span>
+            <span className="text-foreground/40">·</span>
+          </>
+        )}
+        <span>{mappings.length} total columns</span>
+      </div>
+
+      {/* Validation warnings */}
+      {!nameMapped && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <AlertCircle className="h-3.5 w-3.5 text-red-400 shrink-0" />
+          <span className="text-xs text-red-300">
+            <strong>Name</strong> column is required. Map a column to &quot;Name&quot; to continue.
+          </span>
+        </div>
+      )}
+      {nameMapped && !emailMapped && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+          <AlertCircle className="h-3.5 w-3.5 text-yellow-400 shrink-0" />
+          <span className="text-xs text-yellow-300">
+            No <strong>Email</strong> column mapped. Contacts without emails cannot receive messages.
+          </span>
+        </div>
+      )}
+
+      {/* Column mapping list */}
+      <div className="space-y-2 max-h-[45vh] overflow-y-auto pr-1">
+        {mappings.map((mapping, index) => {
+          const icon =
+            mapping.mappedTo !== null ? (
+              <CheckCircle2 className="h-4 w-4 text-green-400 shrink-0" />
+            ) : (
+              <MinusCircle className="h-4 w-4 text-foreground/30 shrink-0" />
+            )
+
+          return (
+            <div
+              key={mapping.csvHeader}
+              className="flex items-center gap-3 px-3 py-2 bg-background/5 border border-border rounded-lg"
+            >
+              {icon}
+
+              {/* CSV header name + samples */}
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-medium text-foreground truncate">
+                  {mapping.csvHeader}
+                </p>
+                {mapping.sampleValues.length > 0 && (
+                  <p className="text-[10px] text-foreground/50 truncate">
+                    {mapping.sampleValues.slice(0, 3).join(' · ')}
+                  </p>
+                )}
+              </div>
+
+              {/* Dropdown */}
+              <Select
+                value={mapping.mappedTo ?? '__skip__'}
+                onValueChange={(val) =>
+                  onUpdateMapping(index, val === '__skip__' ? null : val)
+                }
+              >
+                <SelectTrigger className="w-40 h-8 text-xs">
+                  <SelectValue placeholder="Skip column" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__skip__">
+                    <span className="text-foreground/50">Skip column</span>
+                  </SelectItem>
+                  {RECOGNIZED_FIELDS.map((field) => {
+                    const disabled =
+                      claimedFields.has(field.key) && mapping.mappedTo !== field.key
+                    return (
+                      <SelectItem
+                        key={field.key}
+                        value={field.key}
+                        disabled={disabled}
+                      >
+                        {field.label}
+                        {field.required && ' *'}
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+
+              {/* Confidence badge */}
+              {mapping.mappedTo !== null && mapping.confidence !== 'exact' && (
+                <span
+                  className={`text-[9px] px-1.5 py-0.5 rounded ${
+                    mapping.confidence === 'alias'
+                      ? 'bg-blue-500/20 text-blue-300'
+                      : 'bg-yellow-500/20 text-yellow-300'
+                  }`}
+                >
+                  {mapping.confidence}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between pt-1">
+        <Button variant="outline" onClick={onBack} size="sm" className="text-xs h-8">
+          Choose Different File
+        </Button>
+        <Button
+          onClick={onConfirm}
+          size="sm"
+          className="text-xs h-8"
+          disabled={!nameMapped}
+        >
+          Continue to Preview
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/StepPreviewEdit.tsx
+++ b/src/components/producer/Network/csvImport/StepPreviewEdit.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { AlertCircle, ArrowDown } from 'lucide-react'
+import type { ImportRow } from './types'
+import { FIELD_LABELS } from './constants'
+import { VirtualizedImportTable } from './VirtualizedImportTable'
+import { PRIMARY_TAG_HELPER } from '../copy'
+
+interface StepPreviewEditProps {
+  fileName: string
+  rows: ImportRow[]
+  visibleFields: string[]
+  bulkTags: string
+  onEditCell: (rowIndex: number, fieldKey: string, value: string) => void
+  onToggleSkip: (rowIndex: number) => void
+  onSetBulkTags: (tags: string) => void
+  onValidate: () => void
+  onBack: () => void
+}
+
+export function StepPreviewEdit({
+  fileName,
+  rows,
+  visibleFields,
+  bulkTags,
+  onEditCell,
+  onToggleSkip,
+  onSetBulkTags,
+  onValidate,
+  onBack,
+}: StepPreviewEditProps) {
+  const errorRowRef = useRef<HTMLDivElement | null>(null)
+
+  const stats = useMemo(() => {
+    let valid = 0
+    let errors = 0
+    let skipped = 0
+    let errorRowCount = 0
+
+    for (const row of rows) {
+      if (row._skipped) {
+        skipped++
+        continue
+      }
+      if (row._status === 'error') {
+        errors += Object.values(row._errors).reduce((sum, arr) => sum + arr.length, 0)
+        errorRowCount++
+      } else {
+        valid++
+      }
+    }
+    return { valid, errors, errorRowCount, skipped, total: rows.length }
+  }, [rows])
+
+  const jumpToNextError = () => {
+    errorRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* File + stats bar */}
+      <div className="flex items-center justify-between px-3 py-2 bg-background/5 border border-primary/20 rounded-lg text-[11px]">
+        <span className="text-foreground/90">
+          <strong>{fileName}</strong>
+        </span>
+        <div className="flex items-center gap-3 text-foreground/70">
+          <span className="text-green-400">{stats.valid} valid</span>
+          {stats.errorRowCount > 0 && (
+            <span className="text-red-400">
+              {stats.errors} error{stats.errors !== 1 ? 's' : ''} in {stats.errorRowCount} row
+              {stats.errorRowCount !== 1 ? 's' : ''}
+            </span>
+          )}
+          {stats.skipped > 0 && (
+            <span className="text-foreground/50">{stats.skipped} skipped</span>
+          )}
+        </div>
+      </div>
+
+      {/* Error jump */}
+      {stats.errorRowCount > 0 && (
+        <button
+          onClick={jumpToNextError}
+          className="flex items-center gap-1.5 text-[11px] text-red-400 hover:text-red-300 transition-colors"
+        >
+          <ArrowDown className="h-3 w-3" />
+          Jump to first error
+        </button>
+      )}
+
+      {/* Click-to-edit hint */}
+      <p className="text-[10px] text-foreground/40">
+        Click any cell to edit. Check &quot;Skip&quot; to exclude a row.{' '}
+        {visibleFields.map((f) => FIELD_LABELS[f] || f).join(', ')}
+      </p>
+
+      {/* Virtualized table */}
+      <VirtualizedImportTable
+        rows={rows}
+        visibleFields={visibleFields}
+        onEditCell={onEditCell}
+        onToggleSkip={onToggleSkip}
+        errorRowRef={errorRowRef}
+      />
+
+      {/* Bulk tags */}
+      <div className="flex items-end gap-3 max-w-md">
+        <div className="flex-1">
+          <Label htmlFor="bulk-tags" className="text-[11px] text-foreground/70 mb-1 block">
+            Primary tag for this import
+          </Label>
+          <Input
+            id="bulk-tags"
+            placeholder="e.g., Seattle, Oklahoma City"
+            value={bulkTags}
+            onChange={(e) => onSetBulkTags(e.target.value)}
+            className="h-8 text-xs"
+          />
+          <p className="text-[10px] text-foreground/50 mt-1">{PRIMARY_TAG_HELPER}</p>
+        </div>
+      </div>
+
+      {/* Large file warning */}
+      {rows.length >= 5000 && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+          <AlertCircle className="h-3.5 w-3.5 text-yellow-400 shrink-0" />
+          <span className="text-[11px] text-yellow-300">
+            Large file ({rows.length.toLocaleString()} rows).
+            {rows.length >= 10000 && ' Consider splitting into smaller files for best results.'}
+          </span>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex justify-between pt-1">
+        <Button variant="outline" onClick={onBack} size="sm" className="text-xs h-8">
+          Back to Mapping
+        </Button>
+        <Button
+          onClick={onValidate}
+          size="sm"
+          className="text-xs h-8"
+          disabled={stats.valid === 0}
+        >
+          Validate {stats.valid} Contact{stats.valid !== 1 ? 's' : ''}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/StepPreviewEdit.tsx
+++ b/src/components/producer/Network/csvImport/StepPreviewEdit.tsx
@@ -4,7 +4,6 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { AlertCircle, ArrowDown } from 'lucide-react'
 import type { ImportRow } from './types'
-import { FIELD_LABELS } from './constants'
 import { VirtualizedImportTable } from './VirtualizedImportTable'
 import { PRIMARY_TAG_HELPER } from '../copy'
 
@@ -35,23 +34,29 @@ export function StepPreviewEdit({
 
   const stats = useMemo(() => {
     let valid = 0
-    let errors = 0
+    let warningRowCount = 0
     let skipped = 0
     let errorRowCount = 0
+    let firstError = -1
 
-    for (const row of rows) {
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i]
       if (row._skipped) {
         skipped++
         continue
       }
       if (row._status === 'error') {
-        errors += Object.values(row._errors).reduce((sum, arr) => sum + arr.length, 0)
         errorRowCount++
+        if (firstError === -1) firstError = i
+      } else if (row._status === 'warning') {
+        warningRowCount++
       } else {
         valid++
       }
     }
-    return { valid, errors, errorRowCount, skipped, total: rows.length }
+    // Anything not blocking and not skipped can be imported
+    const importable = valid + warningRowCount
+    return { valid, warningRowCount, errorRowCount, skipped, importable, total: rows.length, firstErrorIndex: firstError }
   }, [rows])
 
   const jumpToNextError = () => {
@@ -61,16 +66,20 @@ export function StepPreviewEdit({
   return (
     <div className="space-y-3">
       {/* File + stats bar */}
-      <div className="flex items-center justify-between px-3 py-2 bg-background/5 border border-primary/20 rounded-lg text-[11px]">
-        <span className="text-foreground/90">
+      <div className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 bg-background/5 border border-primary/20 rounded-lg text-[11px]">
+        <span className="text-foreground/90 truncate max-w-[40%]">
           <strong>{fileName}</strong>
         </span>
-        <div className="flex items-center gap-3 text-foreground/70">
+        <div className="flex items-center gap-3 text-foreground/70 flex-wrap">
           <span className="text-green-400">{stats.valid} valid</span>
+          {stats.warningRowCount > 0 && (
+            <span className="text-yellow-400">
+              {stats.warningRowCount} warning{stats.warningRowCount !== 1 ? 's' : ''}
+            </span>
+          )}
           {stats.errorRowCount > 0 && (
             <span className="text-red-400">
-              {stats.errors} error{stats.errors !== 1 ? 's' : ''} in {stats.errorRowCount} row
-              {stats.errorRowCount !== 1 ? 's' : ''}
+              {stats.errorRowCount} blocking
             </span>
           )}
           {stats.skipped > 0 && (
@@ -86,14 +95,18 @@ export function StepPreviewEdit({
           className="flex items-center gap-1.5 text-[11px] text-red-400 hover:text-red-300 transition-colors"
         >
           <ArrowDown className="h-3 w-3" />
-          Jump to first error
+          Jump to first blocking error
         </button>
       )}
 
-      {/* Click-to-edit hint */}
+      {/* Severity legend + click-to-edit hint */}
       <p className="text-[10px] text-foreground/40">
-        Click any cell to edit. Check &quot;Skip&quot; to exclude a row.{' '}
-        {visibleFields.map((f) => FIELD_LABELS[f] || f).join(', ')}
+        Click any cell to edit · Check &quot;Skip&quot; to exclude a row · Hover a cell{' '}
+        <span className="text-red-400/80">●</span> or{' '}
+        <span className="text-yellow-400/80">●</span> to see its issue.{' '}
+        <span className="text-red-400/80">Red</span> = missing Name/Email (must fix or skip).{' '}
+        <span className="text-yellow-400/80">Yellow</span> = formatting issue (row will be
+        skipped on import unless fixed).
       </p>
 
       {/* Virtualized table */}
@@ -103,6 +116,7 @@ export function StepPreviewEdit({
         onEditCell={onEditCell}
         onToggleSkip={onToggleSkip}
         errorRowRef={errorRowRef}
+        firstErrorIndex={stats.firstErrorIndex}
       />
 
       {/* Bulk tags */}
@@ -142,9 +156,9 @@ export function StepPreviewEdit({
           onClick={onValidate}
           size="sm"
           className="text-xs h-8"
-          disabled={stats.valid === 0}
+          disabled={stats.importable === 0}
         >
-          Validate {stats.valid} Contact{stats.valid !== 1 ? 's' : ''}
+          Validate {stats.importable} Contact{stats.importable !== 1 ? 's' : ''}
         </Button>
       </div>
     </div>

--- a/src/components/producer/Network/csvImport/StepReviewLists.tsx
+++ b/src/components/producer/Network/csvImport/StepReviewLists.tsx
@@ -1,0 +1,131 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { CheckCircle2, AlertCircle } from 'lucide-react'
+import type { BulkImportResult } from '@/services/api'
+import type { ListDraft } from './types'
+import {
+  CONTACTS_ALWAYS_IN_ALL,
+  LISTS_FROM_TAGS,
+  TAGS_ARE_LABELS,
+} from '../copy'
+
+interface StepReviewListsProps {
+  importResult: BulkImportResult
+  discoveredTags: string[]
+  listDrafts: ListDraft[]
+  onUpdateDraft: (index: number, changes: Partial<ListDraft>) => void
+  onCreateLists: () => void
+  onSkipLists: () => void
+}
+
+export function StepReviewLists({
+  importResult,
+  discoveredTags,
+  listDrafts,
+  onUpdateDraft,
+  onCreateLists,
+  onSkipLists,
+}: StepReviewListsProps) {
+  const created = importResult.summary.created ?? 0
+  const updated = importResult.summary.updated ?? 0
+  const importedTotal = created + updated
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center py-1">
+        <CheckCircle2 className="h-7 w-7 text-green-400 mx-auto mb-2" />
+        <h3 className="text-sm font-semibold text-foreground">Review & Create Lists</h3>
+        <p className="text-xs text-foreground/60 mt-1">Contacts imported successfully</p>
+        <p className="text-[11px] text-foreground/50 mt-1">
+          You can also save filters later from All Contacts.
+        </p>
+      </div>
+
+      <ul className="text-xs text-foreground/70 space-y-1 list-disc list-inside bg-background/5 rounded-lg p-3 border border-border">
+        <li>{CONTACTS_ALWAYS_IN_ALL}</li>
+        <li>{TAGS_ARE_LABELS}</li>
+        <li>{LISTS_FROM_TAGS}</li>
+      </ul>
+
+      <p className="text-xs text-foreground/80 text-center">
+        You just imported: <strong>{importedTotal}</strong> contact
+        {importedTotal === 1 ? '' : 's'}
+        {updated > 0 && (
+          <span className="text-foreground/60">
+            {' '}
+            ({created} created, {updated} updated)
+          </span>
+        )}
+      </p>
+
+      {discoveredTags.length > 0 && (
+        <div>
+          <p className="text-[11px] font-medium text-foreground/70 mb-2">
+            New or updated tags found:{' '}
+            <span className="font-normal text-foreground/80">{discoveredTags.join(', ')}</span>
+          </p>
+        </div>
+      )}
+
+      {listDrafts.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[11px] font-medium text-foreground/70">Create lists from tags</p>
+          <div className="space-y-2 max-h-48 overflow-y-auto border border-border rounded-lg p-2">
+            {listDrafts.map((draft, index) => (
+              <div
+                key={draft.tag}
+                className="flex items-start gap-2 p-2 rounded-md bg-background/5"
+              >
+                <Checkbox
+                  id={`list-draft-${draft.tag}`}
+                  checked={draft.checked}
+                  onCheckedChange={(checked) =>
+                    onUpdateDraft(index, { checked: !!checked })
+                  }
+                  className="mt-1"
+                />
+                <div className="flex-1 min-w-0">
+                  <label
+                    htmlFor={`list-draft-${draft.tag}`}
+                    className="text-[11px] text-foreground/80 block mb-1 cursor-pointer"
+                  >
+                    Create a list &lsquo;{draft.name}&rsquo; (tag = {draft.tag})
+                  </label>
+                  <Input
+                    value={draft.name}
+                    onChange={(e) => onUpdateDraft(index, { name: e.target.value })}
+                    className="h-7 text-xs"
+                    disabled={!draft.checked}
+                    aria-label={`List name for tag ${draft.tag}`}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {importResult.errors.length > 0 && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-3.5 w-3.5" />
+          <AlertDescription className="text-[11px]">
+            {importResult.errors.length} row(s) had errors during import.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex justify-between pt-1">
+        <Button variant="outline" onClick={onSkipLists} size="sm" className="text-xs h-8">
+          Skip for now
+        </Button>
+        <Button onClick={onCreateLists} size="sm" className="text-xs h-8">
+          {listDrafts.some((d) => d.checked)
+            ? 'Create lists & finish'
+            : 'Finish'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/StepReviewLists.tsx
+++ b/src/components/producer/Network/csvImport/StepReviewLists.tsx
@@ -5,12 +5,6 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { CheckCircle2, AlertCircle } from 'lucide-react'
 import type { BulkImportResult } from '@/services/api'
 import type { ListDraft } from './types'
-import {
-  CONTACTS_ALWAYS_IN_ALL,
-  LISTS_FROM_TAGS,
-  TAGS_ARE_LABELS,
-} from '../copy'
-
 interface StepReviewListsProps {
   importResult: BulkImportResult
   discoveredTags: string[]
@@ -43,36 +37,24 @@ export function StepReviewLists({
         </p>
       </div>
 
-      <ul className="text-xs text-foreground/70 space-y-1 list-disc list-inside bg-background/5 rounded-lg p-3 border border-border">
-        <li>{CONTACTS_ALWAYS_IN_ALL}</li>
-        <li>{TAGS_ARE_LABELS}</li>
-        <li>{LISTS_FROM_TAGS}</li>
-      </ul>
-
-      <p className="text-xs text-foreground/80 text-center">
-        You just imported: <strong>{importedTotal}</strong> contact
-        {importedTotal === 1 ? '' : 's'}
-        {updated > 0 && (
-          <span className="text-foreground/60">
-            {' '}
-            ({created} created, {updated} updated)
-          </span>
+      <p className="text-[11px] text-foreground/50 text-center">
+        All contacts land in All Contacts. Tags are labels — lists are smart filters saved for later.
+        {discoveredTags.length > 0 && (
+          <> Tags found: <span className="text-foreground/70">{discoveredTags.join(', ')}</span>.</>
         )}
       </p>
 
-      {discoveredTags.length > 0 && (
-        <div>
-          <p className="text-[11px] font-medium text-foreground/70 mb-2">
-            New or updated tags found:{' '}
-            <span className="font-normal text-foreground/80">{discoveredTags.join(', ')}</span>
-          </p>
-        </div>
-      )}
+      <p className="text-xs text-foreground/80 text-center">
+        Imported: <strong>{importedTotal}</strong> contact{importedTotal === 1 ? '' : 's'}
+        {updated > 0 && (
+          <span className="text-foreground/60"> ({created} created, {updated} updated)</span>
+        )}
+      </p>
 
       {listDrafts.length > 0 && (
         <div className="space-y-2">
           <p className="text-[11px] font-medium text-foreground/70">Create lists from tags</p>
-          <div className="space-y-2 max-h-48 overflow-y-auto border border-border rounded-lg p-2">
+          <div className="space-y-2 max-h-72 overflow-y-auto border border-border rounded-lg p-2">
             {listDrafts.map((draft, index) => (
               <div
                 key={draft.tag}

--- a/src/components/producer/Network/csvImport/StepUpload.tsx
+++ b/src/components/producer/Network/csvImport/StepUpload.tsx
@@ -1,0 +1,70 @@
+import React, { useRef } from 'react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Upload, FileText } from 'lucide-react'
+import { downloadCSVTemplate } from '@/utils/csvTemplateGenerator'
+
+interface StepUploadProps {
+  onFileSelect: (file: File) => void
+  errorMessage: string
+}
+
+export function StepUpload({ onFileSelect, errorMessage }: StepUploadProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const file = e.dataTransfer.files[0]
+    if (file) onFileSelect(file)
+  }
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) onFileSelect(file)
+  }
+
+  return (
+    <div className="space-y-3">
+      <Alert>
+        <FileText className="h-3.5 w-3.5" />
+        <AlertDescription className="text-xs">
+          First time importing?{' '}
+          <button
+            onClick={downloadCSVTemplate}
+            className="font-medium text-primary hover:underline"
+          >
+            Download our CSV template
+          </button>{' '}
+          to get started.
+        </AlertDescription>
+      </Alert>
+
+      <div
+        onDrop={handleFileDrop}
+        onDragOver={(e) => e.preventDefault()}
+        className="border-2 border-dashed border-primary/40 bg-background/5 rounded-lg p-6 text-center hover:border-primary hover:bg-background/10 transition-all cursor-pointer"
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <Upload className="mx-auto h-8 w-8 text-primary" />
+        <p className="mt-1.5 text-xs text-foreground/80">
+          Drag and drop your CSV file here, or click to browse
+        </p>
+        <p className="mt-0.5 text-[11px] text-foreground/50">CSV files only</p>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".csv"
+        onChange={handleFileInputChange}
+        className="hidden"
+      />
+
+      {errorMessage && (
+        <Alert variant="destructive">
+          <AlertDescription className="text-xs">{errorMessage}</AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/StepValidationResult.tsx
+++ b/src/components/producer/Network/csvImport/StepValidationResult.tsx
@@ -1,0 +1,114 @@
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { CheckCircle2, AlertCircle, Download } from 'lucide-react'
+import type { BulkImportResult } from '@/services/api'
+import { downloadErrorReport } from '@/utils/csvTemplateGenerator'
+
+interface StepValidationResultProps {
+  result: BulkImportResult
+  discoveredTags: string[]
+  onImport: () => void
+  onBack: () => void
+}
+
+export function StepValidationResult({
+  result,
+  discoveredTags,
+  onImport,
+  onBack,
+}: StepValidationResultProps) {
+  const hasErrors = result.errors.length > 0
+  const wouldCreate = result.summary.would_create || 0
+  const wouldUpdate = result.summary.would_update || 0
+  const wouldSkip = result.summary.would_skip || 0
+  const failed = result.summary.failed || 0
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 justify-center py-2">
+        {hasErrors ? (
+          <AlertCircle className="h-6 w-6 text-yellow-400" />
+        ) : (
+          <CheckCircle2 className="h-6 w-6 text-green-400" />
+        )}
+        <h3 className="text-sm font-semibold text-foreground">
+          {hasErrors ? 'Validation Found Issues' : 'Validation Passed'}
+        </h3>
+      </div>
+
+      {discoveredTags.length > 0 && (
+        <p className="text-xs text-foreground/70 text-center">
+          Tags found in this file:{' '}
+          <span className="text-foreground">{discoveredTags.join(', ')}</span>
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-2">
+        {wouldCreate > 0 && (
+          <div className="border border-green-500/30 bg-green-500/10 rounded-lg p-2.5 text-center">
+            <div className="text-lg font-bold text-green-400">{wouldCreate}</div>
+            <div className="text-[11px] text-foreground/60">Will be created</div>
+          </div>
+        )}
+        {wouldUpdate > 0 && (
+          <div className="border border-blue-500/30 bg-blue-500/10 rounded-lg p-2.5 text-center">
+            <div className="text-lg font-bold text-blue-400">{wouldUpdate}</div>
+            <div className="text-[11px] text-foreground/60">Will be updated</div>
+          </div>
+        )}
+        {wouldSkip > 0 && (
+          <div className="border border-yellow-500/30 bg-yellow-500/10 rounded-lg p-2.5 text-center">
+            <div className="text-lg font-bold text-yellow-400">{wouldSkip}</div>
+            <div className="text-[11px] text-foreground/60">Duplicates (skipped)</div>
+          </div>
+        )}
+        {failed > 0 && (
+          <div className="border border-red-500/30 bg-red-500/10 rounded-lg p-2.5 text-center">
+            <div className="text-lg font-bold text-red-400">{failed}</div>
+            <div className="text-[11px] text-foreground/60">Invalid rows</div>
+          </div>
+        )}
+      </div>
+
+      {hasErrors && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-3.5 w-3.5" />
+          <AlertDescription>
+            <div className="space-y-1.5">
+              <p className="text-xs font-medium">
+                {result.errors.length} row(s) have errors and will be skipped:
+              </p>
+              <div className="max-h-24 overflow-y-auto text-[11px] space-y-0.5">
+                {result.errors.slice(0, 5).map((error, idx) => (
+                  <div key={idx}>
+                    Row {error.row}: {error.message}
+                  </div>
+                ))}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => downloadErrorReport(result.errors)}
+                className="mt-1 h-7 text-[11px]"
+              >
+                <Download className="h-3 w-3 mr-1.5" />
+                Download Error Report
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex justify-between pt-1">
+        <Button variant="outline" onClick={onBack} size="sm" className="text-xs h-8">
+          Back to Preview
+        </Button>
+        <Button onClick={onImport} size="sm" className="text-xs h-8">
+          {hasErrors
+            ? `Import Anyway (${wouldCreate + wouldUpdate} valid)`
+            : `Import ${wouldCreate + wouldUpdate} Contacts`}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/StepValidationResult.tsx
+++ b/src/components/producer/Network/csvImport/StepValidationResult.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/components/ui/tooltip'
 import { CheckCircle2, AlertCircle, Download } from 'lucide-react'
 import type { BulkImportResult } from '@/services/api'
 import { downloadErrorReport } from '@/utils/csvTemplateGenerator'
@@ -9,6 +10,37 @@ interface StepValidationResultProps {
   discoveredTags: string[]
   onImport: () => void
   onBack: () => void
+}
+
+const MAX_ERRORS_SHOWN = 20
+
+function StatRow({
+  icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: ReactNode
+  label: string
+  value: number
+  tone: 'green' | 'blue' | 'yellow' | 'red'
+}) {
+  const toneClass = {
+    green: 'text-green-400',
+    blue: 'text-blue-400',
+    yellow: 'text-yellow-400',
+    red: 'text-red-400',
+  }[tone]
+
+  return (
+    <div className="flex items-center justify-between gap-2 px-3 py-2">
+      <span className="flex items-center gap-2 text-xs text-foreground/80 min-w-0">
+        <span className={toneClass}>{icon}</span>
+        <span className="truncate">{label}</span>
+      </span>
+      <span className={`text-xs font-semibold shrink-0 ${toneClass}`}>{value}</span>
+    </div>
+  )
 }
 
 export function StepValidationResult({
@@ -37,66 +69,71 @@ export function StepValidationResult({
       </div>
 
       {discoveredTags.length > 0 && (
-        <p className="text-xs text-foreground/70 text-center">
-          Tags found in this file:{' '}
-          <span className="text-foreground">{discoveredTags.join(', ')}</span>
+        <p className="text-xs text-foreground/70 text-center truncate">
+          Tags found in this file: <span className="text-foreground">{discoveredTags.join(', ')}</span>
         </p>
       )}
 
-      <div className="grid grid-cols-2 gap-2">
+      {/* Clean one-line-per-stat summary */}
+      <div className="rounded-lg border border-border divide-y divide-border">
         {wouldCreate > 0 && (
-          <div className="border border-green-500/30 bg-green-500/10 rounded-lg p-2.5 text-center">
-            <div className="text-lg font-bold text-green-400">{wouldCreate}</div>
-            <div className="text-[11px] text-foreground/60">Will be created</div>
-          </div>
+          <StatRow icon={<CheckCircle2 className="h-3.5 w-3.5" />} label="Will be created" value={wouldCreate} tone="green" />
         )}
         {wouldUpdate > 0 && (
-          <div className="border border-blue-500/30 bg-blue-500/10 rounded-lg p-2.5 text-center">
-            <div className="text-lg font-bold text-blue-400">{wouldUpdate}</div>
-            <div className="text-[11px] text-foreground/60">Will be updated</div>
-          </div>
+          <StatRow icon={<CheckCircle2 className="h-3.5 w-3.5" />} label="Will be updated" value={wouldUpdate} tone="blue" />
         )}
         {wouldSkip > 0 && (
-          <div className="border border-yellow-500/30 bg-yellow-500/10 rounded-lg p-2.5 text-center">
-            <div className="text-lg font-bold text-yellow-400">{wouldSkip}</div>
-            <div className="text-[11px] text-foreground/60">Duplicates (skipped)</div>
-          </div>
+          <StatRow icon={<AlertCircle className="h-3.5 w-3.5" />} label="Duplicates (skipped)" value={wouldSkip} tone="yellow" />
         )}
         {failed > 0 && (
-          <div className="border border-red-500/30 bg-red-500/10 rounded-lg p-2.5 text-center">
-            <div className="text-lg font-bold text-red-400">{failed}</div>
-            <div className="text-[11px] text-foreground/60">Invalid rows</div>
-          </div>
+          <StatRow icon={<AlertCircle className="h-3.5 w-3.5" />} label="Invalid rows (skipped)" value={failed} tone="red" />
         )}
       </div>
 
+      {/* Error list — one line per row, truncated with hover for the full message */}
       {hasErrors && (
-        <Alert variant="destructive">
-          <AlertCircle className="h-3.5 w-3.5" />
-          <AlertDescription>
-            <div className="space-y-1.5">
-              <p className="text-xs font-medium">
-                {result.errors.length} row(s) have errors and will be skipped:
-              </p>
-              <div className="max-h-24 overflow-y-auto text-[11px] space-y-0.5">
-                {result.errors.slice(0, 5).map((error, idx) => (
-                  <div key={idx}>
-                    Row {error.row}: {error.message}
-                  </div>
-                ))}
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => downloadErrorReport(result.errors)}
-                className="mt-1 h-7 text-[11px]"
-              >
-                <Download className="h-3 w-3 mr-1.5" />
-                Download Error Report
-              </Button>
-            </div>
-          </AlertDescription>
-        </Alert>
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 overflow-hidden">
+          <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-red-500/20">
+            <span className="text-xs font-medium text-red-300 truncate">
+              {result.errors.length} row{result.errors.length !== 1 ? 's' : ''} have errors
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => downloadErrorReport(result.errors)}
+              className="h-6 px-2 text-[10px] shrink-0"
+            >
+              <Download className="h-3 w-3 mr-1" />
+              Download
+            </Button>
+          </div>
+          <TooltipProvider delayDuration={150}>
+            <ul className="max-h-28 overflow-y-auto divide-y divide-red-500/10">
+              {result.errors.slice(0, MAX_ERRORS_SHOWN).map((error, idx) => (
+                <li key={idx} className="flex items-center gap-2 px-3 py-1.5 text-[11px] min-w-0">
+                  <span className="shrink-0 text-red-400/70 font-mono text-[10px]">Row {error.row}</span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="truncate text-red-200 cursor-default">{error.message}</span>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="top"
+                      align="start"
+                      className="max-w-xs bg-red-950 border-red-500/40 text-red-100"
+                    >
+                      {error.message}
+                    </TooltipContent>
+                  </Tooltip>
+                </li>
+              ))}
+            </ul>
+          </TooltipProvider>
+          {result.errors.length > MAX_ERRORS_SHOWN && (
+            <p className="px-3 py-1 text-[10px] text-foreground/40 border-t border-red-500/10">
+              +{result.errors.length - MAX_ERRORS_SHOWN} more — download the report for the full list
+            </p>
+          )}
+        </div>
       )}
 
       <div className="flex justify-between pt-1">

--- a/src/components/producer/Network/csvImport/VirtualizedImportTable.tsx
+++ b/src/components/producer/Network/csvImport/VirtualizedImportTable.tsx
@@ -1,6 +1,8 @@
 import { useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
+import { AlertCircle } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/components/ui/tooltip'
 import { TABLE_HEADER_CLASSES } from '@/components/shared/tableStyles'
 import type { ImportRow } from './types'
 import { FIELD_LABELS } from './constants'
@@ -12,6 +14,7 @@ interface VirtualizedImportTableProps {
   onEditCell: (rowIndex: number, fieldKey: string, value: string) => void
   onToggleSkip: (rowIndex: number) => void
   errorRowRef?: React.MutableRefObject<HTMLDivElement | null>
+  firstErrorIndex?: number
 }
 
 const ROW_HEIGHT = 32
@@ -22,6 +25,7 @@ export function VirtualizedImportTable({
   onEditCell,
   onToggleSkip,
   errorRowRef,
+  firstErrorIndex = -1,
 }: VirtualizedImportTableProps) {
   const parentRef = useRef<HTMLDivElement>(null)
 
@@ -33,91 +37,151 @@ export function VirtualizedImportTable({
   })
 
   return (
-    <div
-      ref={parentRef}
-      className="max-h-[50vh] overflow-auto border border-border rounded-lg bg-background/5"
-    >
-      {/* Sticky header */}
+    <TooltipProvider delayDuration={150}>
       <div
-        className={`sticky top-0 z-10 grid bg-primary/10 border-b border-primary/20 ${TABLE_HEADER_CLASSES}`}
-        style={{
-          gridTemplateColumns: `40px 36px ${visibleFields.map(() => 'minmax(120px, 1fr)').join(' ')}`,
-        }}
+        ref={parentRef}
+        className="max-h-[50vh] overflow-auto border border-border rounded-lg bg-background/5"
       >
-        <div className="px-1 text-center text-foreground/50">#</div>
-        <div className="px-1 text-center text-foreground/50">Skip</div>
-        {visibleFields.map((field) => (
-          <div key={field} className="px-2 py-1.5 text-foreground/80 truncate">
-            {FIELD_LABELS[field] || field}
-          </div>
-        ))}
-      </div>
+        {/* Sticky header */}
+        <div
+          className={`sticky top-0 z-10 grid bg-primary/10 border-b border-primary/20 ${TABLE_HEADER_CLASSES}`}
+          style={{
+            gridTemplateColumns: `40px 36px ${visibleFields.map(() => 'minmax(120px, 1fr)').join(' ')}`,
+          }}
+        >
+          <div className="px-1 text-center text-foreground/50">#</div>
+          <div className="px-1 text-center text-foreground/50">Skip</div>
+          {visibleFields.map((field) => (
+            <div key={field} className="px-2 py-1.5 text-foreground/80 truncate">
+              {FIELD_LABELS[field] || field}
+            </div>
+          ))}
+        </div>
 
-      {/* Virtualized rows */}
-      <div
-        style={{
-          height: `${virtualizer.getTotalSize()}px`,
-          position: 'relative',
-        }}
-      >
-        {virtualizer.getVirtualItems().map((virtualRow) => {
-          const row = rows[virtualRow.index]
-          const isSkipped = row._skipped
-          const isError = row._status === 'error'
-          const isFirstError =
-            isError && rows.findIndex((r) => r._status === 'error' && !r._skipped) === virtualRow.index
+        {/* Virtualized rows */}
+        <div
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            position: 'relative',
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const row = rows[virtualRow.index]
+            const isSkipped = row._skipped
+            const isError = row._status === 'error'
+            const isWarning = row._status === 'warning'
+            const isFirstError = isError && virtualRow.index === firstErrorIndex
 
-          return (
-            <div
-              key={virtualRow.index}
-              ref={isFirstError && errorRowRef ? (el) => { errorRowRef.current = el } : undefined}
-              className={`grid items-center text-[11px] border-b border-primary/10 ${
-                isSkipped
-                  ? 'opacity-40 line-through'
-                  : isError
-                    ? 'bg-red-500/5'
-                    : 'hover:bg-background/5'
-              }`}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                height: `${virtualRow.size}px`,
-                transform: `translateY(${virtualRow.start}px)`,
-                gridTemplateColumns: `40px 36px ${visibleFields.map(() => 'minmax(120px, 1fr)').join(' ')}`,
-              }}
-            >
-              {/* Row number */}
-              <div className="px-1 text-center text-foreground/40 text-[10px]">
-                {row._originalIndex}
-              </div>
+            return (
+              <div
+                key={virtualRow.index}
+                ref={isFirstError && errorRowRef ? (el) => { errorRowRef.current = el } : undefined}
+                className={`grid items-center text-[11px] border-b border-primary/10 ${
+                  isSkipped
+                    ? 'opacity-40 line-through'
+                    : isError
+                      ? 'bg-red-500/5'
+                      : isWarning
+                        ? 'bg-yellow-500/5'
+                        : 'hover:bg-background/5'
+                }`}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: `${virtualRow.size}px`,
+                  transform: `translateY(${virtualRow.start}px)`,
+                  gridTemplateColumns: `40px 36px ${visibleFields.map(() => 'minmax(120px, 1fr)').join(' ')}`,
+                }}
+              >
+                {/* Row number — hover shows every issue for this row */}
+                <div className="px-1 flex items-center justify-center text-foreground/40 text-[10px]">
+                  {isError || isWarning ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className={`flex items-center gap-0.5 cursor-help ${
+                            isError ? 'text-red-400' : 'text-yellow-400'
+                          }`}
+                        >
+                          <AlertCircle className="h-3 w-3" />
+                          {row._originalIndex}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="right"
+                        align="start"
+                        className={
+                          isError
+                            ? 'max-w-xs bg-red-950 border-red-500/40 text-red-100'
+                            : 'max-w-xs bg-yellow-950 border-yellow-500/40 text-yellow-100'
+                        }
+                      >
+                        {Object.keys(row._errors).length > 0 && (
+                          <>
+                            <p className="text-[11px] font-medium mb-1">Must fix (or skip row):</p>
+                            <ul className="text-[11px] space-y-0.5 list-disc list-inside mb-1">
+                              {Object.entries(row._errors).flatMap(([field, msgs]) =>
+                                msgs.map((msg, idx) => (
+                                  <li key={`${field}-${idx}`}>
+                                    <span className="text-red-300">{FIELD_LABELS[field] || field}:</span> {msg}
+                                  </li>
+                                )),
+                              )}
+                            </ul>
+                          </>
+                        )}
+                        {Object.keys(row._warnings).length > 0 && (
+                          <>
+                            <p className="text-[11px] font-medium mb-1 text-yellow-200">
+                              Warnings (row will be skipped on import unless fixed):
+                            </p>
+                            <ul className="text-[11px] space-y-0.5 list-disc list-inside">
+                              {Object.entries(row._warnings).flatMap(([field, msgs]) =>
+                                msgs.map((msg, idx) => (
+                                  <li key={`${field}-${idx}`}>
+                                    <span className="text-yellow-300">{FIELD_LABELS[field] || field}:</span> {msg}
+                                  </li>
+                                )),
+                              )}
+                            </ul>
+                          </>
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    row._originalIndex
+                  )}
+                </div>
 
-              {/* Skip checkbox */}
-              <div className="px-1 flex justify-center">
-                <Checkbox
-                  checked={isSkipped}
-                  onCheckedChange={() => onToggleSkip(virtualRow.index)}
-                  aria-label={`Skip row ${row._originalIndex}`}
-                  className="h-3.5 w-3.5"
-                />
-              </div>
-
-              {/* Editable cells */}
-              {visibleFields.map((field) => (
-                <div key={field} className="px-2 min-w-0">
-                  <EditableCell
-                    value={String(row[field] ?? '')}
-                    fieldKey={field}
-                    errors={row._errors[field]}
-                    onCommit={(value) => onEditCell(virtualRow.index, field, value)}
+                {/* Skip checkbox */}
+                <div className="px-1 flex justify-center">
+                  <Checkbox
+                    checked={isSkipped}
+                    onCheckedChange={() => onToggleSkip(virtualRow.index)}
+                    aria-label={`Skip row ${row._originalIndex}`}
+                    className="h-3.5 w-3.5"
                   />
                 </div>
-              ))}
-            </div>
-          )
-        })}
+
+                {/* Editable cells */}
+                {visibleFields.map((field) => (
+                  <div key={field} className="px-2 min-w-0">
+                    <EditableCell
+                      value={String(row[field] ?? '')}
+                      fieldKey={field}
+                      errors={row._errors[field]}
+                      warnings={row._warnings[field]}
+                      onCommit={(value) => onEditCell(virtualRow.index, field, value)}
+                    />
+                  </div>
+                ))}
+              </div>
+            )
+          })}
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   )
 }

--- a/src/components/producer/Network/csvImport/VirtualizedImportTable.tsx
+++ b/src/components/producer/Network/csvImport/VirtualizedImportTable.tsx
@@ -1,0 +1,123 @@
+import { useRef } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { Checkbox } from '@/components/ui/checkbox'
+import { TABLE_HEADER_CLASSES } from '@/components/shared/tableStyles'
+import type { ImportRow } from './types'
+import { FIELD_LABELS } from './constants'
+import { EditableCell } from './EditableCell'
+
+interface VirtualizedImportTableProps {
+  rows: ImportRow[]
+  visibleFields: string[]
+  onEditCell: (rowIndex: number, fieldKey: string, value: string) => void
+  onToggleSkip: (rowIndex: number) => void
+  errorRowRef?: React.MutableRefObject<HTMLDivElement | null>
+}
+
+const ROW_HEIGHT = 32
+
+export function VirtualizedImportTable({
+  rows,
+  visibleFields,
+  onEditCell,
+  onToggleSkip,
+  errorRowRef,
+}: VirtualizedImportTableProps) {
+  const parentRef = useRef<HTMLDivElement>(null)
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 10,
+  })
+
+  return (
+    <div
+      ref={parentRef}
+      className="max-h-[50vh] overflow-auto border border-border rounded-lg bg-background/5"
+    >
+      {/* Sticky header */}
+      <div
+        className={`sticky top-0 z-10 grid bg-primary/10 border-b border-primary/20 ${TABLE_HEADER_CLASSES}`}
+        style={{
+          gridTemplateColumns: `40px 36px ${visibleFields.map(() => 'minmax(120px, 1fr)').join(' ')}`,
+        }}
+      >
+        <div className="px-1 text-center text-foreground/50">#</div>
+        <div className="px-1 text-center text-foreground/50">Skip</div>
+        {visibleFields.map((field) => (
+          <div key={field} className="px-2 py-1.5 text-foreground/80 truncate">
+            {FIELD_LABELS[field] || field}
+          </div>
+        ))}
+      </div>
+
+      {/* Virtualized rows */}
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          position: 'relative',
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const row = rows[virtualRow.index]
+          const isSkipped = row._skipped
+          const isError = row._status === 'error'
+          const isFirstError =
+            isError && rows.findIndex((r) => r._status === 'error' && !r._skipped) === virtualRow.index
+
+          return (
+            <div
+              key={virtualRow.index}
+              ref={isFirstError && errorRowRef ? (el) => { errorRowRef.current = el } : undefined}
+              className={`grid items-center text-[11px] border-b border-primary/10 ${
+                isSkipped
+                  ? 'opacity-40 line-through'
+                  : isError
+                    ? 'bg-red-500/5'
+                    : 'hover:bg-background/5'
+              }`}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: `${virtualRow.size}px`,
+                transform: `translateY(${virtualRow.start}px)`,
+                gridTemplateColumns: `40px 36px ${visibleFields.map(() => 'minmax(120px, 1fr)').join(' ')}`,
+              }}
+            >
+              {/* Row number */}
+              <div className="px-1 text-center text-foreground/40 text-[10px]">
+                {row._originalIndex}
+              </div>
+
+              {/* Skip checkbox */}
+              <div className="px-1 flex justify-center">
+                <Checkbox
+                  checked={isSkipped}
+                  onCheckedChange={() => onToggleSkip(virtualRow.index)}
+                  aria-label={`Skip row ${row._originalIndex}`}
+                  className="h-3.5 w-3.5"
+                />
+              </div>
+
+              {/* Editable cells */}
+              {visibleFields.map((field) => (
+                <div key={field} className="px-2 min-w-0">
+                  <EditableCell
+                    value={String(row[field] ?? '')}
+                    fieldKey={field}
+                    errors={row._errors[field]}
+                    onCommit={(value) => onEditCell(virtualRow.index, field, value)}
+                  />
+                </div>
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/clientValidation.ts
+++ b/src/components/producer/Network/csvImport/clientValidation.ts
@@ -1,0 +1,102 @@
+import type { ImportRow } from './types'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const PHONE_REGEX = /^[0-9\-().\s+]+$/
+const SOCIAL_HANDLE_REGEX = /^[a-z0-9._]+$/i
+const MAX_SOCIAL_HANDLE_LENGTH = 30
+const MAX_AFFILIATION_LENGTH = 5000
+const URL_REGEX = /^https?:\/\/.+/i
+
+/**
+ * Validate a single import row. Returns errors keyed by field.
+ */
+export function validateRow(row: ImportRow): Record<string, string[]> {
+  const errors: Record<string, string[]> = {}
+
+  const addError = (field: string, message: string) => {
+    if (!errors[field]) errors[field] = []
+    errors[field].push(message)
+  }
+
+  // Name: required
+  const name = String(row.name ?? '').trim()
+  if (!name) {
+    addError('name', 'Name is required')
+  }
+
+  // Email: valid format if present
+  const email = String(row.email ?? '').trim()
+  if (email && !EMAIL_REGEX.test(email)) {
+    addError('email', 'Invalid email format')
+  }
+
+  // Phone: digits, dashes, parens, spaces, dots, plus
+  const phone = String(row.phone ?? '').trim()
+  if (phone && !PHONE_REGEX.test(phone)) {
+    addError('phone', 'Invalid phone format')
+  }
+
+  // Instagram handle
+  const ig = String(row.instagram_handle ?? '').trim()
+  if (ig) {
+    const cleaned = ig.replace(/^@/, '')
+    if (!SOCIAL_HANDLE_REGEX.test(cleaned)) {
+      addError('instagram_handle', 'Letters, numbers, periods, and underscores only')
+    } else if (cleaned.length > MAX_SOCIAL_HANDLE_LENGTH) {
+      addError('instagram_handle', `Max ${MAX_SOCIAL_HANDLE_LENGTH} characters`)
+    }
+  }
+
+  // TikTok handle
+  const tt = String(row.tiktok_handle ?? '').trim()
+  if (tt) {
+    const cleaned = tt.replace(/^@/, '')
+    if (!SOCIAL_HANDLE_REGEX.test(cleaned)) {
+      addError('tiktok_handle', 'Letters, numbers, periods, and underscores only')
+    } else if (cleaned.length > MAX_SOCIAL_HANDLE_LENGTH) {
+      addError('tiktok_handle', `Max ${MAX_SOCIAL_HANDLE_LENGTH} characters`)
+    }
+  }
+
+  // Website: valid URL
+  const website = String(row.website ?? '').trim()
+  if (website && !URL_REGEX.test(website)) {
+    // Try with https:// prefix
+    if (!URL_REGEX.test(`https://${website}`)) {
+      addError('website', 'Must be a valid URL')
+    }
+  }
+
+  // Affiliation: max length
+  const affiliation = String(row.affiliation ?? '').trim()
+  if (affiliation && affiliation.length > MAX_AFFILIATION_LENGTH) {
+    addError('affiliation', `Max ${MAX_AFFILIATION_LENGTH} characters`)
+  }
+
+  return errors
+}
+
+/**
+ * Validate all rows. Mutates _errors and _status in place for performance.
+ * Returns count of error rows.
+ */
+export function validateAllRows(rows: ImportRow[]): number {
+  let errorCount = 0
+  for (const row of rows) {
+    if (row._skipped) continue
+    const errors = validateRow(row)
+    row._errors = errors
+    row._status = Object.keys(errors).length > 0 ? 'error' : 'valid'
+    if (row._status === 'error') errorCount++
+  }
+  return errorCount
+}
+
+/**
+ * Get row-level status for a single row after edit.
+ */
+export function revalidateRow(row: ImportRow): { errors: Record<string, string[]>; status: ImportRow['_status'] } {
+  const errors = validateRow(row)
+  const status: ImportRow['_status'] = Object.keys(errors).length > 0 ? 'error' : 'valid'
+  return { errors, status }
+}

--- a/src/components/producer/Network/csvImport/clientValidation.ts
+++ b/src/components/producer/Network/csvImport/clientValidation.ts
@@ -5,88 +5,164 @@ const PHONE_REGEX = /^[0-9\-().\s+]+$/
 const SOCIAL_HANDLE_REGEX = /^[a-z0-9._]+$/i
 const MAX_SOCIAL_HANDLE_LENGTH = 30
 const MAX_AFFILIATION_LENGTH = 5000
-const URL_REGEX = /^https?:\/\/.+/i
 
 /**
- * Validate a single import row. Returns errors keyed by field.
+ * Producers often paste a full profile URL (e.g. "instagram.com/foo") into the
+ * Instagram/TikTok handle field instead of the bare handle. The backend
+ * (VendorContactFieldRules#extract_handle_from_url) strips the host and
+ * accepts just the username — mirror that here so client-side validation
+ * doesn't flag something the server will happily accept.
  */
-export function validateRow(row: ImportRow): Record<string, string[]> {
-  const errors: Record<string, string[]> = {}
+function extractHandleFromUrl(cleaned: string): string {
+  const igMatch = cleaned.match(/^(?:https?:\/\/)?(?:www\.)?instagram\.com\/@?([^/?#]+)/i)
+  if (igMatch) return igMatch[1]
 
-  const addError = (field: string, message: string) => {
-    if (!errors[field]) errors[field] = []
-    errors[field].push(message)
+  const ttMatch = cleaned.match(/^(?:https?:\/\/)?(?:www\.)?tiktok\.com\/@?([^/?#]+)/i)
+  if (ttMatch) return ttMatch[1]
+
+  return cleaned
+}
+
+function socialHandleError(raw: string): string | null {
+  const cleaned = extractHandleFromUrl(raw.trim()).replace(/^@/, '')
+  if (cleaned.includes(' ')) {
+    return 'Must not contain spaces (letters, numbers, periods, and underscores only)'
   }
-
-  // Name: required
-  const name = String(row.name ?? '').trim()
-  if (!name) {
-    addError('name', 'Name is required')
+  if (!SOCIAL_HANDLE_REGEX.test(cleaned)) {
+    return 'Letters, numbers, periods, and underscores only'
   }
-
-  // Email: valid format if present
-  const email = String(row.email ?? '').trim()
-  if (email && !EMAIL_REGEX.test(email)) {
-    addError('email', 'Invalid email format')
+  if (cleaned.length > MAX_SOCIAL_HANDLE_LENGTH) {
+    return `Max ${MAX_SOCIAL_HANDLE_LENGTH} characters`
   }
-
-  // Phone: digits, dashes, parens, spaces, dots, plus
-  const phone = String(row.phone ?? '').trim()
-  if (phone && !PHONE_REGEX.test(phone)) {
-    addError('phone', 'Invalid phone format')
-  }
-
-  // Instagram handle
-  const ig = String(row.instagram_handle ?? '').trim()
-  if (ig) {
-    const cleaned = ig.replace(/^@/, '')
-    if (!SOCIAL_HANDLE_REGEX.test(cleaned)) {
-      addError('instagram_handle', 'Letters, numbers, periods, and underscores only')
-    } else if (cleaned.length > MAX_SOCIAL_HANDLE_LENGTH) {
-      addError('instagram_handle', `Max ${MAX_SOCIAL_HANDLE_LENGTH} characters`)
-    }
-  }
-
-  // TikTok handle
-  const tt = String(row.tiktok_handle ?? '').trim()
-  if (tt) {
-    const cleaned = tt.replace(/^@/, '')
-    if (!SOCIAL_HANDLE_REGEX.test(cleaned)) {
-      addError('tiktok_handle', 'Letters, numbers, periods, and underscores only')
-    } else if (cleaned.length > MAX_SOCIAL_HANDLE_LENGTH) {
-      addError('tiktok_handle', `Max ${MAX_SOCIAL_HANDLE_LENGTH} characters`)
-    }
-  }
-
-  // Website: valid URL
-  const website = String(row.website ?? '').trim()
-  if (website && !URL_REGEX.test(website)) {
-    // Try with https:// prefix
-    if (!URL_REGEX.test(`https://${website}`)) {
-      addError('website', 'Must be a valid URL')
-    }
-  }
-
-  // Affiliation: max length
-  const affiliation = String(row.affiliation ?? '').trim()
-  if (affiliation && affiliation.length > MAX_AFFILIATION_LENGTH) {
-    addError('affiliation', `Max ${MAX_AFFILIATION_LENGTH} characters`)
-  }
-
-  return errors
+  return null
 }
 
 /**
- * Validate all rows. Mutates _errors and _status in place for performance.
- * Returns count of error rows.
+ * Mirrors backend VendorContactFieldRules.normalize_website + WEBSITE_FORMAT:
+ * bare domains get an https:// prefix, then the result must be a parseable URL.
+ * Using the URL constructor instead of a hand-rolled regex catches malformed
+ * URLs (e.g. "https://" with nothing after it) that a lenient regex would miss.
+ */
+function websiteError(raw: string): string | null {
+  const cleaned = raw.trim()
+  if (!cleaned) return null
+
+  const candidate = /^https?:\/\//i.test(cleaned) ? cleaned : `https://${cleaned}`
+
+  try {
+    const url = new URL(candidate)
+    if (!url.hostname.includes('.')) return 'Must be a valid URL'
+    return null
+  } catch {
+    return 'Must be a valid URL'
+  }
+}
+
+export interface RowValidation {
+  /** Blocking: row cannot be imported until fixed or skipped (missing Name/Email only) */
+  errors: Record<string, string[]>
+  /** Non-blocking in the preview: formatting issues the producer may fix inline.
+   *  Note: the server's validate_row still rejects these — rows left unfixed will
+   *  appear in the "Invalid rows (skipped)" count at the validation step. */
+  warnings: Record<string, string[]>
+}
+
+/**
+ * Validate a single import row.
+ *
+ * Severity model: the ONLY blocking errors are a missing Name (DB hard-requires
+ * it) and a missing Email (our unique identifier for matching/de-duping).
+ * Everything else — format nitpicks on phone, socials, website, location,
+ * affiliation length — is a warning: we surface it so the producer can clean
+ * their data inline. Rows left with warnings will be rejected by the backend's
+ * validate_row and appear in the "Invalid rows (skipped)" count at the
+ * validation step — they are not silently imported with bad data.
+ */
+export function validateRow(row: ImportRow): RowValidation {
+  const errors: Record<string, string[]> = {}
+  const warnings: Record<string, string[]> = {}
+
+  const add = (bucket: Record<string, string[]>, field: string, message: string) => {
+    if (!bucket[field]) bucket[field] = []
+    bucket[field].push(message)
+  }
+
+  // ── Blocking errors ────────────────────────────────────────────────
+
+  const name = String(row.name ?? '').trim()
+  if (!name) {
+    add(errors, 'name', 'Name is required')
+  }
+
+  const email = String(row.email ?? '').trim()
+  if (!email) {
+    add(errors, 'email', 'Email is required')
+  }
+
+  // ── Warnings ───────────────────────────────────────────────────────
+
+  if (email && !EMAIL_REGEX.test(email)) {
+    add(warnings, 'email', 'Email format looks invalid')
+  }
+
+  const phone = String(row.phone ?? '').trim()
+  if (phone && !PHONE_REGEX.test(phone)) {
+    add(warnings, 'phone', 'Phone format looks invalid')
+  }
+
+  const ig = String(row.instagram_handle ?? '').trim()
+  if (ig) {
+    const issue = socialHandleError(ig)
+    if (issue) add(warnings, 'instagram_handle', issue)
+  }
+
+  const tt = String(row.tiktok_handle ?? '').trim()
+  if (tt) {
+    const issue = socialHandleError(tt)
+    if (issue) add(warnings, 'tiktok_handle', issue)
+  }
+
+  const website = String(row.website ?? '').trim()
+  if (website) {
+    const issue = websiteError(website)
+    if (issue) add(warnings, 'website', issue)
+  }
+
+  const location = String(row.location ?? '').trim()
+  if (location && !location.includes(',')) {
+    add(
+      warnings,
+      'location',
+      "Consider 'City, State' format (e.g., 'San Francisco, CA')",
+    )
+  }
+
+  const affiliation = String(row.affiliation ?? '').trim()
+  if (affiliation && affiliation.length > MAX_AFFILIATION_LENGTH) {
+    add(warnings, 'affiliation', `Max ${MAX_AFFILIATION_LENGTH} characters`)
+  }
+
+  return { errors, warnings }
+}
+
+function statusFrom(validation: RowValidation): ImportRow['_status'] {
+  if (Object.keys(validation.errors).length > 0) return 'error'
+  if (Object.keys(validation.warnings).length > 0) return 'warning'
+  return 'valid'
+}
+
+/**
+ * Validate all rows. Mutates _errors, _warnings, and _status in place for
+ * performance. Returns count of blocking-error rows.
  */
 export function validateAllRows(rows: ImportRow[]): number {
   let errorCount = 0
   for (const row of rows) {
     if (row._skipped) continue
-    const errors = validateRow(row)
-    row._errors = errors
-    row._status = Object.keys(errors).length > 0 ? 'error' : 'valid'
+    const validation = validateRow(row)
+    row._errors = validation.errors
+    row._warnings = validation.warnings
+    row._status = statusFrom(validation)
     if (row._status === 'error') errorCount++
   }
   return errorCount
@@ -95,8 +171,7 @@ export function validateAllRows(rows: ImportRow[]): number {
 /**
  * Get row-level status for a single row after edit.
  */
-export function revalidateRow(row: ImportRow): { errors: Record<string, string[]>; status: ImportRow['_status'] } {
-  const errors = validateRow(row)
-  const status: ImportRow['_status'] = Object.keys(errors).length > 0 ? 'error' : 'valid'
-  return { errors, status }
+export function revalidateRow(row: ImportRow): RowValidation & { status: ImportRow['_status'] } {
+  const validation = validateRow(row)
+  return { ...validation, status: statusFrom(validation) }
 }

--- a/src/components/producer/Network/csvImport/columnMapping.ts
+++ b/src/components/producer/Network/csvImport/columnMapping.ts
@@ -118,6 +118,7 @@ export function buildImportRows(
       _originalIndex: idx + 2, // 1-indexed + header row
       _skipped: false,
       _errors: {},
+      _warnings: {},
       _status: 'valid',
     }
 
@@ -130,8 +131,10 @@ export function buildImportRows(
 
     // Handle first_name + last_name → name merge
     if (Object.keys(mergeHeaders).length > 0) {
-      const mergeConfig = Object.values(MERGE_FIELDS)[0]
-      if (mergeConfig && !headerToField.has('name')) {
+      // Find the merge config that matches our actual headers
+      const matchingNorm = Object.keys(mergeHeaders).find((n) => MERGE_FIELDS[n])
+      const mergeConfig = matchingNorm ? MERGE_FIELDS[matchingNorm] : null
+      if (mergeConfig && ![...headerToField.values()].includes('name')) {
         const parts = mergeConfig.parts
           .map((part) => {
             const csvH = mergeHeaders[part]

--- a/src/components/producer/Network/csvImport/columnMapping.ts
+++ b/src/components/producer/Network/csvImport/columnMapping.ts
@@ -1,0 +1,167 @@
+import type { ColumnMapping, ImportRow } from './types'
+import { RECOGNIZED_FIELD_KEYS, HEADER_ALIASES, MERGE_FIELDS } from './constants'
+
+/**
+ * Normalize a CSV header for matching: lowercase, trim, replace spaces with underscores.
+ */
+function normalizeHeader(header: string): string {
+  return header.trim().toLowerCase().replace(/\s+/g, '_').replace(/^\uFEFF/, '')
+}
+
+/**
+ * Collect first N non-empty sample values for a given header across rows.
+ */
+function sampleValues(header: string, rows: Record<string, string>[], count = 3): string[] {
+  const samples: string[] = []
+  for (const row of rows) {
+    const val = row[header]?.trim()
+    if (val) {
+      samples.push(val)
+      if (samples.length >= count) break
+    }
+  }
+  return samples
+}
+
+/**
+ * Auto-detect column mappings from CSV headers.
+ * Returns one ColumnMapping per CSV column.
+ */
+export function autoDetectMappings(
+  csvHeaders: string[],
+  rows: Record<string, string>[],
+): ColumnMapping[] {
+  const claimed = new Set<string>()
+  const mappings: ColumnMapping[] = []
+
+  for (const header of csvHeaders) {
+    const normalized = normalizeHeader(header)
+    const samples = sampleValues(header, rows)
+
+    // 1. Exact match
+    if (RECOGNIZED_FIELD_KEYS.includes(normalized) && !claimed.has(normalized)) {
+      claimed.add(normalized)
+      mappings.push({ csvHeader: header, mappedTo: normalized, confidence: 'exact', sampleValues: samples })
+      continue
+    }
+
+    // 2. Alias match
+    const aliasTarget = HEADER_ALIASES[normalized]
+    if (aliasTarget && !claimed.has(aliasTarget)) {
+      claimed.add(aliasTarget)
+      mappings.push({ csvHeader: header, mappedTo: aliasTarget, confidence: 'alias', sampleValues: samples })
+      continue
+    }
+
+    // 3. Merge field (first_name, last_name → name)
+    const mergeField = MERGE_FIELDS[normalized]
+    if (mergeField && !claimed.has(mergeField.target)) {
+      // Don't claim yet — let both parts map. We'll merge in buildImportRows.
+      mappings.push({ csvHeader: header, mappedTo: normalized, confidence: 'alias', sampleValues: samples })
+      continue
+    }
+
+    // 4. Fuzzy substring match
+    const fuzzyMatch = RECOGNIZED_FIELD_KEYS.find(
+      (key) => !claimed.has(key) && (normalized.includes(key) || key.includes(normalized)),
+    )
+    if (fuzzyMatch) {
+      claimed.add(fuzzyMatch)
+      mappings.push({ csvHeader: header, mappedTo: fuzzyMatch, confidence: 'fuzzy', sampleValues: samples })
+      continue
+    }
+
+    // 5. Alias target already claimed or no match
+    if (aliasTarget && claimed.has(aliasTarget)) {
+      mappings.push({ csvHeader: header, mappedTo: null, confidence: 'none', sampleValues: samples })
+      continue
+    }
+
+    // 6. No match
+    mappings.push({ csvHeader: header, mappedTo: null, confidence: 'none', sampleValues: samples })
+  }
+
+  return mappings
+}
+
+/**
+ * Convert raw CSV rows + column mappings into ImportRows with mapped field keys.
+ * Handles first_name + last_name merge into name.
+ */
+export function buildImportRows(
+  rawRows: Record<string, string>[],
+  mappings: ColumnMapping[],
+): ImportRow[] {
+  // Build header → field key map
+  const headerToField = new Map<string, string>()
+  for (const m of mappings) {
+    if (m.mappedTo) headerToField.set(m.csvHeader, m.mappedTo)
+  }
+
+  // Check for first_name/last_name merge
+  const hasMerge = mappings.some((m) => {
+    const norm = normalizeHeader(m.csvHeader)
+    return MERGE_FIELDS[norm] !== undefined
+  })
+  const mergeHeaders: Record<string, string> = {}
+  if (hasMerge) {
+    for (const m of mappings) {
+      const norm = normalizeHeader(m.csvHeader)
+      if (MERGE_FIELDS[norm]) {
+        mergeHeaders[norm] = m.csvHeader
+      }
+    }
+  }
+
+  return rawRows.map((raw, idx) => {
+    const row: ImportRow = {
+      _originalIndex: idx + 2, // 1-indexed + header row
+      _skipped: false,
+      _errors: {},
+      _status: 'valid',
+    }
+
+    for (const [csvHeader, fieldKey] of headerToField) {
+      const norm = normalizeHeader(csvHeader)
+      // Skip merge-source fields (they'll be combined into 'name')
+      if (MERGE_FIELDS[norm]) continue
+      row[fieldKey] = raw[csvHeader]?.trim() ?? ''
+    }
+
+    // Handle first_name + last_name → name merge
+    if (Object.keys(mergeHeaders).length > 0) {
+      const mergeConfig = Object.values(MERGE_FIELDS)[0]
+      if (mergeConfig && !headerToField.has('name')) {
+        const parts = mergeConfig.parts
+          .map((part) => {
+            const csvH = mergeHeaders[part]
+            return csvH ? (raw[csvH]?.trim() ?? '') : ''
+          })
+          .filter(Boolean)
+        row.name = parts.join(' ')
+      }
+    }
+
+    return row
+  })
+}
+
+/**
+ * Check if the required 'name' field is mapped (either directly or via merge fields).
+ */
+export function isNameMapped(mappings: ColumnMapping[]): boolean {
+  // Direct name mapping
+  if (mappings.some((m) => m.mappedTo === 'name')) return true
+
+  // Merged via first_name + last_name
+  const mergeNorms = mappings
+    .filter((m) => m.mappedTo !== null)
+    .map((m) => normalizeHeader(m.csvHeader))
+  const hasFirstName = mergeNorms.some(
+    (n) => n === 'first_name' || n === 'firstname',
+  )
+  const hasLastName = mergeNorms.some(
+    (n) => n === 'last_name' || n === 'lastname',
+  )
+  return hasFirstName || hasLastName
+}

--- a/src/components/producer/Network/csvImport/constants.ts
+++ b/src/components/producer/Network/csvImport/constants.ts
@@ -11,7 +11,10 @@ export interface FieldDefinition {
 
 export const RECOGNIZED_FIELDS: FieldDefinition[] = [
   { key: 'name', label: 'Name', required: true },
-  { key: 'email', label: 'Email', required: false },
+  // Email is required on import even though the backend allows it blank —
+  // it's the unique identifier used to match/de-dupe existing contacts and
+  // the only way to actually reach an imported contact.
+  { key: 'email', label: 'Email', required: true },
   { key: 'phone', label: 'Phone', required: false },
   { key: 'affiliation', label: 'Affiliation', required: false },
   { key: 'instagram_handle', label: 'Instagram', required: false },

--- a/src/components/producer/Network/csvImport/constants.ts
+++ b/src/components/producer/Network/csvImport/constants.ts
@@ -1,0 +1,120 @@
+/**
+ * Recognized contact fields for CSV import.
+ * Mirrors backend VendorContactFieldRules — keep in sync.
+ */
+
+export interface FieldDefinition {
+  key: string
+  label: string
+  required: boolean
+}
+
+export const RECOGNIZED_FIELDS: FieldDefinition[] = [
+  { key: 'name', label: 'Name', required: true },
+  { key: 'email', label: 'Email', required: false },
+  { key: 'phone', label: 'Phone', required: false },
+  { key: 'affiliation', label: 'Affiliation', required: false },
+  { key: 'instagram_handle', label: 'Instagram', required: false },
+  { key: 'tiktok_handle', label: 'TikTok', required: false },
+  { key: 'website', label: 'Website', required: false },
+  { key: 'location', label: 'Location', required: false },
+  { key: 'tags', label: 'Tags', required: false },
+  { key: 'notes', label: 'Notes', required: false },
+]
+
+/** All recognized field keys */
+export const RECOGNIZED_FIELD_KEYS = RECOGNIZED_FIELDS.map((f) => f.key)
+
+/** Display labels keyed by field key */
+export const FIELD_LABELS: Record<string, string> = Object.fromEntries(
+  RECOGNIZED_FIELDS.map((f) => [f.key, f.label]),
+)
+
+/**
+ * Alias map: normalized CSV header → recognized field key.
+ * Covers common variations, legacy field names, and abbreviations.
+ */
+export const HEADER_ALIASES: Record<string, string> = {
+  // Name
+  full_name: 'name',
+  contact_name: 'name',
+  vendor_name: 'name',
+  vendor: 'name',
+  contact: 'name',
+
+  // Email
+  e_mail: 'email',
+  email_address: 'email',
+  e_mail_address: 'email',
+
+  // Phone
+  phone_number: 'phone',
+  cell: 'phone',
+  cell_phone: 'phone',
+  mobile: 'phone',
+  mobile_phone: 'phone',
+  telephone: 'phone',
+  tel: 'phone',
+
+  // Affiliation (and legacy business_name)
+  business_name: 'affiliation',
+  business: 'affiliation',
+  company: 'affiliation',
+  company_name: 'affiliation',
+  organization: 'affiliation',
+  org: 'affiliation',
+  studio: 'affiliation',
+  brand: 'affiliation',
+  brand_name: 'affiliation',
+  shop: 'affiliation',
+  shop_name: 'affiliation',
+
+  // Instagram
+  instagram: 'instagram_handle',
+  ig: 'instagram_handle',
+  ig_handle: 'instagram_handle',
+  insta: 'instagram_handle',
+
+  // TikTok
+  tiktok: 'tiktok_handle',
+  tik_tok: 'tiktok_handle',
+  tt: 'tiktok_handle',
+
+  // Website
+  url: 'website',
+  site: 'website',
+  portfolio: 'website',
+  portfolio_url: 'website',
+  web: 'website',
+  link: 'website',
+
+  // Location
+  city: 'location',
+  address: 'location',
+  city_state: 'location',
+
+  // Tags
+  tag: 'tags',
+  categories: 'tags',
+  category: 'tags',
+  label: 'tags',
+  labels: 'tags',
+  type: 'tags',
+
+  // Notes
+  note: 'notes',
+  comments: 'notes',
+  comment: 'notes',
+  description: 'notes',
+}
+
+/**
+ * Fields that should be merged if both appear in the CSV
+ * (e.g., first_name + last_name → name)
+ */
+export const MERGE_FIELDS: Record<string, { target: string; parts: string[] }> = {
+  first_name: { target: 'name', parts: ['first_name', 'last_name'] },
+  last_name: { target: 'name', parts: ['first_name', 'last_name'] },
+  firstname: { target: 'name', parts: ['firstname', 'lastname'] },
+  lastname: { target: 'name', parts: ['firstname', 'lastname'] },
+}

--- a/src/components/producer/Network/csvImport/csvRewriter.ts
+++ b/src/components/producer/Network/csvImport/csvRewriter.ts
@@ -22,7 +22,8 @@ export function prepareSubmission(
     }
   }
 
-  if (!cellsEdited) {
+  const hasSkippedRows = importRows.some((r) => r._skipped)
+  if (!cellsEdited && !hasSkippedRows) {
     return {
       file: originalFile,
       columnMapping: Object.keys(columnMapping).length > 0 ? columnMapping : null,

--- a/src/components/producer/Network/csvImport/csvRewriter.ts
+++ b/src/components/producer/Network/csvImport/csvRewriter.ts
@@ -1,0 +1,54 @@
+import Papa from 'papaparse'
+import type { ImportRow, ColumnMapping } from './types'
+import { RECOGNIZED_FIELD_KEYS } from './constants'
+
+/**
+ * Build the file + column_mapping to send to the server.
+ *
+ * - If no cells were edited: return the original file + column_mapping JSON
+ * - If cells were edited: reconstruct CSV with canonical headers using Papa.unparse()
+ */
+export function prepareSubmission(
+  originalFile: File,
+  mappings: ColumnMapping[],
+  importRows: ImportRow[],
+  cellsEdited: boolean,
+): { file: File; columnMapping: Record<string, string> | null } {
+  // Build column mapping: csvHeader → recognizedFieldKey
+  const columnMapping: Record<string, string> = {}
+  for (const m of mappings) {
+    if (m.mappedTo && RECOGNIZED_FIELD_KEYS.includes(m.mappedTo)) {
+      columnMapping[m.csvHeader] = m.mappedTo
+    }
+  }
+
+  if (!cellsEdited) {
+    return {
+      file: originalFile,
+      columnMapping: Object.keys(columnMapping).length > 0 ? columnMapping : null,
+    }
+  }
+
+  // Reconstruct CSV from edited importRows
+  const activeRows = importRows.filter((r) => !r._skipped)
+  const activeFields = RECOGNIZED_FIELD_KEYS.filter((key) =>
+    mappings.some((m) => m.mappedTo === key),
+  )
+
+  const csvData = activeRows.map((row) => {
+    const obj: Record<string, string> = {}
+    for (const field of activeFields) {
+      obj[field] = String(row[field] ?? '')
+    }
+    return obj
+  })
+
+  const csvString = Papa.unparse(csvData, { header: true })
+  const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' })
+  const reconstructedFile = new File([blob], originalFile.name, { type: 'text/csv' })
+
+  return {
+    file: reconstructedFile,
+    columnMapping: null, // Headers are already canonical
+  }
+}

--- a/src/components/producer/Network/csvImport/types.ts
+++ b/src/components/producer/Network/csvImport/types.ts
@@ -1,0 +1,78 @@
+import type { BulkImportResult } from '@/services/api'
+import type { ImportSession } from '../importSession'
+
+export interface ColumnMapping {
+  csvHeader: string
+  mappedTo: string | null
+  confidence: 'exact' | 'alias' | 'fuzzy' | 'none'
+  sampleValues: string[]
+}
+
+export interface ImportRow {
+  _originalIndex: number
+  _skipped: boolean
+  _errors: Record<string, string[]>
+  _status: 'valid' | 'warning' | 'error'
+  [fieldKey: string]: unknown
+}
+
+export type ImportStep =
+  | 'idle'
+  | 'parsing'
+  | 'column_mapping'
+  | 'preview_editing'
+  | 'server_validating'
+  | 'validated'
+  | 'uploading'
+  | 'review_lists'
+  | 'creating_lists'
+
+export interface ListDraft {
+  tag: string
+  name: string
+  checked: boolean
+}
+
+export interface ImportState {
+  step: ImportStep
+  file: File | null
+  rawRows: Record<string, string>[]
+  rawHeaders: string[]
+  columnMappings: ColumnMapping[]
+  importRows: ImportRow[]
+  bulkTags: string
+  skipDuplicates: boolean
+  updateExisting: boolean
+  validationResult: BulkImportResult | null
+  importResult: BulkImportResult | null
+  listDrafts: ListDraft[]
+  errorMessage: string
+  cellsEdited: boolean
+}
+
+export type ImportAction =
+  | { type: 'FILE_PARSED'; file: File; headers: string[]; rows: Record<string, string>[] }
+  | { type: 'SET_COLUMN_MAPPINGS'; mappings: ColumnMapping[] }
+  | { type: 'UPDATE_COLUMN_MAPPING'; index: number; mappedTo: string | null }
+  | { type: 'CONFIRM_MAPPINGS'; importRows: ImportRow[] }
+  | { type: 'EDIT_CELL'; rowIndex: number; fieldKey: string; value: string }
+  | { type: 'TOGGLE_ROW_SKIP'; rowIndex: number }
+  | { type: 'UPDATE_ROW_ERRORS'; rowIndex: number; errors: Record<string, string[]>; status: ImportRow['_status'] }
+  | { type: 'SET_BULK_TAGS'; tags: string }
+  | { type: 'SET_SKIP_DUPLICATES'; value: boolean }
+  | { type: 'SET_UPDATE_EXISTING'; value: boolean }
+  | { type: 'SERVER_VALIDATING' }
+  | { type: 'VALIDATION_COMPLETE'; result: BulkImportResult }
+  | { type: 'UPLOADING' }
+  | { type: 'UPLOAD_COMPLETE'; result: BulkImportResult }
+  | { type: 'SET_LIST_DRAFTS'; drafts: ListDraft[] }
+  | { type: 'UPDATE_LIST_DRAFT'; index: number; changes: Partial<ListDraft> }
+  | { type: 'ERROR'; message: string }
+  | { type: 'RESET' }
+
+export interface CSVUploadModalProps {
+  open: boolean
+  onClose: () => void
+  onSuccess: (session: ImportSession) => void
+  organizationId: number
+}

--- a/src/components/producer/Network/csvImport/types.ts
+++ b/src/components/producer/Network/csvImport/types.ts
@@ -11,7 +11,10 @@ export interface ColumnMapping {
 export interface ImportRow {
   _originalIndex: number
   _skipped: boolean
+  /** Blocking issues (missing Name/Email) — row cannot be imported until fixed or skipped */
   _errors: Record<string, string[]>
+  /** Non-blocking formatting issues — row can still be imported as-is */
+  _warnings: Record<string, string[]>
   _status: 'valid' | 'warning' | 'error'
   [fieldKey: string]: unknown
 }
@@ -54,10 +57,11 @@ export type ImportAction =
   | { type: 'FILE_PARSED'; file: File; headers: string[]; rows: Record<string, string>[] }
   | { type: 'SET_COLUMN_MAPPINGS'; mappings: ColumnMapping[] }
   | { type: 'UPDATE_COLUMN_MAPPING'; index: number; mappedTo: string | null }
+  | { type: 'ASSIGN_FIELD'; fieldKey: string; csvHeader: string | null }
   | { type: 'CONFIRM_MAPPINGS'; importRows: ImportRow[] }
   | { type: 'EDIT_CELL'; rowIndex: number; fieldKey: string; value: string }
   | { type: 'TOGGLE_ROW_SKIP'; rowIndex: number }
-  | { type: 'UPDATE_ROW_ERRORS'; rowIndex: number; errors: Record<string, string[]>; status: ImportRow['_status'] }
+  | { type: 'UPDATE_ROW_ERRORS'; rowIndex: number; errors: Record<string, string[]>; warnings: Record<string, string[]>; status: ImportRow['_status'] }
   | { type: 'SET_BULK_TAGS'; tags: string }
   | { type: 'SET_SKIP_DUPLICATES'; value: boolean }
   | { type: 'SET_UPDATE_EXISTING'; value: boolean }
@@ -67,6 +71,7 @@ export type ImportAction =
   | { type: 'UPLOAD_COMPLETE'; result: BulkImportResult }
   | { type: 'SET_LIST_DRAFTS'; drafts: ListDraft[] }
   | { type: 'UPDATE_LIST_DRAFT'; index: number; changes: Partial<ListDraft> }
+  | { type: 'GO_TO_PREVIEW' }
   | { type: 'ERROR'; message: string }
   | { type: 'RESET' }
 

--- a/src/components/producer/Network/csvImport/useImportState.ts
+++ b/src/components/producer/Network/csvImport/useImportState.ts
@@ -1,0 +1,126 @@
+import { useReducer, useCallback } from 'react'
+import type { ImportState, ImportAction } from './types'
+
+const initialState: ImportState = {
+  step: 'idle',
+  file: null,
+  rawRows: [],
+  rawHeaders: [],
+  columnMappings: [],
+  importRows: [],
+  bulkTags: '',
+  skipDuplicates: true,
+  updateExisting: false,
+  validationResult: null,
+  importResult: null,
+  listDrafts: [],
+  errorMessage: '',
+  cellsEdited: false,
+}
+
+function importReducer(state: ImportState, action: ImportAction): ImportState {
+  switch (action.type) {
+    case 'FILE_PARSED':
+      return {
+        ...state,
+        step: 'column_mapping',
+        file: action.file,
+        rawHeaders: action.headers,
+        rawRows: action.rows,
+        errorMessage: '',
+      }
+
+    case 'SET_COLUMN_MAPPINGS':
+      return {
+        ...state,
+        columnMappings: action.mappings,
+      }
+
+    case 'UPDATE_COLUMN_MAPPING': {
+      const mappings = [...state.columnMappings]
+      mappings[action.index] = { ...mappings[action.index], mappedTo: action.mappedTo, confidence: 'exact' }
+      return { ...state, columnMappings: mappings }
+    }
+
+    case 'CONFIRM_MAPPINGS':
+      return {
+        ...state,
+        step: 'preview_editing',
+        importRows: action.importRows,
+        cellsEdited: false,
+      }
+
+    case 'EDIT_CELL': {
+      const rows = [...state.importRows]
+      rows[action.rowIndex] = {
+        ...rows[action.rowIndex],
+        [action.fieldKey]: action.value,
+      }
+      return { ...state, importRows: rows, cellsEdited: true }
+    }
+
+    case 'TOGGLE_ROW_SKIP': {
+      const rows = [...state.importRows]
+      rows[action.rowIndex] = {
+        ...rows[action.rowIndex],
+        _skipped: !rows[action.rowIndex]._skipped,
+      }
+      return { ...state, importRows: rows }
+    }
+
+    case 'UPDATE_ROW_ERRORS': {
+      const rows = [...state.importRows]
+      rows[action.rowIndex] = {
+        ...rows[action.rowIndex],
+        _errors: action.errors,
+        _status: action.status,
+      }
+      return { ...state, importRows: rows }
+    }
+
+    case 'SET_BULK_TAGS':
+      return { ...state, bulkTags: action.tags }
+
+    case 'SET_SKIP_DUPLICATES':
+      return { ...state, skipDuplicates: action.value }
+
+    case 'SET_UPDATE_EXISTING':
+      return { ...state, updateExisting: action.value }
+
+    case 'SERVER_VALIDATING':
+      return { ...state, step: 'server_validating', errorMessage: '' }
+
+    case 'VALIDATION_COMPLETE':
+      return { ...state, step: 'validated', validationResult: action.result }
+
+    case 'UPLOADING':
+      return { ...state, step: 'uploading', errorMessage: '' }
+
+    case 'UPLOAD_COMPLETE':
+      return { ...state, step: 'review_lists', importResult: action.result }
+
+    case 'SET_LIST_DRAFTS':
+      return { ...state, listDrafts: action.drafts }
+
+    case 'UPDATE_LIST_DRAFT': {
+      const drafts = [...state.listDrafts]
+      drafts[action.index] = { ...drafts[action.index], ...action.changes }
+      return { ...state, listDrafts: drafts }
+    }
+
+    case 'ERROR':
+      return { ...state, step: 'idle', errorMessage: action.message }
+
+    case 'RESET':
+      return initialState
+
+    default:
+      return state
+  }
+}
+
+export function useImportState() {
+  const [state, dispatch] = useReducer(importReducer, initialState)
+  const reset = useCallback(() => dispatch({ type: 'RESET' }), [])
+  return { state, dispatch, reset }
+}

--- a/src/components/producer/Network/csvImport/useImportState.ts
+++ b/src/components/producer/Network/csvImport/useImportState.ts
@@ -33,12 +33,28 @@ function importReducer(state: ImportState, action: ImportAction): ImportState {
     case 'SET_COLUMN_MAPPINGS':
       return {
         ...state,
+        step: 'column_mapping',
         columnMappings: action.mappings,
       }
 
     case 'UPDATE_COLUMN_MAPPING': {
       const mappings = [...state.columnMappings]
       mappings[action.index] = { ...mappings[action.index], mappedTo: action.mappedTo, confidence: 'exact' }
+      return { ...state, columnMappings: mappings }
+    }
+
+    case 'ASSIGN_FIELD': {
+      // Field-anchored mapping: a field can only be fed by one CSV column at a
+      // time, so reassigning it first frees up whatever column it used to claim.
+      const mappings = state.columnMappings.map((m) => {
+        if (m.mappedTo === action.fieldKey && m.csvHeader !== action.csvHeader) {
+          return { ...m, mappedTo: null, confidence: 'none' as const }
+        }
+        if (action.csvHeader && m.csvHeader === action.csvHeader) {
+          return { ...m, mappedTo: action.fieldKey, confidence: 'exact' as const }
+        }
+        return m
+      })
       return { ...state, columnMappings: mappings }
     }
 
@@ -73,6 +89,7 @@ function importReducer(state: ImportState, action: ImportAction): ImportState {
       rows[action.rowIndex] = {
         ...rows[action.rowIndex],
         _errors: action.errors,
+        _warnings: action.warnings,
         _status: action.status,
       }
       return { ...state, importRows: rows }
@@ -108,8 +125,16 @@ function importReducer(state: ImportState, action: ImportAction): ImportState {
       return { ...state, listDrafts: drafts }
     }
 
-    case 'ERROR':
-      return { ...state, step: 'idle', errorMessage: action.message }
+    case 'GO_TO_PREVIEW':
+      return { ...state, step: 'preview_editing' }
+
+    case 'ERROR': {
+      // If contacts are already imported, stay on review_lists so user can retry
+      const errorStep = state.step === 'review_lists' || state.step === 'creating_lists'
+        ? 'review_lists'
+        : 'idle'
+      return { ...state, step: errorStep, errorMessage: action.message }
+    }
 
     case 'RESET':
       return initialState

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -15,15 +15,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className,
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/src/index.css
+++ b/src/index.css
@@ -632,6 +632,20 @@
     box-shadow: var(--voxxy-dark-inset-line-strong), var(--voxxy-dark-modal-shadow);
   }
 
+  /**
+   * Large workspace modals — multi-step flows with tables, editors, or complex
+   * content that need near-fullscreen real estate (CSV import, bulk editors, etc.).
+   * Always combine with voxxy-modal-surface for the surface treatment.
+   * !important on sizing is required to beat Radix DialogContent's built-in max-w-lg.
+   */
+  .voxxy-modal-workspace {
+    width: 90vw !important;
+    max-width: 90vw !important;
+    max-height: 92vh !important;
+    overflow-y: auto;
+    padding: 1.25rem;
+  }
+
   .voxxy-overlay-scrim {
     background-color: hsl(255 20% 35% / 0.2);
     backdrop-filter: blur(6px);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2277,6 +2277,7 @@ export interface BulkImportOptions {
   updateExisting?: boolean
   tags?: string[]
   validateOnly?: boolean
+  columnMapping?: Record<string, string>
 }
 
 export interface ContactList {
@@ -2802,6 +2803,10 @@ export const vendorContactsApi = {
 
     if (options.tags && options.tags.length > 0) {
       formData.append('tags', JSON.stringify(options.tags))
+    }
+
+    if (options.columnMapping) {
+      formData.append('column_mapping', JSON.stringify(options.columnMapping))
     }
 
     console.log(

--- a/src/utils/csvTemplateGenerator.ts
+++ b/src/utils/csvTemplateGenerator.ts
@@ -10,9 +10,6 @@ export function generateCSVTemplate(): string {
     'location',
     'tags',
     'notes',
-    'eventbrite_email',
-    'venmo_handle',
-    'paypal_email',
   ]
 
   const exampleRows = [
@@ -27,9 +24,6 @@ export function generateCSVTemplate(): string {
       location: 'San Francisco, CA',
       tags: 'art,local',
       notes: 'Met at Spring Market 2024',
-      eventbrite_email: 'sarah@ceramics.com',
-      venmo_handle: '@sarahceramics',
-      paypal_email: '',
     },
     {
       name: 'John Davidson',
@@ -42,9 +36,6 @@ export function generateCSVTemplate(): string {
       location: 'Oakland, CA',
       tags: 'food,catering',
       notes: 'Interested in summer events',
-      eventbrite_email: '',
-      venmo_handle: '',
-      paypal_email: 'john@paypal.com',
     },
   ]
 


### PR DESCRIPTION
## Summary
- Complete UX overhaul of CSV import flow: upload → auto-detect columns → remap via dropdowns → preview ALL rows with inline editing → fix errors on-screen → skip bad rows → validate → import
- Decomposed 717-line `CSVUploadModal.tsx` into 13 focused files in `csvImport/` directory
- Added `@tanstack/react-virtual` for virtualized table rendering (handles 1000+ row CSVs smoothly)

## New flow
1. **Upload** — drag/drop or file picker, template download
2. **Column Mapping** — auto-detects headers (exact, alias, fuzzy match from 40+ aliases). User remaps via dropdowns. Blocks if `name` not mapped.
3. **Preview & Edit** — virtualized table showing ALL rows. Click-to-edit cells, client-side validation with inline errors, skip/unskip rows, error summary with jump-to-error
4. **Server Validation** — shows would_create/update/skip/failed counts
5. **Import & List Creation** — tag discovery, list creation flow

## Key files
- `csvImport/types.ts` — ImportRow, ColumnMapping, ImportState types
- `csvImport/constants.ts` — 10 recognized fields, 40+ header aliases, display labels
- `csvImport/useImportState.ts` — useReducer replacing 10+ useState calls
- `csvImport/columnMapping.ts` — auto-detection with exact/alias/fuzzy/none confidence
- `csvImport/clientValidation.ts` — mirrors backend validation rules
- `csvImport/csvRewriter.ts` — sends original file + mapping OR reconstructed CSV if cells edited
- `csvImport/VirtualizedImportTable.tsx` — @tanstack/react-virtual based table
- `csvImport/EditableCell.tsx` — click-to-edit with error tooltips
- `CSVUploadModal.tsx` — slim orchestrator (~270 lines, down from 717)

## Test plan
- [ ] Upload CSV with exact headers → auto-maps all, preview shows all rows
- [ ] Upload CSV with non-standard headers ("Company", "IG", "Cell") → auto-detects via aliases
- [ ] Upload CSV with unrecognized headers → shows unmapped, dropdown to remap or skip
- [ ] Upload CSV missing `name` → blocks with error
- [ ] Edit cell with invalid email → red border + error appears immediately
- [ ] Skip a row → strikethrough, excluded from counts
- [ ] Jump to next error → scrolls to error row
- [ ] Server validate → shows create/update/skip/failed counts
- [ ] Import → success + list creation works
- [ ] Upload 1000+ row CSV → smooth virtualized rendering
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk vendor contact import and API payload shape changed across a large UI refactor; incorrect mapping or CSV rewrite could affect production contact data, though validate-only and server checks mitigate this.
> 
> **Overview**
> **Replaces the monolithic CSV import modal** with a multi-step flow (upload → column mapping → full-row preview/edit → server validation → import → optional smart lists), split across `csvImport/` modules and a slim `CSVUploadModal` orchestrator.
> 
> **Column mapping** no longer requires fixed `name`/`email` headers: headers are auto-detected (exact, alias, fuzzy, first/last name merge), users remap via dropdowns, and `bulk_import` can send a `column_mapping` JSON with the original file or a **rebuilt CSV** when rows are edited or skipped (`prepareSubmission`).
> 
> **Preview step** adds client-side validation (blocking missing name/email vs formatting warnings), click-to-edit cells, per-row skip, jump-to-error, and a **virtualized** table via `@tanstack/react-virtual` for large files. Modal UX adds workspace sizing (`voxxy-modal-workspace`), exit confirmation, and blocks dismiss while work is in progress.
> 
> Smaller changes: email editor live preview recognizes `[affiliation]` and `[ticketCode]`; tooltips render in a **Portal**; download template drops legacy payment/Eventbrite columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ecd2e586ebdc76dec4f19eab2f9edcba39832ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->