### PR TITLE
Staging polish (frontend): CSV names/parity + universal sort + bulk actions + hide n8n

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -187,6 +187,32 @@ All Voxxy-specific utility classes are defined in `@layer components` inside `sr
 | `.voxxy-table-row`        | Data row with bottom border.                                                                                                                                       |
 | `.voxxy-table-row-hover`  | Hover state for data rows. In dark mode uses `--voxxy-grad-hover-row-hover`.                                                                                       |
 
+### Sortable column headers
+
+Use the universal `TableSortHeader` for **every** sortable column so the sort
+affordance looks and behaves the same across all producer tables. Do not embed
+custom sort chevrons in header labels or roll a per-table `SortIcon`.
+
+```tsx
+import { TableSortHeader, createSortHandler, type SortOrder } from '@/components/shared/TableSortHeader'
+
+const [sortField, setSortField] = useState<'first_name' | 'email' | null>(null)
+const [sortOrder, setSortOrder] = useState<SortOrder>('asc')
+const handleSort = useCallback(createSortHandler(setSortField, setSortOrder), [])
+
+<TableSortHeader label="Email" field="email" currentSort={sortField} currentOrder={sortOrder} onSort={handleSort} />
+```
+
+- **Idle** columns show a muted `ChevronsUpDown` by default (visible affordance —
+  users can tell the column is sortable). Pass `showIdleIcon={false}` only in
+  rare, space-constrained cases.
+- **Active** column shows `ChevronUp` (asc) / `ChevronDown` (desc) in the accent
+  color, and the label text is emphasized.
+- Omit `onSort` to render a **static** header cell — lets non-sortable columns
+  sit in the same layout without a special case.
+- Use `className` for alignment (`justify-center`, `justify-end`) and `title`
+  for a tooltip. Pair with `createSortHandler` for the standard toggle.
+
 ### Hover effects
 
 | Class                | Description                                           |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,9 @@ const Dashboard = lazy(() => import('./pages/Dashboard'))
 const VendorDashboard = lazy(() => import('./pages/VendorDashboard'))
 const AdminUnsubscribesPage = lazy(() => import('./pages/AdminUnsubscribesPage'))
 const AdminBugReportsPage = lazy(() => import('./pages/AdminBugReportsPage'))
-const IncomingPaymentsPage = lazy(() => import('./pages/IncomingPaymentsPage'))
+// NOTE: Incoming Payments (n8n webhook inbox) is retired for now — payments are
+// handled via the Google Sheets sync. The page + /payments route are removed
+// from the app; re-add them if the n8n integration is revived.
 
 // Lazy load: Email Template Manager (load on-demand)
 const TemplateManager = lazy(() => import('./components/producer/Email/TemplateManager'))
@@ -98,42 +100,6 @@ function ProtectedDashboard() {
   // All checks passed, render dashboard
   console.log('✅ All checks passed, rendering dashboard')
   return <Dashboard />
-}
-
-// Protected Incoming Payments - ensures user is verified and paid before showing payments
-function ProtectedIncomingPayments() {
-  const { userProfile, loading, isAdmin, isProducer, isEmailVerified, isPaid } = useAuth()
-
-  if (loading) {
-    return <LoadingTransition message="Loading payments..." />
-  }
-
-  if (!userProfile) {
-    console.log('🔒 No user profile, redirecting to home')
-    return <Navigate to="/" replace />
-  }
-
-  // Admins always have access
-  if (isAdmin) {
-    console.log('🟣 Admin accessing payments')
-    return <IncomingPaymentsPage />
-  }
-
-  // Check email verification for non-admins
-  if (!isEmailVerified) {
-    console.log('🔒 Email not verified, redirecting to pending')
-    return <Navigate to="/pending" replace />
-  }
-
-  // Check payment for producers
-  if (isProducer && !isPaid) {
-    console.log('🔒 Producer without active subscription, redirecting to pending')
-    return <Navigate to="/pending" replace />
-  }
-
-  // All checks passed, render payments page
-  console.log('✅ All checks passed, rendering payments page')
-  return <IncomingPaymentsPage />
 }
 
 // Role-based redirect component - routes authenticated users to their holding screen
@@ -384,9 +350,6 @@ export default function App() {
 
             {/* Unified Dashboard - Protected (verified + paid producers/admins only) */}
             <Route path="/dashboard" element={<ProtectedDashboard />} />
-
-            {/* Incoming Payments - Protected (verified + paid producers/admins only) */}
-            <Route path="/payments" element={<ProtectedIncomingPayments />} />
 
             {/* 404 - Redirect to home */}
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/producer/Email/EmailAuditTable.tsx
+++ b/src/components/producer/Email/EmailAuditTable.tsx
@@ -12,16 +12,11 @@
  * 8. Action (vertical ellipsis dropdown, only for failed deliveries)
  */
 
-import {
-  ChevronUp,
-  ChevronDown,
-  ChevronsUpDown,
-  MoreVertical,
-  MessageCircleQuestion,
-} from 'lucide-react'
+import { MoreVertical, MessageCircleQuestion } from 'lucide-react'
 import { format } from 'date-fns'
 import type { AuditEntry } from '@/types/email'
 import { DELIVERY_STATUS_CONFIGS } from '@/types/email'
+import { TableSortHeader } from '@/components/shared/TableSortHeader'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -46,23 +41,6 @@ interface EmailAuditTableProps {
   sortDirection?: SortDirection
   onSort?: (column: SortColumn) => void
   onContactSupport?: (entry: AuditEntry) => void
-}
-
-function SortIcon({
-  column,
-  sortColumn,
-  sortDirection,
-}: {
-  column: SortColumn
-  sortColumn?: SortColumn | null
-  sortDirection?: SortDirection
-}) {
-  if (sortColumn !== column) return <ChevronsUpDown className="w-3 h-3 opacity-40" />
-  return sortDirection === 'asc' ? (
-    <ChevronUp className="w-3 h-3 text-primary" />
-  ) : (
-    <ChevronDown className="w-3 h-3 text-primary" />
-  )
 }
 
 const STATUS_COLOR_VARIANT: Record<
@@ -147,13 +125,13 @@ export function EmailAuditTable({
   }
 
   const col = (column: SortColumn, label: string) => (
-    <button
-      onClick={() => onSort?.(column)}
-      className={`flex items-center gap-1 hover:text-foreground transition-colors ${sortColumn === column ? 'text-foreground' : ''}`}
-    >
-      {label}
-      <SortIcon column={column} sortColumn={sortColumn} sortDirection={sortDirection} />
-    </button>
+    <TableSortHeader
+      label={label}
+      field={column}
+      currentSort={sortColumn}
+      currentOrder={sortDirection}
+      onSort={onSort}
+    />
   )
 
   // 9 columns: Date | First Name | Last Name | Email | Email Name | Category | Status | Details | Action

--- a/src/components/producer/Email/EmailTable.tsx
+++ b/src/components/producer/Email/EmailTable.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
-import { ChevronUp, ChevronDown, ChevronsUpDown, HelpCircle } from 'lucide-react'
+import { ChevronUp, ChevronDown, HelpCircle } from 'lucide-react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { ScheduledEmail, AuditFilters } from '@/types/email'
 import EmailRow from './EmailRow'
 import { TABLE_HEADER_CLASSES } from '@/components/shared/tableStyles'
+import { TableSortHeader } from '@/components/shared/TableSortHeader'
 
 type SortColumn =
   | 'name'
@@ -29,24 +30,6 @@ interface EmailTableProps {
   sortColumn?: SortColumn | null
   sortDirection?: SortDirection
   onSort?: (column: SortColumn) => void
-}
-
-function SortIcon({
-  column,
-  sortColumn,
-  sortDirection,
-}: {
-  column: SortColumn
-  sortColumn?: SortColumn | null
-  sortDirection?: SortDirection
-}) {
-  if (sortColumn !== column)
-    return <ChevronsUpDown className="h-3 w-3 text-foreground/45 dark:text-foreground/40" />
-  return sortDirection === 'asc' ? (
-    <ChevronUp className="h-3 w-3 text-violet-700 dark:text-primary" />
-  ) : (
-    <ChevronDown className="h-3 w-3 text-violet-700 dark:text-primary" />
-  )
 }
 
 // Check if email is a system email (matches backend SYSTEM_TRIGGERS)
@@ -92,27 +75,19 @@ export default function EmailTable({
     )
   }
 
-  const col = (column: SortColumn, label: string, className?: string, title?: string) => {
-    // Only show sort icons if onSort is provided (scheduled emails table)
-    if (!onSort) {
-      return (
-        <div className={`flex items-center gap-1 ${className ?? ''}`} title={title}>
-          {label}
-        </div>
-      )
-    }
-
-    return (
-      <button
-        onClick={() => onSort(column)}
-        className={`flex items-center gap-1 hover:text-foreground transition-colors ${sortColumn === column ? 'text-foreground' : ''} ${className ?? ''}`}
-        title={title}
-      >
-        {label}
-        <SortIcon column={column} sortColumn={sortColumn} sortDirection={sortDirection} />
-      </button>
-    )
-  }
+  // Sortable header cell via the universal TableSortHeader (onSort omitted →
+  // renders a static, non-sortable label).
+  const col = (column: SortColumn, label: string, className?: string, title?: string) => (
+    <TableSortHeader
+      label={label}
+      field={column}
+      currentSort={sortColumn}
+      currentOrder={sortDirection}
+      onSort={onSort}
+      className={className}
+      title={title}
+    />
+  )
 
   // Group emails into system and reminders
   const systemEmails = emails.filter((email) => isSystemEmail(email.trigger_type))

--- a/src/components/producer/EventSettings.tsx
+++ b/src/components/producer/EventSettings.tsx
@@ -12,7 +12,6 @@ import {
   AlertCircle,
   DollarSign,
   Save,
-  Webhook,
 } from 'lucide-react'
 import {
   Accordion,
@@ -1391,114 +1390,6 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
                     : 'No categories configured yet.'}
                 </div>
               )}
-            </AccordionContent>
-          </AccordionItem>
-
-          {/* n8n Webhook Integration Status */}
-          <AccordionItem value="n8n-webhook" className="border-border">
-            <AccordionTrigger className={triggerHoverClass}>
-              <div className="flex items-center gap-3">
-                <div className="rounded-lg bg-purple-500/20 p-1.5">
-                  <Webhook className="h-4 w-4 text-purple-700 dark:text-purple-400" />
-                </div>
-                <div className="text-left">
-                  <span className="text-sm font-semibold text-foreground">
-                    n8n Payment Sync Status
-                  </span>
-                  <p className="text-xs text-foreground/50 font-normal">
-                    Eventbrite Event ID auto-detection status per category
-                  </p>
-                </div>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent className="px-4">
-              <div className="space-y-3">
-                <div className={cn(compactWell, 'bg-blue-500/5 border border-blue-500/20')}>
-                  <p className="text-xs text-foreground/70 mb-2">
-                    <strong>✨ Auto-Detection Enabled:</strong>
-                  </p>
-                  <p className="text-xs text-muted-foreground mb-3">
-                    Webhook configuration is now organization-wide! When you add Eventbrite payment
-                    links to categories below, we automatically extract the Eventbrite Event ID.
-                    Your n8n workflow will detect the correct event without any manual
-                    configuration.
-                  </p>
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      window.location.href = '/dashboard/settings'
-                    }}
-                    className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-lg voxxy-btn-cta transition-all"
-                  >
-                    <Webhook className="h-4 w-4" />
-                    Configure Webhook in Settings
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
-                </div>
-
-                {applications.length > 0 && (
-                  <div>
-                    <p className="text-xs font-semibold text-foreground mb-2">Category Status:</p>
-                    <div className="space-y-2">
-                      {applications.map((app) => {
-                        const hasEventbriteEngine = app.payment_engines?.some(
-                          (pe) => pe.engine === 'eventbrite',
-                        )
-                        const hasEventbriteId = !!app.eventbrite_event_id
-
-                        return (
-                          <div key={app.id} className={cn(compactWell, 'voxxy-hover-panel')}>
-                            <div className="flex items-center justify-between">
-                              <div className="flex items-center gap-2">
-                                <p className="text-xs font-semibold text-foreground">{app.name}</p>
-                                {hasEventbriteId ? (
-                                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/20 border border-green-500/30 text-[10px] font-medium text-green-800 dark:text-green-400">
-                                    <Check className="w-3 h-3" />
-                                    n8n Ready
-                                  </span>
-                                ) : hasEventbriteEngine ? (
-                                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/20 border border-amber-500/30 text-[10px] font-medium text-amber-800 dark:text-amber-400">
-                                    <AlertCircle className="w-3 h-3" />
-                                    Invalid URL
-                                  </span>
-                                ) : (
-                                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-muted border border-border text-[10px] font-medium text-muted-foreground">
-                                    No Eventbrite
-                                  </span>
-                                )}
-                              </div>
-                              {hasEventbriteId && (
-                                <p className="text-[10px] font-mono text-muted-foreground">
-                                  ID: {app.eventbrite_event_id}
-                                </p>
-                              )}
-                            </div>
-                            {hasEventbriteEngine && !hasEventbriteId && (
-                              <p className="text-[10px] text-muted-foreground mt-1">
-                                ⚠️ Eventbrite link found but ID extraction failed. Check URL format
-                                in Payment Config.
-                              </p>
-                            )}
-                          </div>
-                        )
-                      })}
-                    </div>
-                  </div>
-                )}
-
-                <div className={cn(compactWell, 'bg-accent/30')}>
-                  <p className="text-xs text-muted-foreground">
-                    <strong>How it works:</strong> Add Eventbrite payment links in Payment
-                    Configuration above. We automatically extract the Event ID from URLs like{' '}
-                    <code className="bg-background/50 px-1 rounded">
-                      eventbrite.com/e/event-name-123456
-                    </code>
-                    . Your n8n workflow sends this ID in the payload, and we match it to the correct
-                    category automatically!
-                  </p>
-                </div>
-              </div>
             </AccordionContent>
           </AccordionItem>
 

--- a/src/components/producer/GoLiveInvitationEditor.tsx
+++ b/src/components/producer/GoLiveInvitationEditor.tsx
@@ -8,7 +8,6 @@ import {
   AlertTriangle,
   Plus,
   ChevronDown,
-  ChevronUp,
   ChevronLeft,
   ChevronRight,
   Filter,
@@ -16,6 +15,7 @@ import {
 
 const PAGE_SIZE = 50
 import { vendorContactsApi, contactListsApi, VendorContact, ContactList } from '@/services/api'
+import { TableSortHeader } from '@/components/shared/TableSortHeader'
 
 interface GoLiveInvitationEditorProps {
   event: any
@@ -703,39 +703,21 @@ export default function GoLiveInvitationEditor({
                   className="w-3.5 h-3.5 rounded border-border bg-background/10 text-primary focus:ring-primary focus:ring-offset-0 focus:ring-1"
                 />
               </div>
-              <button
-                type="button"
-                onClick={() => handleSort('name')}
-                className="flex items-center gap-1 hover:text-foreground transition-colors text-left"
-              >
-                Name
-                {sortColumn === 'name' ? (
-                  sortDirection === 'asc' ? (
-                    <ChevronUp className="w-3 h-3" />
-                  ) : (
-                    <ChevronDown className="w-3 h-3" />
-                  )
-                ) : (
-                  <ChevronDown className="w-3 h-3 opacity-30" />
-                )}
-              </button>
+              <TableSortHeader
+                label="Name"
+                field="name"
+                currentSort={sortColumn}
+                currentOrder={sortDirection}
+                onSort={handleSort}
+              />
               <div>Affiliation</div>
-              <button
-                type="button"
-                onClick={() => handleSort('email')}
-                className="flex items-center gap-1 hover:text-foreground transition-colors text-left"
-              >
-                Email
-                {sortColumn === 'email' ? (
-                  sortDirection === 'asc' ? (
-                    <ChevronUp className="w-3 h-3" />
-                  ) : (
-                    <ChevronDown className="w-3 h-3" />
-                  )
-                ) : (
-                  <ChevronDown className="w-3 h-3 opacity-30" />
-                )}
-              </button>
+              <TableSortHeader
+                label="Email"
+                field="email"
+                currentSort={sortColumn}
+                currentOrder={sortDirection}
+                onSort={handleSort}
+              />
               <div>Type</div>
             </div>
           </div>

--- a/src/components/producer/Network/BulkEditModal.tsx
+++ b/src/components/producer/Network/BulkEditModal.tsx
@@ -67,12 +67,12 @@ export default function BulkEditModal({
 
   return (
     <div
-      className="voxxy-overlay-scrim fixed inset-0 z-50 flex items-center justify-center p-4"
+      className="voxxy-overlay-scrim fixed inset-0 z-50 flex justify-end"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <div className="voxxy-modal-surface w-full max-w-md rounded-xl overflow-hidden">
+      <div className="voxxy-modal-surface flex h-full w-full max-w-md flex-col overflow-hidden shadow-2xl sm:max-w-lg">
         <div className="voxxy-gradient-modal-header flex items-center justify-between border-b border-primary/20 px-5 py-3">
           <div>
             <h2 className="text-base font-semibold text-foreground">{BULK_EDIT_LABEL}</h2>
@@ -91,7 +91,7 @@ export default function BulkEditModal({
           </button>
         </div>
 
-        <div className="p-5 space-y-4">
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
           {!hasSelection ? (
             <p className="text-sm text-foreground/70">{BULK_EDIT_EMPTY_HINT}</p>
           ) : (

--- a/src/components/producer/Network/CSVUploadModal.tsx
+++ b/src/components/producer/Network/CSVUploadModal.tsx
@@ -24,7 +24,7 @@ import { useImportState } from './csvImport/useImportState'
 import { autoDetectMappings, buildImportRows } from './csvImport/columnMapping'
 import { validateAllRows, revalidateRow } from './csvImport/clientValidation'
 import { prepareSubmission } from './csvImport/csvRewriter'
-import { RECOGNIZED_FIELD_KEYS, MERGE_FIELDS } from './csvImport/constants'
+import { RECOGNIZED_FIELD_KEYS } from './csvImport/constants'
 import type { CSVUploadModalProps } from './csvImport/types'
 
 import { StepUpload } from './csvImport/StepUpload'
@@ -68,17 +68,11 @@ export function CSVUploadModal({
   )
 
   const visibleFields = useMemo(() => {
-    const fields = state.columnMappings
+    // Mapped recognized fields, including first_name/last_name which now stay
+    // as separate preview columns (joined into `name` only at submission).
+    return state.columnMappings
       .filter((m) => m.mappedTo !== null && RECOGNIZED_FIELD_KEYS.includes(m.mappedTo!))
       .map((m) => m.mappedTo!)
-    // If name was created via merge (first_name+last_name), ensure it appears
-    const hasMerge = state.columnMappings.some(
-      (m) => m.mappedTo !== null && MERGE_FIELDS[m.mappedTo!] !== undefined,
-    )
-    if (hasMerge && !fields.includes('name')) {
-      fields.unshift('name')
-    }
-    return fields
   }, [state.columnMappings])
 
   // ─── Handlers ────────────────────────────────────────────────────

--- a/src/components/producer/Network/NetworkPage.tsx
+++ b/src/components/producer/Network/NetworkPage.tsx
@@ -32,15 +32,12 @@ import ViewContactModal from './ViewContactModal'
 import { CSVUploadModal } from './CSVUploadModal'
 import ListsManagement from './Lists/ListsManagement'
 import BulkEditModal from './BulkEditModal'
+import SelectionActionBar from './SelectionActionBar'
 import ContactExportModal from './ContactExportModal'
 import FilterPanel, { type FilterDraft } from './FilterPanel'
 import type { ActiveFilter } from '@/components/shared/SearchFilterBar'
 import { notify } from '@/errors/notify'
 import { getApiErrorMessage } from '@/errors/getApiErrorMessage'
-import {
-  IMPORT_BATCH_VIEW_LABEL,
-  BULK_EDIT_LABEL,
-} from './copy'
 import {
   type ImportSession,
   clearImportSession,
@@ -1050,16 +1047,6 @@ export default function NetworkPage({
                     </button>
                     <button
                       onClick={() => {
-                        setShowBulkEditModal(true)
-                        setActionsMenuOpen(false)
-                      }}
-                      className="flex items-center gap-2 w-full px-4 py-2.5 text-xs font-medium text-foreground hover:bg-primary/10 transition-colors"
-                    >
-                      <Users className="w-3.5 h-3.5" />
-                      {BULK_EDIT_LABEL}
-                    </button>
-                    <button
-                      onClick={() => {
                         setShowExportModal(true)
                         setActionsMenuOpen(false)
                       }}
@@ -1136,6 +1123,15 @@ export default function NetworkPage({
                 </button>
               </div>
             )}
+
+          {/* Selection action bar — appears when rows are selected */}
+          <SelectionActionBar
+            count={selectedContacts.length}
+            onEdit={() => setShowBulkEditModal(true)}
+            onDelete={handleBulkDelete}
+            onClear={() => setSelectedContacts([])}
+            loading={bulkUpdateLoading}
+          />
 
           {/* Contacts Table */}
           {displayedContacts.length > 0 && (

--- a/src/components/producer/Network/SelectionActionBar.test.tsx
+++ b/src/components/producer/Network/SelectionActionBar.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import SelectionActionBar from './SelectionActionBar'
+
+describe('SelectionActionBar', () => {
+  const noop = () => {}
+
+  it('renders nothing when no rows are selected', () => {
+    const { container } = render(
+      <SelectionActionBar count={0} onEdit={noop} onDelete={noop} onClear={noop} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the selected count and the bulk actions when rows are selected', () => {
+    render(<SelectionActionBar count={3} onEdit={noop} onDelete={noop} onClear={noop} />)
+    expect(screen.getByText('3 selected')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument()
+  })
+
+  it('wires up edit, delete, and clear callbacks', () => {
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+    const onClear = vi.fn()
+    render(<SelectionActionBar count={2} onEdit={onEdit} onDelete={onDelete} onClear={onClear} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /clear selection/i }))
+
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables actions and shows deleting state while loading', () => {
+    render(
+      <SelectionActionBar count={2} onEdit={noop} onDelete={noop} onClear={noop} loading />,
+    )
+    expect(screen.getByRole('button', { name: /edit/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /deleting/i })).toBeDisabled()
+  })
+})

--- a/src/components/producer/Network/SelectionActionBar.tsx
+++ b/src/components/producer/Network/SelectionActionBar.tsx
@@ -1,0 +1,70 @@
+import { Pencil, Trash2, X } from 'lucide-react'
+
+interface SelectionActionBarProps {
+  /** Number of currently selected rows. The bar renders only when > 0. */
+  count: number
+  onEdit: () => void
+  onDelete: () => void
+  onClear: () => void
+  loading?: boolean
+}
+
+/**
+ * Contextual action bar that appears directly above the contacts table when one
+ * or more rows are selected. Bulk actions (Edit / Delete) live here so producers
+ * can act on a selection without digging through a menu or opening a modal first.
+ */
+export default function SelectionActionBar({
+  count,
+  onEdit,
+  onDelete,
+  onClear,
+  loading = false,
+}: SelectionActionBarProps) {
+  if (count <= 0) return null
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Bulk actions for selected contacts"
+      className="flex flex-wrap items-center gap-2 px-3 py-2 bg-primary/15 border border-primary/30 rounded-lg"
+    >
+      <span className="text-sm font-medium text-foreground">
+        {count} selected
+      </span>
+
+      <div className="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onEdit}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-border text-foreground/90 hover:bg-background/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Pencil className="w-3.5 h-3.5" />
+          Edit
+        </button>
+
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-red-600/20 text-red-400 hover:bg-red-600/30 hover:text-red-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+          {loading ? 'Deleting...' : 'Delete'}
+        </button>
+
+        <button
+          type="button"
+          onClick={onClear}
+          disabled={loading}
+          className="flex items-center gap-1 text-xs text-foreground/60 hover:text-foreground transition-colors disabled:opacity-50"
+          aria-label="Clear selection"
+        >
+          <X className="w-3.5 h-3.5" />
+          Clear
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/producer/Network/csvImport/StepColumnMapping.tsx
+++ b/src/components/producer/Network/csvImport/StepColumnMapping.tsx
@@ -47,7 +47,8 @@ export function StepColumnMapping({
       {!nameMapped && (
         <div className="flex items-center gap-2 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg">
           <span className="text-xs text-red-300">
-            <strong>Name</strong> is required. Choose a CSV column for it below to continue.
+            <strong>First Name</strong> is required (or map a single Full Name column). Choose a CSV
+            column for it below to continue.
           </span>
         </div>
       )}

--- a/src/components/producer/Network/csvImport/StepPreviewEdit.tsx
+++ b/src/components/producer/Network/csvImport/StepPreviewEdit.tsx
@@ -126,7 +126,7 @@ export function StepPreviewEdit({
         Click any cell to edit · Check &quot;Skip&quot; to exclude a row · Hover a cell{' '}
         <span className="text-red-400/80">●</span> or{' '}
         <span className="text-yellow-400/80">●</span> to see its issue.{' '}
-        <span className="text-red-400/80">Red</span> = missing Name/Email (must fix or skip).{' '}
+        <span className="text-red-400/80">Red</span> = missing First Name/Email (must fix or skip).{' '}
         <span className="text-yellow-400/80">Yellow</span> = formatting issue (will still import).
       </p>
 

--- a/src/components/producer/Network/csvImport/StepReviewLists.tsx
+++ b/src/components/producer/Network/csvImport/StepReviewLists.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { CheckCircle2, AlertCircle } from 'lucide-react'
@@ -15,6 +16,17 @@ interface StepReviewListsProps {
 
 const MAX_VISIBLE_ERRORS = 5
 
+/** Group {row, field, message}[] by message with counts, most frequent first. */
+function groupByMessage(items: Array<{ row: number; field: string; message: string }>) {
+  const counts = new Map<string, number>()
+  for (const item of items) {
+    counts.set(item.message, (counts.get(item.message) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([message, count]) => ({ message, count }))
+}
+
 export function StepReviewLists({
   importResult,
   errorMessage,
@@ -22,7 +34,12 @@ export function StepReviewLists({
 }: StepReviewListsProps) {
   const created = importResult.summary.created ?? 0
   const updated = importResult.summary.updated ?? 0
+  const failed = importResult.summary.failed ?? 0
   const importedTotal = created + updated
+  const groupedWarnings = useMemo(
+    () => groupByMessage(importResult.warnings ?? []),
+    [importResult.warnings],
+  )
 
   return (
     <div className="space-y-4">
@@ -46,7 +63,26 @@ export function StepReviewLists({
         {updated > 0 && (
           <span className="text-foreground/60"> ({created} created, {updated} updated)</span>
         )}
+        {failed > 0 && (
+          <span className="text-red-400/80"> · {failed} not imported</span>
+        )}
       </p>
+
+      {groupedWarnings.length > 0 && (
+        <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-4 py-3">
+          <p className="text-xs font-medium text-yellow-300 mb-2">
+            Formatting cleaned up on import
+          </p>
+          <div className="space-y-1.5">
+            {groupedWarnings.map(({ message, count }) => (
+              <div key={message} className="flex justify-between gap-3 text-xs">
+                <span className="text-yellow-200/70 truncate">{message}</span>
+                <span className="text-yellow-400 font-medium shrink-0">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {importResult.errors.length > 0 && (
         <Alert variant="destructive">

--- a/src/components/producer/Network/csvImport/clientValidation.test.ts
+++ b/src/components/producer/Network/csvImport/clientValidation.test.ts
@@ -19,9 +19,9 @@ function makeRow(overrides: Partial<ImportRow> = {}): ImportRow {
 
 describe('validateRow', () => {
   describe('blocking errors', () => {
-    it('returns error when name is missing', () => {
+    it('returns error when the single Full Name column is missing', () => {
       const result = validateRow(makeRow({ name: '' }))
-      expect(result.errors.name).toContain('Name is required')
+      expect(result.errors.name).toContain('First name is required')
     })
 
     it('returns error when email is missing', () => {
@@ -37,6 +37,29 @@ describe('validateRow', () => {
 
     it('returns no errors for valid row', () => {
       const result = validateRow(makeRow())
+      expect(Object.keys(result.errors)).toHaveLength(0)
+    })
+  })
+
+  describe('first/last name columns', () => {
+    it('is valid when first_name is present and there is no Full Name column', () => {
+      const result = validateRow(
+        makeRow({ name: undefined, first_name: 'Alice', last_name: 'Smith' }),
+      )
+      expect(Object.keys(result.errors)).toHaveLength(0)
+    })
+
+    it('blocks on the first_name cell when a first_name column is present but blank', () => {
+      const result = validateRow(
+        makeRow({ name: undefined, first_name: '', last_name: 'Smith' }),
+      )
+      expect(result.errors.first_name).toContain('First name is required')
+      // The error targets the visible first_name cell, not a phantom name cell
+      expect(result.errors.name).toBeUndefined()
+    })
+
+    it('is valid with first name only (last name optional)', () => {
+      const result = validateRow(makeRow({ name: undefined, first_name: 'Alice' }))
       expect(Object.keys(result.errors)).toHaveLength(0)
     })
   })
@@ -200,7 +223,7 @@ describe('revalidateRow', () => {
   it('returns errors, warnings, and computed status', () => {
     const result = revalidateRow(makeRow({ name: '' }))
 
-    expect(result.errors.name).toContain('Name is required')
+    expect(result.errors.name).toContain('First name is required')
     expect(result.status).toBe('error')
   })
 

--- a/src/components/producer/Network/csvImport/clientValidation.ts
+++ b/src/components/producer/Network/csvImport/clientValidation.ts
@@ -86,12 +86,14 @@ export interface RowValidation {
 /**
  * Validate a single import row.
  *
- * Severity model: the ONLY blocking errors are a missing Name (DB hard-requires
- * it) and a missing Email (our unique identifier for matching/de-duping).
- * Everything else — format nitpicks on phone, socials, website, location,
- * affiliation length — is a warning: we surface it so the producer can clean
- * their data inline. The backend also treats these as warnings, so rows with
- * only warnings will still import successfully.
+ * Severity model: the ONLY blocking errors are a missing first name (a single
+ * Full Name column also satisfies this) and a missing Email (our unique
+ * identifier for matching/de-duping). Everything else — format nitpicks on
+ * phone, socials, website, location, affiliation length — is a warning: we
+ * surface it so the producer can clean their data inline. The backend also
+ * treats these as warnings, so rows with only warnings still import.
+ * Duplicate emails are a hard error, but those are only known server-side and
+ * are surfaced at the validation step.
  */
 export function validateRow(row: ImportRow): RowValidation {
   const errors: Record<string, string[]> = {}
@@ -104,9 +106,15 @@ export function validateRow(row: ImportRow): RowValidation {
 
   // ── Blocking errors ────────────────────────────────────────────────
 
-  const name = String(row.name ?? '').trim()
-  if (!name) {
-    add(errors, 'name', 'Name is required')
+  // First name is required. Files may provide either separate first/last name
+  // columns or a single Full Name column, so the requirement is satisfied by
+  // either. Attach the error to whichever name column is present in the row so
+  // the offending cell highlights.
+  const firstName = String(row.first_name ?? '').trim()
+  const fullName = String(row.name ?? '').trim()
+  if (!firstName && !fullName) {
+    const field = row.first_name !== undefined ? 'first_name' : 'name'
+    add(errors, field, 'First name is required')
   }
 
   const email = String(row.email ?? '').trim()

--- a/src/components/producer/Network/csvImport/columnMapping.test.ts
+++ b/src/components/producer/Network/csvImport/columnMapping.test.ts
@@ -35,7 +35,7 @@ describe('autoDetectMappings', () => {
     expect(mappings[1]).toMatchObject({ mappedTo: 'email', confidence: 'alias' })
   })
 
-  it('maps first_name/last_name as merge fields', () => {
+  it('exact-matches first_name/last_name to their own fields', () => {
     const mappings = autoDetectMappings(['first_name', 'last_name', 'email'], [
       { first_name: 'Alice', last_name: 'Smith', email: 'a@b.com' },
     ])
@@ -45,14 +45,14 @@ describe('autoDetectMappings', () => {
     expect(ln?.mappedTo).toBe('last_name')
   })
 
-  it('maps firstname/lastname (no underscore) as merge fields', () => {
+  it('aliases firstname/lastname (no underscore) to first_name/last_name', () => {
     const mappings = autoDetectMappings(['firstname', 'lastname', 'email'], [
       { firstname: 'Alice', lastname: 'Smith', email: 'a@b.com' },
     ])
     const fn = mappings.find((m) => m.csvHeader === 'firstname')
     const ln = mappings.find((m) => m.csvHeader === 'lastname')
-    expect(fn?.mappedTo).toBe('firstname')
-    expect(ln?.mappedTo).toBe('lastname')
+    expect(fn?.mappedTo).toBe('first_name')
+    expect(ln?.mappedTo).toBe('last_name')
   })
 
   it('sets unmapped columns to null with confidence none', () => {
@@ -103,55 +103,47 @@ describe('buildImportRows', () => {
     expect(rows[0]._status).toBe('valid')
   })
 
-  it('merges first_name + last_name into name', () => {
+  it('keeps first_name and last_name as separate columns (no merge)', () => {
     const mappings: ColumnMapping[] = [
-      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'alias', sampleValues: [] },
-      { csvHeader: 'last_name', mappedTo: 'last_name', confidence: 'alias', sampleValues: [] },
+      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'exact', sampleValues: [] },
+      { csvHeader: 'last_name', mappedTo: 'last_name', confidence: 'exact', sampleValues: [] },
       { csvHeader: 'email', mappedTo: 'email', confidence: 'exact', sampleValues: [] },
     ]
     const rawRows = [{ first_name: 'Alice', last_name: 'Smith', email: 'a@b.com' }]
 
     const rows = buildImportRows(rawRows, mappings)
 
-    expect(rows[0].name).toBe('Alice Smith')
+    expect(rows[0].first_name).toBe('Alice')
+    expect(rows[0].last_name).toBe('Smith')
+    // name is NOT merged at this stage — it's joined only at submission
+    expect(rows[0].name).toBeUndefined()
   })
 
-  it('merges firstname + lastname (no underscore) into name', () => {
+  it('keeps a first_name-only file as a first_name column', () => {
     const mappings: ColumnMapping[] = [
-      { csvHeader: 'firstname', mappedTo: 'firstname', confidence: 'alias', sampleValues: [] },
-      { csvHeader: 'lastname', mappedTo: 'lastname', confidence: 'alias', sampleValues: [] },
-      { csvHeader: 'email', mappedTo: 'email', confidence: 'exact', sampleValues: [] },
-    ]
-    const rawRows = [{ firstname: 'Alice', lastname: 'Smith', email: 'a@b.com' }]
-
-    const rows = buildImportRows(rawRows, mappings)
-
-    expect(rows[0].name).toBe('Alice Smith')
-  })
-
-  it('handles first_name only (no last_name)', () => {
-    const mappings: ColumnMapping[] = [
-      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'alias', sampleValues: [] },
+      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'exact', sampleValues: [] },
       { csvHeader: 'email', mappedTo: 'email', confidence: 'exact', sampleValues: [] },
     ]
     const rawRows = [{ first_name: 'Alice', email: 'a@b.com' }]
 
     const rows = buildImportRows(rawRows, mappings)
 
-    expect(rows[0].name).toBe('Alice')
+    expect(rows[0].first_name).toBe('Alice')
+    expect(rows[0].name).toBeUndefined()
   })
 
-  it('does not overwrite direct name mapping with merge', () => {
+  it('keeps a direct Full Name mapping alongside first_name', () => {
     const mappings: ColumnMapping[] = [
       { csvHeader: 'Name', mappedTo: 'name', confidence: 'exact', sampleValues: [] },
-      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'alias', sampleValues: [] },
+      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'exact', sampleValues: [] },
       { csvHeader: 'email', mappedTo: 'email', confidence: 'exact', sampleValues: [] },
     ]
-    const rawRows = [{ Name: 'Direct Name', first_name: 'Merged', email: 'a@b.com' }]
+    const rawRows = [{ Name: 'Direct Name', first_name: 'First', email: 'a@b.com' }]
 
     const rows = buildImportRows(rawRows, mappings)
 
     expect(rows[0].name).toBe('Direct Name')
+    expect(rows[0].first_name).toBe('First')
   })
 
   it('skips unmapped columns', () => {
@@ -189,18 +181,19 @@ describe('isNameMapped', () => {
     expect(isNameMapped(mappings)).toBe(true)
   })
 
-  it('returns true when first_name is mapped (merge)', () => {
+  it('returns true when first_name is mapped', () => {
     const mappings: ColumnMapping[] = [
-      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'alias', sampleValues: [] },
+      { csvHeader: 'first_name', mappedTo: 'first_name', confidence: 'exact', sampleValues: [] },
     ]
     expect(isNameMapped(mappings)).toBe(true)
   })
 
-  it('returns true when lastname (no underscore) is mapped', () => {
+  it('returns false when only last_name is mapped (last name alone is insufficient)', () => {
     const mappings: ColumnMapping[] = [
-      { csvHeader: 'lastname', mappedTo: 'lastname', confidence: 'alias', sampleValues: [] },
+      { csvHeader: 'last_name', mappedTo: 'last_name', confidence: 'exact', sampleValues: [] },
+      { csvHeader: 'email', mappedTo: 'email', confidence: 'exact', sampleValues: [] },
     ]
-    expect(isNameMapped(mappings)).toBe(true)
+    expect(isNameMapped(mappings)).toBe(false)
   })
 
   it('returns false when no name-related field is mapped', () => {

--- a/src/components/producer/Network/csvImport/columnMapping.ts
+++ b/src/components/producer/Network/csvImport/columnMapping.ts
@@ -1,5 +1,5 @@
 import type { ColumnMapping, ImportRow } from './types'
-import { RECOGNIZED_FIELD_KEYS, HEADER_ALIASES, MERGE_FIELDS } from './constants'
+import { RECOGNIZED_FIELD_KEYS, HEADER_ALIASES } from './constants'
 
 /**
  * Normalize a CSV header for matching: lowercase, trim, replace spaces with underscores.
@@ -53,15 +53,7 @@ export function autoDetectMappings(
       continue
     }
 
-    // 3. Merge field (first_name, last_name → name)
-    const mergeField = MERGE_FIELDS[normalized]
-    if (mergeField && !claimed.has(mergeField.target)) {
-      // Don't claim yet — let both parts map. We'll merge in buildImportRows.
-      mappings.push({ csvHeader: header, mappedTo: normalized, confidence: 'alias', sampleValues: samples })
-      continue
-    }
-
-    // 4. Fuzzy substring match
+    // 3. Fuzzy substring match
     const fuzzyMatch = RECOGNIZED_FIELD_KEYS.find(
       (key) => !claimed.has(key) && (normalized.includes(key) || key.includes(normalized)),
     )
@@ -71,13 +63,13 @@ export function autoDetectMappings(
       continue
     }
 
-    // 5. Alias target already claimed or no match
+    // 4. Alias target already claimed or no match
     if (aliasTarget && claimed.has(aliasTarget)) {
       mappings.push({ csvHeader: header, mappedTo: null, confidence: 'none', sampleValues: samples })
       continue
     }
 
-    // 6. No match
+    // 5. No match
     mappings.push({ csvHeader: header, mappedTo: null, confidence: 'none', sampleValues: samples })
   }
 
@@ -86,7 +78,8 @@ export function autoDetectMappings(
 
 /**
  * Convert raw CSV rows + column mappings into ImportRows with mapped field keys.
- * Handles first_name + last_name merge into name.
+ * First name and last name are kept as separate columns; they're only joined
+ * into a single `name` at submission time (see csvRewriter).
  */
 export function buildImportRows(
   rawRows: Record<string, string>[],
@@ -96,21 +89,6 @@ export function buildImportRows(
   const headerToField = new Map<string, string>()
   for (const m of mappings) {
     if (m.mappedTo) headerToField.set(m.csvHeader, m.mappedTo)
-  }
-
-  // Check for first_name/last_name merge
-  const hasMerge = mappings.some((m) => {
-    const norm = normalizeHeader(m.csvHeader)
-    return MERGE_FIELDS[norm] !== undefined
-  })
-  const mergeHeaders: Record<string, string> = {}
-  if (hasMerge) {
-    for (const m of mappings) {
-      const norm = normalizeHeader(m.csvHeader)
-      if (MERGE_FIELDS[norm]) {
-        mergeHeaders[norm] = m.csvHeader
-      }
-    }
   }
 
   return rawRows.map((raw, idx) => {
@@ -123,24 +101,7 @@ export function buildImportRows(
     }
 
     for (const [csvHeader, fieldKey] of headerToField) {
-      const norm = normalizeHeader(csvHeader)
-      // Skip merge-source fields (they'll be combined into 'name')
-      if (MERGE_FIELDS[norm]) continue
       row[fieldKey] = raw[csvHeader]?.trim() ?? ''
-    }
-
-    // Handle first_name + last_name → name merge
-    // Collect ALL merge-source values regardless of naming convention
-    // (handles mixed cases like `firstname` + `last_name`)
-    if (Object.keys(mergeHeaders).length > 0 && ![...headerToField.values()].includes('name')) {
-      const nameParts: string[] = []
-      for (const csvHeader of Object.values(mergeHeaders)) {
-        const val = raw[csvHeader]?.trim()
-        if (val) nameParts.push(val)
-      }
-      if (nameParts.length > 0) {
-        row.name = nameParts.join(' ')
-      }
     }
 
     return row
@@ -148,21 +109,9 @@ export function buildImportRows(
 }
 
 /**
- * Check if the required 'name' field is mapped (either directly or via merge fields).
+ * Check if the name requirement is satisfied — either a single Full Name column
+ * or a First Name column is mapped. (Last name alone is not sufficient.)
  */
 export function isNameMapped(mappings: ColumnMapping[]): boolean {
-  // Direct name mapping
-  if (mappings.some((m) => m.mappedTo === 'name')) return true
-
-  // Merged via first_name + last_name
-  const mergeNorms = mappings
-    .filter((m) => m.mappedTo !== null)
-    .map((m) => normalizeHeader(m.csvHeader))
-  const hasFirstName = mergeNorms.some(
-    (n) => n === 'first_name' || n === 'firstname',
-  )
-  const hasLastName = mergeNorms.some(
-    (n) => n === 'last_name' || n === 'lastname',
-  )
-  return hasFirstName || hasLastName
+  return mappings.some((m) => m.mappedTo === 'name' || m.mappedTo === 'first_name')
 }

--- a/src/components/producer/Network/csvImport/constants.ts
+++ b/src/components/producer/Network/csvImport/constants.ts
@@ -10,11 +10,17 @@ export interface FieldDefinition {
 }
 
 export const RECOGNIZED_FIELDS: FieldDefinition[] = [
-  { key: 'name', label: 'Name', required: true },
-  // Email is required on import even though the backend allows it blank —
-  // it's the unique identifier used to match/de-dupe existing contacts and
-  // the only way to actually reach an imported contact.
+  // Most spreadsheets keep first and last name in separate columns, so we keep
+  // them separate through mapping + preview and only join them into a single
+  // `name` at submission time. First name is required; last name is optional.
+  { key: 'first_name', label: 'First Name', required: true },
+  { key: 'last_name', label: 'Last Name', required: false },
+  // Email is required — it's the unique identifier used to match/de-dupe
+  // existing contacts and the only way to actually reach an imported contact.
   { key: 'email', label: 'Email', required: true },
+  // Fallback for files that keep the whole name in one column. Either this OR
+  // First Name satisfies the name requirement.
+  { key: 'name', label: 'Full Name', required: false },
   { key: 'phone', label: 'Phone', required: false },
   { key: 'affiliation', label: 'Affiliation', required: false },
   { key: 'instagram_handle', label: 'Instagram', required: false },
@@ -24,6 +30,9 @@ export const RECOGNIZED_FIELDS: FieldDefinition[] = [
   { key: 'tags', label: 'Tags', required: false },
   { key: 'notes', label: 'Notes', required: false },
 ]
+
+/** Name-part fields that are joined into the canonical `name` at submission. */
+export const NAME_PART_KEYS = ['first_name', 'last_name'] as const
 
 /** All recognized field keys */
 export const RECOGNIZED_FIELD_KEYS = RECOGNIZED_FIELDS.map((f) => f.key)
@@ -38,8 +47,24 @@ export const FIELD_LABELS: Record<string, string> = Object.fromEntries(
  * Covers common variations, legacy field names, and abbreviations.
  */
 export const HEADER_ALIASES: Record<string, string> = {
-  // Name
+  // First name
+  firstname: 'first_name',
+  fname: 'first_name',
+  first: 'first_name',
+  given_name: 'first_name',
+  givenname: 'first_name',
+
+  // Last name
+  lastname: 'last_name',
+  lname: 'last_name',
+  last: 'last_name',
+  surname: 'last_name',
+  family_name: 'last_name',
+  familyname: 'last_name',
+
+  // Full name (single-column fallback)
   full_name: 'name',
+  fullname: 'name',
   contact_name: 'name',
   vendor_name: 'name',
   vendor: 'name',
@@ -109,15 +134,4 @@ export const HEADER_ALIASES: Record<string, string> = {
   comments: 'notes',
   comment: 'notes',
   description: 'notes',
-}
-
-/**
- * Fields that should be merged if both appear in the CSV
- * (e.g., first_name + last_name → name)
- */
-export const MERGE_FIELDS: Record<string, { target: string; parts: string[] }> = {
-  first_name: { target: 'name', parts: ['first_name', 'last_name'] },
-  last_name: { target: 'name', parts: ['first_name', 'last_name'] },
-  firstname: { target: 'name', parts: ['firstname', 'lastname'] },
-  lastname: { target: 'name', parts: ['firstname', 'lastname'] },
 }

--- a/src/components/producer/Network/csvImport/csvRewriter.test.ts
+++ b/src/components/producer/Network/csvImport/csvRewriter.test.ts
@@ -6,7 +6,7 @@ function makeMapping(csvHeader: string, mappedTo: string | null): ColumnMapping 
   return { csvHeader, mappedTo, confidence: 'exact', sampleValues: [] }
 }
 
-function makeRow(overrides: Partial<ImportRow> & { name: string; email: string }): ImportRow {
+function makeRow(overrides: Partial<ImportRow> & { email: string }): ImportRow {
   return {
     _originalIndex: 2,
     _skipped: false,
@@ -112,23 +112,53 @@ describe('prepareSubmission', () => {
     })
   })
 
-  describe('merge fields', () => {
-    it('includes name column when first_name/last_name merge is active', async () => {
-      const mergeMappings: ColumnMapping[] = [
+  describe('first/last name joined at submit', () => {
+    const nameParts: ColumnMapping[] = [
+      makeMapping('first_name', 'first_name'),
+      makeMapping('last_name', 'last_name'),
+      makeMapping('Email', 'email'),
+    ]
+
+    it('reconstructs and joins first_name + last_name into a canonical name column', async () => {
+      const rows = [makeRow({ first_name: 'Alice', last_name: 'Smith', email: 'alice@test.com' })]
+
+      const result = prepareSubmission(makeFile(), nameParts, rows, false)
+
+      // Presence of name parts forces reconstruction even without edits/skips
+      expect(result.columnMapping).toBeNull()
+
+      const text = await readFileText(result.file)
+      expect(text).toContain('name')
+      expect(text).not.toContain('first_name')
+      expect(text).not.toContain('last_name')
+      expect(text).toContain('Alice Smith')
+    })
+
+    it('joins first name only when last name is absent', async () => {
+      const rows = [makeRow({ first_name: 'Alice', last_name: '', email: 'alice@test.com' })]
+
+      const result = prepareSubmission(makeFile(), nameParts, rows, false)
+
+      const text = await readFileText(result.file)
+      expect(text).toContain('Alice')
+      expect(text).not.toContain('Alice ') // no trailing space from empty last name
+    })
+
+    it('prefers an explicit Full Name over first/last when both present', async () => {
+      const mixed: ColumnMapping[] = [
+        makeMapping('Name', 'name'),
         makeMapping('first_name', 'first_name'),
-        makeMapping('last_name', 'last_name'),
         makeMapping('Email', 'email'),
       ]
       const rows = [
-        makeRow({ name: 'Alice Smith', email: 'alice@test.com' }),
+        makeRow({ name: 'Explicit Name', first_name: 'Ignored', email: 'alice@test.com' }),
       ]
 
-      const result = prepareSubmission(makeFile(), mergeMappings, rows, true)
+      const result = prepareSubmission(makeFile(), mixed, rows, false)
 
       const text = await readFileText(result.file)
-      // Should have name column even though no mapping targets 'name' directly
-      expect(text).toContain('name')
-      expect(text).toContain('Alice Smith')
+      expect(text).toContain('Explicit Name')
+      expect(text).not.toContain('Ignored')
     })
   })
 

--- a/src/components/producer/Network/csvImport/csvRewriter.ts
+++ b/src/components/producer/Network/csvImport/csvRewriter.ts
@@ -1,12 +1,29 @@
 import Papa from 'papaparse'
 import type { ImportRow, ColumnMapping } from './types'
-import { RECOGNIZED_FIELD_KEYS, MERGE_FIELDS } from './constants'
+import { RECOGNIZED_FIELD_KEYS, NAME_PART_KEYS } from './constants'
+
+/** Backend-canonical fields — first_name/last_name fold into `name` on submit. */
+const SUBMISSION_FIELD_KEYS = RECOGNIZED_FIELD_KEYS.filter(
+  (key) => !NAME_PART_KEYS.includes(key as (typeof NAME_PART_KEYS)[number]),
+)
+
+/** Join first + last name for a row, falling back to an explicit Full Name. */
+function resolveName(row: ImportRow): string {
+  const explicit = String(row.name ?? '').trim()
+  if (explicit) return explicit
+  return NAME_PART_KEYS.map((key) => String(row[key] ?? '').trim())
+    .filter(Boolean)
+    .join(' ')
+}
 
 /**
  * Build the file + column_mapping to send to the server.
  *
- * - If no cells were edited: return the original file + column_mapping JSON
- * - If cells were edited: reconstruct CSV with canonical headers using Papa.unparse()
+ * - If no cells were edited / rows skipped / name parts to join: return the
+ *   original file + column_mapping JSON (backend applies the mapping).
+ * - Otherwise: reconstruct the CSV with canonical headers using Papa.unparse().
+ *   First name + last name are joined into a single canonical `name` column,
+ *   since the backend stores one name field.
  */
 export function prepareSubmission(
   originalFile: File,
@@ -14,37 +31,43 @@ export function prepareSubmission(
   importRows: ImportRow[],
   cellsEdited: boolean,
 ): { file: File; columnMapping: Record<string, string> | null } {
-  // Build column mapping: csvHeader → recognizedFieldKey
+  // Build column mapping: csvHeader → recognizedFieldKey (backend fields only)
   const columnMapping: Record<string, string> = {}
   for (const m of mappings) {
-    if (m.mappedTo && RECOGNIZED_FIELD_KEYS.includes(m.mappedTo)) {
+    if (m.mappedTo && SUBMISSION_FIELD_KEYS.includes(m.mappedTo)) {
       columnMapping[m.csvHeader] = m.mappedTo
     }
   }
 
   const hasSkippedRows = importRows.some((r) => r._skipped)
-  if (!cellsEdited && !hasSkippedRows) {
+  // first_name/last_name aren't backend fields, so whenever they're mapped we
+  // must reconstruct the CSV to join them into `name`.
+  const hasNameParts = mappings.some(
+    (m) => m.mappedTo === 'first_name' || m.mappedTo === 'last_name',
+  )
+
+  if (!cellsEdited && !hasSkippedRows && !hasNameParts) {
     return {
       file: originalFile,
       columnMapping: Object.keys(columnMapping).length > 0 ? columnMapping : null,
     }
   }
 
-  // Reconstruct CSV from edited importRows
+  // Reconstruct CSV from edited importRows using canonical backend headers.
   const activeRows = importRows.filter((r) => !r._skipped)
-  const activeFields = RECOGNIZED_FIELD_KEYS.filter((key) =>
-    mappings.some((m) => m.mappedTo === key),
-  )
-  // If name was merged from first_name+last_name, ensure it's included
-  const hasMerge = mappings.some((m) => m.mappedTo !== null && MERGE_FIELDS[m.mappedTo!])
-  if (hasMerge && !activeFields.includes('name')) {
-    activeFields.unshift('name')
-  }
+  const activeFields = SUBMISSION_FIELD_KEYS.filter((key) => {
+    if (key === 'name') {
+      return mappings.some(
+        (m) => m.mappedTo === 'name' || m.mappedTo === 'first_name' || m.mappedTo === 'last_name',
+      )
+    }
+    return mappings.some((m) => m.mappedTo === key)
+  })
 
   const csvData = activeRows.map((row) => {
     const obj: Record<string, string> = {}
     for (const field of activeFields) {
-      obj[field] = String(row[field] ?? '')
+      obj[field] = field === 'name' ? resolveName(row) : String(row[field] ?? '')
     }
     return obj
   })

--- a/src/components/shared/TableSortHeader.test.tsx
+++ b/src/components/shared/TableSortHeader.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TableSortHeader, createSortHandler } from './TableSortHeader'
+
+describe('TableSortHeader', () => {
+  it('renders a clickable button with a visible idle affordance by default', () => {
+    render(
+      <TableSortHeader label="Email" field="email" currentSort={null} onSort={vi.fn()} />,
+    )
+    const button = screen.getByRole('button', { name: /sort by email/i })
+    expect(button).toBeInTheDocument()
+    // idle affordance is an svg icon rendered alongside the label
+    expect(button.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('can hide the idle affordance when showIdleIcon is false', () => {
+    render(
+      <TableSortHeader
+        label="Email"
+        field="email"
+        currentSort={null}
+        onSort={vi.fn()}
+        showIdleIcon={false}
+      />,
+    )
+    const button = screen.getByRole('button', { name: /sort by email/i })
+    expect(button.querySelector('svg')).not.toBeInTheDocument()
+  })
+
+  it('calls onSort with the field when clicked', () => {
+    const onSort = vi.fn()
+    render(
+      <TableSortHeader label="Name" field="name" currentSort={null} onSort={onSort} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /sort by name/i }))
+    expect(onSort).toHaveBeenCalledWith('name')
+  })
+
+  it('shows an active icon when it is the current sort column', () => {
+    const { rerender } = render(
+      <TableSortHeader
+        label="Name"
+        field="name"
+        currentSort="name"
+        currentOrder="asc"
+        onSort={vi.fn()}
+      />,
+    )
+    // active column gets emphasized text color
+    expect(screen.getByRole('button', { name: /sort by name/i })).toHaveClass('text-foreground')
+
+    rerender(
+      <TableSortHeader
+        label="Name"
+        field="name"
+        currentSort="name"
+        currentOrder="desc"
+        onSort={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /sort by name/i })).toBeInTheDocument()
+  })
+
+  it('renders a static, non-interactive header when onSort is omitted', () => {
+    render(<TableSortHeader label="Actions" field="actions" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+  })
+})
+
+describe('createSortHandler', () => {
+  it('sets a new field to ascending order', () => {
+    const setField = vi.fn()
+    const setOrder = vi.fn()
+    const handler = createSortHandler(setField, setOrder)
+
+    handler('email')
+
+    // setField is called with an updater that returns the new field
+    const fieldUpdater = setField.mock.calls[0][0]
+    expect(fieldUpdater('name')).toBe('email')
+    expect(setOrder).toHaveBeenCalledWith('asc')
+  })
+
+  it('flips direction when the same field is clicked again', () => {
+    const setField = vi.fn()
+    const setOrder = vi.fn()
+    const handler = createSortHandler(setField, setOrder)
+
+    handler('email')
+    const fieldUpdater = setField.mock.calls[0][0]
+    // same field → updater returns it unchanged and toggles order
+    expect(fieldUpdater('email')).toBe('email')
+    const orderUpdater = setOrder.mock.calls.at(-1)?.[0]
+    expect(orderUpdater('asc')).toBe('desc')
+    expect(orderUpdater('desc')).toBe('asc')
+  })
+})

--- a/src/components/shared/TableSortHeader.tsx
+++ b/src/components/shared/TableSortHeader.tsx
@@ -1,4 +1,5 @@
-import { ArrowUp, ArrowDown, ChevronsUpDown } from 'lucide-react'
+import { ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 export type SortOrder = 'asc' | 'desc'
 
@@ -7,35 +8,74 @@ interface TableSortHeaderProps<T extends string> {
   field: T
   currentSort?: T | null
   currentOrder?: SortOrder
+  /** Omit to render a static, non-sortable header cell (keeps columns visually consistent). */
   onSort?: (field: T) => void
-  /** Show idle chevron icon when not active (default: false) */
+  /**
+   * Show a muted idle affordance when the column isn't the active sort.
+   * Defaults to true so every sortable column advertises that it can be sorted
+   * (the affordance is no longer hidden inside the label text).
+   */
   showIdleIcon?: boolean
+  /** Extra classes for alignment, e.g. 'justify-center' or 'justify-end'. */
+  className?: string
+  /** Native tooltip text. */
+  title?: string
 }
 
+/**
+ * Universal sortable table-header cell.
+ *
+ * One consistent affordance across every producer table:
+ * - idle  → muted double chevron (ChevronsUpDown), always visible so users can
+ *           see the column is sortable
+ * - asc   → ChevronUp   (accent color)
+ * - desc  → ChevronDown (accent color)
+ *
+ * Pair with `createSortHandler` for the standard toggle behavior.
+ */
 export function TableSortHeader<T extends string>({
   label,
   field,
   currentSort,
   currentOrder,
   onSort,
-  showIdleIcon = false,
+  showIdleIcon = true,
+  className,
+  title,
 }: TableSortHeaderProps<T>) {
+  // Non-sortable column: render a plain label so headers stay visually aligned
+  // whether or not a given column supports sorting.
+  if (!onSort) {
+    return (
+      <div className={cn('flex items-center gap-1', className)} title={title}>
+        {label}
+      </div>
+    )
+  }
+
   const isActive = currentSort === field
+
   return (
     <button
       type="button"
-      onClick={() => onSort?.(field)}
-      className="flex items-center gap-0.5 hover:text-foreground transition-colors text-left"
+      onClick={() => onSort(field)}
+      aria-label={`Sort by ${label}`}
+      title={title}
+      className={cn(
+        'flex items-center gap-1 text-left transition-colors hover:text-foreground',
+        isActive && 'text-foreground',
+        className,
+      )}
     >
       {label}
       {isActive ? (
         currentOrder === 'asc' ? (
-          <ArrowUp className="w-3 h-3" />
+          <ChevronUp className="h-3 w-3 text-violet-700 dark:text-primary" />
         ) : (
-          <ArrowDown className="w-3 h-3" />
+          <ChevronDown className="h-3 w-3 text-violet-700 dark:text-primary" />
         )
       ) : showIdleIcon ? (
-        <ChevronsUpDown className="w-3 h-3 opacity-40" />
+        <ChevronsUpDown className="h-3 w-3 text-foreground/45 dark:text-foreground/40" />
       ) : null}
     </button>
   )

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -15,10 +15,6 @@ import {
   Loader2,
   Key,
   Mail,
-  Webhook,
-  Copy,
-  RotateCw,
-  Check,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ConfirmationModal } from '@/components/ui/confirmation-modal'
@@ -119,25 +115,6 @@ export default function SettingsPage({ onBack, onStartGuide }: SettingsPageProps
     fetchOrganization()
   }, [userProfile])
 
-  // Fetch webhook config
-  useEffect(() => {
-    const fetchWebhookConfig = async () => {
-      if (!organization?.slug) return
-
-      try {
-        setLoadingWebhook(true)
-        const config = await organizationsApi.getWebhookConfig(organization.slug)
-        setWebhookConfig(config)
-      } catch (err) {
-        console.error('Failed to fetch webhook config:', err)
-      } finally {
-        setLoadingWebhook(false)
-      }
-    }
-
-    fetchWebhookConfig()
-  }, [organization])
-
   const [isSaving, setIsSaving] = useState(false)
   const [showDeleteWarning, setShowDeleteWarning] = useState(false)
   const [isLoadingBilling, setIsLoadingBilling] = useState(false)
@@ -145,17 +122,6 @@ export default function SettingsPage({ onBack, onStartGuide }: SettingsPageProps
   const [isResettingPassword, setIsResettingPassword] = useState(false)
   const [emailSent, setEmailSent] = useState(false)
   const [resendDisabled, setResendDisabled] = useState(false)
-
-  // Webhook state
-  const [webhookConfig, setWebhookConfig] = useState<{
-    webhook_url: string
-    webhook_token: string
-  } | null>(null)
-  const [loadingWebhook, setLoadingWebhook] = useState(false)
-  const [copiedWebhook, setCopiedWebhook] = useState(false)
-  const [copiedPayload, setCopiedPayload] = useState(false)
-  const [showRegenerateModal, setShowRegenerateModal] = useState(false)
-  const [isRegenerating, setIsRegenerating] = useState(false)
 
   const handleSaveChanges = async () => {
     if (!userProfile?.id) {
@@ -259,62 +225,6 @@ export default function SettingsPage({ onBack, onStartGuide }: SettingsPageProps
 
   const handleOrganizationChange = (field: string, value: string) => {
     setOrganizationData((prev) => ({ ...prev, [field]: value }))
-  }
-
-  const handleCopyWebhookUrl = async () => {
-    if (!webhookConfig?.webhook_url) return
-
-    try {
-      await navigator.clipboard.writeText(webhookConfig.webhook_url)
-      setCopiedWebhook(true)
-      toast.success('Webhook URL copied to clipboard!')
-      setTimeout(() => setCopiedWebhook(false), 2000)
-    } catch (err) {
-      console.error('Failed to copy webhook URL:', err)
-      toast.error('Failed to copy URL')
-    }
-  }
-
-  const handleCopyN8nPayload = async () => {
-    const payloadTemplate = `{
-  "eventbrite_event_id": "={{ $json.event.id }}",
-  "application_code": "={{ $json.attendee.answers.application_code }}",
-  "eventbrite_order_id": "={{ $json.order.id }}",
-  "email": "={{ $json.attendee.profile.email }}",
-  "first_name": "={{ $json.attendee.profile.first_name }}",
-  "last_name": "={{ $json.attendee.profile.last_name }}",
-  "payment_date": "={{ $json.order.created }}",
-  "payment_amount": "={{ $json.order.costs.gross.value }}",
-  "currency": "={{ $json.order.costs.gross.currency }}",
-  "ticket_type": "={{ $json.attendee.ticket_class_name }}"
-}`
-
-    try {
-      await navigator.clipboard.writeText(payloadTemplate)
-      setCopiedPayload(true)
-      toast.success('n8n payload template copied to clipboard!')
-      setTimeout(() => setCopiedPayload(false), 2000)
-    } catch (err) {
-      console.error('Failed to copy payload template:', err)
-      toast.error('Failed to copy template')
-    }
-  }
-
-  const handleRegenerateWebhookToken = async () => {
-    if (!organization?.slug) return
-
-    setIsRegenerating(true)
-    try {
-      const config = await organizationsApi.regenerateWebhookToken(organization.slug)
-      setWebhookConfig(config)
-      toast.success('Webhook token regenerated! Update your n8n workflow with the new URL.')
-      setShowRegenerateModal(false)
-    } catch (err: any) {
-      console.error('Failed to regenerate webhook token:', err)
-      toast.error(err.message || 'Failed to regenerate token')
-    } finally {
-      setIsRegenerating(false)
-    }
   }
 
   if (!userProfile) {
@@ -913,166 +823,6 @@ export default function SettingsPage({ onBack, onStartGuide }: SettingsPageProps
             </>
           )}
 
-          {/* Webhook Integration Section */}
-          {organization && webhookConfig && (
-            <>
-              <div className="border-t border-border dark:border-violet-500/25" />
-
-              <div>
-                <div className="flex items-center gap-3 mb-3">
-                  <Webhook className="h-4 w-4 text-primary dark:text-violet-400" />
-                  <div>
-                    <span className="text-sm font-semibold text-foreground">
-                      n8n Webhook Integration
-                    </span>
-                    <p className="text-xs text-muted-foreground font-normal">
-                      Automatically sync Eventbrite payments via n8n workflows
-                    </p>
-                  </div>
-                </div>
-                <div className="space-y-4">
-                  <div
-                    className={cn(
-                      'rounded-lg border border-border bg-gradient-to-br from-primary/[0.06] via-muted/40 to-accent/[0.08] p-4',
-                      'dark:border-violet-400/45 dark:from-violet-950/50 dark:via-primary/15/35 dark:to-voxxy-pink/10 dark:backdrop-blur-sm',
-                    )}
-                  >
-                    <div className="flex flex-1 items-start justify-between gap-4 mb-3">
-                      <div className="flex flex-1 items-start gap-3">
-                        <div className={cn(innerGlassWell, 'p-2')}>
-                          <Webhook className="h-4 w-4 text-primary dark:text-violet-400" />
-                        </div>
-                        <div className="flex-1">
-                          <h4 className="text-sm font-semibold text-foreground mb-1">
-                            Webhook URL
-                          </h4>
-                          <p className="text-xs text-muted-foreground mb-3">
-                            Use this URL in your n8n HTTP Request node to send payment notifications
-                          </p>
-                          <div className={cn(innerGlassWell, 'mb-3')}>
-                            <code className="text-xs text-foreground font-mono break-all">
-                              {webhookConfig.webhook_url}
-                            </code>
-                          </div>
-                          <div className="flex gap-2">
-                            <button
-                              onClick={handleCopyWebhookUrl}
-                              className="voxxy-btn-cta inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
-                            >
-                              {copiedWebhook ? (
-                                <>
-                                  <Check className="w-3.5 h-3.5" />
-                                  Copied!
-                                </>
-                              ) : (
-                                <>
-                                  <Copy className="w-3.5 h-3.5" />
-                                  Copy URL
-                                </>
-                              )}
-                            </button>
-                            <button
-                              onClick={() => setShowRegenerateModal(true)}
-                              className="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium border border-border bg-muted text-foreground hover:bg-muted/80 transition-colors"
-                            >
-                              <RotateCw className="w-3.5 h-3.5" />
-                              Regenerate Token
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="border-t border-border pt-3 dark:border-violet-500/30">
-                      <p className="text-[10px] text-muted-foreground mb-2">
-                        <strong>How to use:</strong> Copy this URL and paste it into your n8n HTTP
-                        Request node. When Eventbrite payments are received, n8n will POST to this
-                        endpoint to automatically mark registrations as paid.
-                      </p>
-                      <p className="text-[10px] text-muted-foreground">
-                        <strong>⚠️ Warning:</strong> Regenerating the token will invalidate the old
-                        URL immediately. Update your n8n workflow before regenerating.
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* n8n Payload Template */}
-                  <div
-                    className={cn(
-                      'rounded-lg border border-border bg-gradient-to-br from-primary/[0.06] via-muted/40 to-accent/[0.08] p-4',
-                      'dark:border-violet-400/45 dark:from-violet-950/50 dark:via-primary/15/35 dark:to-voxxy-pink/10 dark:backdrop-blur-sm',
-                    )}
-                  >
-                    <div className="flex flex-1 items-start justify-between gap-4 mb-3">
-                      <div className="flex flex-1 items-start gap-3">
-                        <div className={cn(innerGlassWell, 'p-2')}>
-                          <Copy className="h-4 w-4 text-primary dark:text-violet-400" />
-                        </div>
-                        <div className="flex-1">
-                          <h4 className="text-sm font-semibold text-foreground mb-1">
-                            n8n Payload Template
-                          </h4>
-                          <p className="text-xs text-muted-foreground mb-3">
-                            Universal payload template that works for all events - automatically
-                            detects the correct event via Eventbrite Event ID
-                          </p>
-                          <div className={cn(innerGlassWell, 'mb-3 overflow-x-auto')}>
-                            <pre className="text-[10px] text-foreground font-mono whitespace-pre">
-                              {`{
-  "eventbrite_event_id": "={{ $json.event.id }}",
-  "application_code": "={{ $json.attendee.answers.application_code }}",
-  "eventbrite_order_id": "={{ $json.order.id }}",
-  "email": "={{ $json.attendee.profile.email }}",
-  "first_name": "={{ $json.attendee.profile.first_name }}",
-  "last_name": "={{ $json.attendee.profile.last_name }}",
-  "payment_date": "={{ $json.order.created }}",
-  "payment_amount": "={{ $json.order.costs.gross.value }}",
-  "currency": "={{ $json.order.costs.gross.currency }}",
-  "ticket_type": "={{ $json.attendee.ticket_class_name }}"
-}`}
-                            </pre>
-                          </div>
-                          <button
-                            onClick={handleCopyN8nPayload}
-                            className="voxxy-btn-cta inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
-                          >
-                            {copiedPayload ? (
-                              <>
-                                <Check className="w-3.5 h-3.5" />
-                                Copied!
-                              </>
-                            ) : (
-                              <>
-                                <Copy className="w-3.5 h-3.5" />
-                                Copy Template
-                              </>
-                            )}
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="border-t border-border pt-3 dark:border-violet-500/30">
-                      <p className="text-[10px] text-muted-foreground mb-2">
-                        <strong>✨ Auto-Detection:</strong> This template automatically detects
-                        which Voxxy event to use based on the Eventbrite Event ID. No need to
-                        configure anything per-event!
-                      </p>
-                      <p className="text-[10px] text-muted-foreground mb-2">
-                        <strong>How it works:</strong> When you add an Eventbrite payment link to a
-                        vendor category in Event Settings, we automatically extract and store the
-                        Eventbrite Event ID. When n8n sends this payload, we match it to the correct
-                        Voxxy event.
-                      </p>
-                      <p className="text-[10px] text-muted-foreground">
-                        <strong>Setup:</strong> Paste this template into your n8n HTTP Request
-                        node's Body (JSON format). Configure your workflow once, then reuse it for
-                        all future events!
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
         </div>
 
         {/* Save Button */}
@@ -1160,19 +910,6 @@ export default function SettingsPage({ onBack, onStartGuide }: SettingsPageProps
         cancelText={emailSent ? 'Close' : 'Cancel'}
         isDestructive={false}
         isLoading={isResettingPassword || (emailSent && resendDisabled)}
-      />
-
-      {/* Regenerate Webhook Token Confirmation Modal */}
-      <ConfirmationModal
-        isOpen={showRegenerateModal}
-        onClose={() => setShowRegenerateModal(false)}
-        onConfirm={handleRegenerateWebhookToken}
-        title="Regenerate Webhook Token?"
-        description="This will generate a new webhook URL and immediately invalidate the old one. Make sure to update your n8n workflow with the new URL after regenerating, or your payment sync will stop working."
-        confirmText="Regenerate Token"
-        cancelText="Cancel"
-        isDestructive={true}
-        isLoading={isRegenerating}
       />
     </div>
   )


### PR DESCRIPTION
## Staging-polish sprint (frontend)

Four tracks bundled into one frontend PR (per request: one PR per repo).

---

### Track 1 — CSV import: split first/last name + validation parity

- **First name & last name are now separate recognized columns** through the whole preview/edit flow (most spreadsheets split them). They're joined into a single `name` only at submit time, so the backend contract is unchanged.
- Removed the old `MERGE_FIELDS` special-casing; `first_name`/`last_name` are regular recognized fields with aliases (`fname`, `lname`, etc.).
- Client validation now blocks only on **email + first name** (either a `first_name` column or a single Full Name column). `contact_type`/`status` dropped.
- Done screen shows a **created / updated / failed** breakdown plus the grouped warnings, mirroring the validation step.
- Unit tests updated/added: `columnMapping`, `csvRewriter`, `clientValidation`.

### Track 2 — Universal sortable table headers

- `TableSortHeader` now shows a **muted idle affordance by default** (double-chevron) so sortable columns are discoverable, instead of hiding the icon in the label. One consistent icon set (idle `ChevronsUpDown`, asc `ChevronUp`, desc `ChevronDown`), alignment/title passthrough, active-state emphasis, `aria-label`, and a static fallback when `onSort` is omitted.
- Retrofit `EmailTable`, `EmailAuditTable`, `GoLiveInvitationEditor` onto the shared component (removed 3 duplicated `SortIcon` helpers + the broken always-down idle chevron). `ContactsTable` + `ApplicantsTab` pick up the idle affordance automatically.
- Added `TableSortHeader` unit tests + documented the pattern in `STYLE_GUIDE.md`.

### Track 3 — Network bulk actions

- New **`SelectionActionBar`** that appears directly above the contacts table when rows are selected, exposing **Delete** and **Edit** inline — no more digging through the Actions menu / edit modal just to delete.
- Converted `BulkEditModal` from a cramped centered popup into a **full-height right side sheet** (wider, scrollable) with more room for the category/tags/location controls.
- Removed the redundant "Edit Selected Contacts" item from the Actions dropdown.
- Added `SelectionActionBar` unit tests.

### Track 4 — Hide n8n payment-webhook UI

- Removed the `/payments` route + `ProtectedIncomingPayments` wrapper + lazy import.
- Removed the "n8n Webhook Integration" block from `SettingsPage` (webhook URL, copy/regenerate token, payload template) + its fetch/state/handlers + regenerate modal.
- Removed the "n8n Payment Sync Status" accordion from `EventSettings`.
- `IncomingPaymentsPage` + the incoming-payments/webhook API methods are left dormant for a clean revival path. Pairs with the backend `N8N_WEBHOOKS_ENABLED` gate.

---

### Verification
- `tsc --noEmit` clean, `vite build` succeeds, ESLint clean on all changed files (no new warnings).
- `vitest run`: **161 passing**. One **pre-existing** failure in `src/services/vendorContacts.test.ts` (`create` sends `contact_name` but asserts `name`) — file is byte-identical to `dev`, fails in isolation, unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CSV submit-time name joining and broader import validation affect contact data entry; removing `/payments` and webhook settings changes how producers configure payment sync unless they use Sheets-only flows.
> 
> **Overview**
> Bundles four staging-polish tracks: **CSV import**, **shared table sorting**, **Network bulk actions**, and **retiring n8n payment UI**.
> 
> **CSV import** keeps `first_name` / `last_name` as separate mapped and preview columns (aliases like `fname` / `lname`); the old `MERGE_FIELDS` path is removed. Blocking validation is **first name** (or a Full Name column) plus **email**, with errors on the visible name cell. `csvRewriter` joins name parts into canonical `name` only at submit. The import-done step adds failed counts and grouped warning summaries.
> 
> **Table sorting** upgrades `TableSortHeader` (default idle chevrons, static headers without `onSort`, `createSortHandler`) and wires `EmailTable`, `EmailAuditTable`, and `GoLiveInvitationEditor` to it instead of per-table sort buttons. Documented in `STYLE_GUIDE.md` with new tests.
> 
> **Network** adds a **`SelectionActionBar`** above the contacts table when rows are selected (Edit / Delete / Clear); bulk edit moves from the Actions menu into that bar. **`BulkEditModal`** becomes a full-height right sheet.
> 
> **n8n** removes the `/payments` route and protected wrapper, Settings webhook copy/regenerate UI, and Event Settings “n8n Payment Sync Status” accordion—payments are described as Google Sheets sync; dormant page/API left for revival.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee264f9eb8a280680d9f1894f4d4226f74b4723c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->