### PR TITLE
feat: Google Sheets payment sync UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,9 @@ const PaymentOnboardingPage = lazy(() => import('./pages/PaymentOnboardingPage')
 const PaymentSuccessPage = lazy(() => import('./pages/PaymentSuccessPage'))
 const PaymentCanceledPage = lazy(() => import('./pages/PaymentCanceledPage'))
 
+// Lazy load: Google OAuth callback
+const GoogleOAuthCallback = lazy(() => import('./pages/GoogleOAuthCallback'))
+
 // Lazy load: Dashboards (load on-demand)
 const Dashboard = lazy(() => import('./pages/Dashboard'))
 const VendorDashboard = lazy(() => import('./pages/VendorDashboard'))
@@ -303,6 +306,9 @@ export default function App() {
 
             {/* Unified Account Setup Hub - Email verification & payment request */}
             <Route path="/pending" element={<BetaPendingPage />} />
+
+            {/* Google OAuth Callback */}
+            <Route path="/google/callback" element={<GoogleOAuthCallback />} />
 
             {/* Payment Flow */}
             <Route path="/payment/onboarding" element={<PaymentOnboardingPage />} />

--- a/src/components/producer/EventSettings.tsx
+++ b/src/components/producer/EventSettings.tsx
@@ -1450,18 +1450,9 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
                     Your n8n workflow will detect the correct event without any manual
                     configuration.
                   </p>
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      window.location.href = '/dashboard/settings'
-                    }}
-                    className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-lg voxxy-btn-cta transition-all"
-                  >
-                    <Webhook className="h-4 w-4" />
-                    Configure Webhook in Settings
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
+                  <p className="text-xs text-muted-foreground italic">
+                    Webhook configuration is managed at the organization level.
+                  </p>
                 </div>
 
                 {applications.length > 0 && (

--- a/src/components/producer/EventSettings.tsx
+++ b/src/components/producer/EventSettings.tsx
@@ -1529,7 +1529,6 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
             </AccordionContent>
           </AccordionItem>
 
->>>>>>> e5beb3c (feat: Google Sheets payment sync — OAuth flow, sync UI, column auto-detect)
           {/* Event Links Section */}
           <AccordionItem value="links" className="border-border border-b-0">
             <AccordionTrigger className={triggerHoverClass}>

--- a/src/components/producer/EventSettings.tsx
+++ b/src/components/producer/EventSettings.tsx
@@ -12,6 +12,8 @@ import {
   AlertCircle,
   DollarSign,
   Save,
+  Webhook,
+  Sheet,
 } from 'lucide-react'
 import {
   Accordion,
@@ -39,6 +41,7 @@ import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import { ConfirmationModal } from '@/components/ui/confirmation-modal'
 import { useAuth } from '@/hooks/useAuth'
+import GoogleSheetsSync from './GoogleSheets/GoogleSheetsSync'
 
 interface Event {
   id: number
@@ -1393,6 +1396,140 @@ export default function EventSettings({ event, onUpdate, onDelete, isAdmin }: Ev
             </AccordionContent>
           </AccordionItem>
 
+          {/* Google Sheets Payment Sync */}
+          <AccordionItem value="google-sheets-sync" className="border-border">
+            <AccordionTrigger className={triggerHoverClass}>
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg bg-emerald-500/20 p-1.5">
+                  <Sheet className="h-4 w-4 text-emerald-700 dark:text-emerald-400" />
+                </div>
+                <div className="text-left">
+                  <span className="text-sm font-semibold text-foreground">
+                    Google Sheets Payment Sync
+                  </span>
+                  <p className="text-xs text-foreground/50 font-normal">
+                    Sync vendor payment status from your spreadsheet
+                  </p>
+                </div>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent className="px-4">
+              <GoogleSheetsSync
+                organizationId={currentUser?.organization_id || 0}
+                eventSlug={event.slug}
+              />
+            </AccordionContent>
+          </AccordionItem>
+
+          {/* n8n Webhook Integration Status */}
+          <AccordionItem value="n8n-webhook" className="border-border">
+            <AccordionTrigger className={triggerHoverClass}>
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg bg-purple-500/20 p-1.5">
+                  <Webhook className="h-4 w-4 text-purple-700 dark:text-purple-400" />
+                </div>
+                <div className="text-left">
+                  <span className="text-sm font-semibold text-foreground">
+                    n8n Payment Sync Status
+                  </span>
+                  <p className="text-xs text-foreground/50 font-normal">
+                    Eventbrite Event ID auto-detection status per category
+                  </p>
+                </div>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent className="px-4">
+              <div className="space-y-3">
+                <div className={cn(compactWell, 'bg-blue-500/5 border border-blue-500/20')}>
+                  <p className="text-xs text-foreground/70 mb-2">
+                    <strong>✨ Auto-Detection Enabled:</strong>
+                  </p>
+                  <p className="text-xs text-muted-foreground mb-3">
+                    Webhook configuration is now organization-wide! When you add Eventbrite payment
+                    links to categories below, we automatically extract the Eventbrite Event ID.
+                    Your n8n workflow will detect the correct event without any manual
+                    configuration.
+                  </p>
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      window.location.href = '/dashboard/settings'
+                    }}
+                    className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-lg voxxy-btn-cta transition-all"
+                  >
+                    <Webhook className="h-4 w-4" />
+                    Configure Webhook in Settings
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+
+                {applications.length > 0 && (
+                  <div>
+                    <p className="text-xs font-semibold text-foreground mb-2">Category Status:</p>
+                    <div className="space-y-2">
+                      {applications.map((app) => {
+                        const hasEventbriteEngine = app.payment_engines?.some(
+                          (pe) => pe.engine === 'eventbrite',
+                        )
+                        const hasEventbriteId = !!app.eventbrite_event_id
+
+                        return (
+                          <div key={app.id} className={cn(compactWell, 'voxxy-hover-panel')}>
+                            <div className="flex items-center justify-between">
+                              <div className="flex items-center gap-2">
+                                <p className="text-xs font-semibold text-foreground">{app.name}</p>
+                                {hasEventbriteId ? (
+                                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/20 border border-green-500/30 text-[10px] font-medium text-green-800 dark:text-green-400">
+                                    <Check className="w-3 h-3" />
+                                    n8n Ready
+                                  </span>
+                                ) : hasEventbriteEngine ? (
+                                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/20 border border-amber-500/30 text-[10px] font-medium text-amber-800 dark:text-amber-400">
+                                    <AlertCircle className="w-3 h-3" />
+                                    Invalid URL
+                                  </span>
+                                ) : (
+                                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-muted border border-border text-[10px] font-medium text-muted-foreground">
+                                    No Eventbrite
+                                  </span>
+                                )}
+                              </div>
+                              {hasEventbriteId && (
+                                <p className="text-[10px] font-mono text-muted-foreground">
+                                  ID: {app.eventbrite_event_id}
+                                </p>
+                              )}
+                            </div>
+                            {hasEventbriteEngine && !hasEventbriteId && (
+                              <p className="text-[10px] text-muted-foreground mt-1">
+                                ⚠️ Eventbrite link found but ID extraction failed. Check URL format
+                                in Payment Config.
+                              </p>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                <div className={cn(compactWell, 'bg-accent/30')}>
+                  <p className="text-xs text-muted-foreground">
+                    <strong>How it works:</strong> Add Eventbrite payment links in Payment
+                    Configuration above. We automatically extract the Event ID from URLs like{' '}
+                    <code className="bg-background/50 px-1 rounded">
+                      eventbrite.com/e/event-name-123456
+                    </code>
+                    . Your n8n workflow sends this ID in the payload, and we match it to the correct
+                    category automatically!
+                  </p>
+                </div>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+
+>>>>>>> e5beb3c (feat: Google Sheets payment sync — OAuth flow, sync UI, column auto-detect)
           {/* Event Links Section */}
           <AccordionItem value="links" className="border-border border-b-0">
             <AccordionTrigger className={triggerHoverClass}>

--- a/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
+++ b/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
@@ -21,17 +21,20 @@ import type {
   SyncResult,
 } from '@/types/googleSheets'
 import { autoDetectColumns } from './columnAutoDetect'
+import SyncErrorsPanel from './SyncErrorsPanel'
 import { toast } from 'sonner'
 
 interface GoogleSheetsSyncProps {
   organizationId: number
   eventSlug: string
+  registrations?: Array<{ id: number; name?: string; email?: string; phone?: string }>
   onSyncComplete?: () => void
 }
 
 export default function GoogleSheetsSync({
   organizationId,
   eventSlug,
+  registrations = [],
   onSyncComplete,
 }: GoogleSheetsSyncProps) {
   // Connection state
@@ -172,7 +175,8 @@ export default function GoogleSheetsSync({
         )
         setHeaders(metadata.headers || [])
 
-        if (metadata.headers?.length > 0) {
+        // Only auto-detect if no config exists (don't overwrite manual mappings)
+        if (!config && metadata.headers?.length > 0) {
           applyAutoDetect(metadata.headers)
         }
 
@@ -183,7 +187,7 @@ export default function GoogleSheetsSync({
         setFetchingMetadata(false)
       }
     },
-    [organizationId, sheetUrl],
+    [organizationId, sheetUrl, config],
   )
 
   const handleConnect = async () => {
@@ -246,6 +250,9 @@ export default function GoogleSheetsSync({
 
   const handleSheetUrlChange = (url: string) => {
     setSheetUrl(url)
+    setSheetTabName('')
+    setHeaders([])
+    setTabs([])
     setDirty(true)
     if (url.includes('docs.google.com/spreadsheets')) {
       fetchMetadata(url)
@@ -274,10 +281,10 @@ export default function GoogleSheetsSync({
     try {
       const data = {
         sheet_url: sheetUrl,
-        sheet_tab_name: sheetTabName || undefined,
-        email_column: emailColumn || undefined,
-        phone_column: phoneColumn || undefined,
-        ticket_code_column: ticketCodeColumn || undefined,
+        sheet_tab_name: sheetTabName || null,
+        email_column: emailColumn || null,
+        phone_column: phoneColumn || null,
+        ticket_code_column: ticketCodeColumn || null,
         paid_status_column: paidStatusColumn,
         paid_value: paidValue || 'TRUE',
         active: true,
@@ -627,6 +634,15 @@ export default function GoogleSheetsSync({
                   `, ${lastSyncResult.results.skipped} skipped`}
               </span>
             </div>
+          )}
+
+          {/* Sync errors — manual resolution panel */}
+          {config && (
+            <SyncErrorsPanel
+              eventSlug={eventSlug}
+              registrations={registrations}
+              onErrorsChange={onSyncComplete}
+            />
           )}
         </div>
       )}

--- a/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
+++ b/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
@@ -27,20 +27,21 @@ import { toast } from 'sonner'
 interface GoogleSheetsSyncProps {
   organizationId: number
   eventSlug: string
-  registrations?: Array<{ id: number; name?: string; email?: string; phone?: string }>
   onSyncComplete?: () => void
 }
 
 export default function GoogleSheetsSync({
   organizationId,
   eventSlug,
-  registrations = [],
   onSyncComplete,
 }: GoogleSheetsSyncProps) {
   // Connection state
   const [connectionStatus, setConnectionStatus] =
     useState<GoogleSheetsConnectionStatus | null>(null)
   const [loading, setLoading] = useState(true)
+
+  // Sync errors refresh trigger
+  const [syncVersion, setSyncVersion] = useState(0)
 
   // Config state
   const [config, setConfig] = useState<PaymentSyncConfig | null>(null)
@@ -320,6 +321,7 @@ export default function GoogleSheetsSync({
       toast.success(
         `Sync complete: ${synced} updated, ${errCount} errors, ${skipped} skipped`,
       )
+      setSyncVersion((v) => v + 1)
       onSyncComplete?.()
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Sync failed'
@@ -640,7 +642,7 @@ export default function GoogleSheetsSync({
           {config && (
             <SyncErrorsPanel
               eventSlug={eventSlug}
-              registrations={registrations}
+              refreshTrigger={syncVersion}
               onErrorsChange={onSyncComplete}
             />
           )}

--- a/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
+++ b/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
@@ -1,0 +1,635 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  Link2,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  RefreshCw,
+  Sheet,
+  Unlink,
+  Play,
+  Clock,
+  Trash2,
+} from 'lucide-react'
+import {
+  googleSheetsOauthApi,
+  paymentSyncConfigApi,
+} from '@/services/googleSheetsApi'
+import type {
+  GoogleSheetsConnectionStatus,
+  PaymentSyncConfig,
+  SyncResult,
+} from '@/types/googleSheets'
+import { autoDetectColumns } from './columnAutoDetect'
+import { toast } from 'sonner'
+
+interface GoogleSheetsSyncProps {
+  organizationId: number
+  eventSlug: string
+  onSyncComplete?: () => void
+}
+
+export default function GoogleSheetsSync({
+  organizationId,
+  eventSlug,
+  onSyncComplete,
+}: GoogleSheetsSyncProps) {
+  // Connection state
+  const [connectionStatus, setConnectionStatus] =
+    useState<GoogleSheetsConnectionStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // Config state
+  const [config, setConfig] = useState<PaymentSyncConfig | null>(null)
+  const [sheetUrl, setSheetUrl] = useState('')
+  const [sheetTabName, setSheetTabName] = useState('')
+  const [emailColumn, setEmailColumn] = useState('')
+  const [phoneColumn, setPhoneColumn] = useState('')
+  const [ticketCodeColumn, setTicketCodeColumn] = useState('')
+  const [paidStatusColumn, setPaidStatusColumn] = useState('')
+  const [paidValue, setPaidValue] = useState('TRUE')
+
+  // Metadata state
+  const [fetchingMetadata, setFetchingMetadata] = useState(false)
+  const [metadataError, setMetadataError] = useState<string | null>(null)
+  const [tabs, setTabs] = useState<string[]>([])
+  const [headers, setHeaders] = useState<string[]>([])
+  const [autoDetected, setAutoDetected] = useState(false)
+
+  // Save/sync state
+  const [saving, setSaving] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const [lastSyncResult, setLastSyncResult] = useState<SyncResult | null>(null)
+  const [disconnecting, setDisconnecting] = useState(false)
+  const [removing, setRemoving] = useState(false)
+  const [dirty, setDirty] = useState(false)
+
+  const fetchUrlRef = useRef<string | null>(null)
+
+  // Load connection status + existing config
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const status = await googleSheetsOauthApi.getStatus(organizationId)
+        setConnectionStatus(status)
+
+        if (status.connected) {
+          try {
+            const existingConfig = await paymentSyncConfigApi.get(eventSlug)
+            loadConfigIntoState(existingConfig)
+          } catch {
+            // No config yet — that's fine
+          }
+        }
+      } catch {
+        setConnectionStatus({ connected: false, email: null, connected_at: null })
+      } finally {
+        setLoading(false)
+      }
+    }
+    init()
+  }, [organizationId, eventSlug])
+
+  const loadConfigIntoState = (c: PaymentSyncConfig) => {
+    setConfig(c)
+    setSheetUrl(c.sheet_url || '')
+    setSheetTabName(c.sheet_tab_name || '')
+    setEmailColumn(c.email_column || '')
+    setPhoneColumn(c.phone_column || '')
+    setTicketCodeColumn(c.ticket_code_column || '')
+    setPaidStatusColumn(c.paid_status_column || '')
+    setPaidValue(c.paid_value || 'TRUE')
+    if (c.column_headers?.length > 0) {
+      setHeaders(c.column_headers)
+    }
+  }
+
+  const applyAutoDetect = (detectedHeaders: string[]) => {
+    const detected = autoDetectColumns(detectedHeaders)
+    if (detected.emailColumn) setEmailColumn(detected.emailColumn)
+    if (detected.phoneColumn) setPhoneColumn(detected.phoneColumn)
+    if (detected.ticketCodeColumn) setTicketCodeColumn(detected.ticketCodeColumn)
+    if (detected.paidStatusColumn) setPaidStatusColumn(detected.paidStatusColumn)
+    if (detected.paidValue) setPaidValue(detected.paidValue)
+    setAutoDetected(true)
+  }
+
+  // Fetch sheet metadata when URL changes
+  const fetchMetadata = useCallback(
+    async (url: string, tabOverride?: string) => {
+      if (!url.includes('docs.google.com/spreadsheets')) return
+
+      fetchUrlRef.current = url
+      setFetchingMetadata(true)
+      setMetadataError(null)
+      try {
+        const metadata = await googleSheetsOauthApi.getSheetMetadata(
+          organizationId,
+          url,
+          undefined,
+          tabOverride || sheetTabName || undefined,
+        )
+
+        if (fetchUrlRef.current !== url) return
+
+        setTabs(metadata.tabs || [])
+        setHeaders(metadata.headers || [])
+        if (!sheetTabName && metadata.tabs?.length > 0) {
+          setSheetTabName(metadata.tabs[0])
+        }
+
+        // Auto-detect column mappings if no config exists
+        if (!config && metadata.headers?.length > 0) {
+          applyAutoDetect(metadata.headers)
+        }
+
+        setDirty(true)
+      } catch (err) {
+        if (fetchUrlRef.current !== url) return
+        const message = err instanceof Error ? err.message : 'Could not access sheet'
+        setMetadataError(message)
+        setTabs([])
+        setHeaders([])
+      } finally {
+        setFetchingMetadata(false)
+      }
+    },
+    [organizationId, sheetTabName, config],
+  )
+
+  // Fetch headers when tab changes
+  const fetchHeadersForTab = useCallback(
+    async (tabName: string) => {
+      if (!sheetUrl) return
+
+      setFetchingMetadata(true)
+      try {
+        const metadata = await googleSheetsOauthApi.getSheetMetadata(
+          organizationId,
+          sheetUrl,
+          undefined,
+          tabName,
+        )
+        setHeaders(metadata.headers || [])
+
+        if (metadata.headers?.length > 0) {
+          applyAutoDetect(metadata.headers)
+        }
+
+        setDirty(true)
+      } catch {
+        setHeaders([])
+      } finally {
+        setFetchingMetadata(false)
+      }
+    },
+    [organizationId, sheetUrl],
+  )
+
+  const handleConnect = async () => {
+    try {
+      localStorage.setItem('gsheets_org_id', String(organizationId))
+      localStorage.setItem('gsheets_return_slug', eventSlug)
+
+      const redirectUri = `${window.location.origin}/google/callback`
+      const { auth_url } = await googleSheetsOauthApi.getAuthUrl(organizationId, redirectUri)
+      window.location.href = auth_url
+    } catch (err) {
+      console.error('Failed to get auth URL:', err)
+      toast.error('Failed to start Google connection')
+    }
+  }
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true)
+    try {
+      await googleSheetsOauthApi.disconnect(organizationId)
+      setConnectionStatus({ connected: false, email: null, connected_at: null })
+      resetFormState()
+      toast.success('Google Sheets disconnected')
+    } catch {
+      toast.error('Failed to disconnect')
+    } finally {
+      setDisconnecting(false)
+    }
+  }
+
+  const handleRemoveConfig = async () => {
+    if (!config) return
+    setRemoving(true)
+    try {
+      await paymentSyncConfigApi.delete(eventSlug)
+      resetFormState()
+      toast.success('Sync configuration removed. You can set up a new one.')
+    } catch {
+      toast.error('Failed to remove configuration')
+    } finally {
+      setRemoving(false)
+    }
+  }
+
+  const resetFormState = () => {
+    setConfig(null)
+    setHeaders([])
+    setTabs([])
+    setSheetUrl('')
+    setSheetTabName('')
+    setEmailColumn('')
+    setPhoneColumn('')
+    setTicketCodeColumn('')
+    setPaidStatusColumn('')
+    setPaidValue('TRUE')
+    setAutoDetected(false)
+    setDirty(false)
+    setLastSyncResult(null)
+  }
+
+  const handleSheetUrlChange = (url: string) => {
+    setSheetUrl(url)
+    setDirty(true)
+    if (url.includes('docs.google.com/spreadsheets')) {
+      fetchMetadata(url)
+    }
+  }
+
+  const handleTabChange = (tabName: string) => {
+    setSheetTabName(tabName)
+    setDirty(true)
+    fetchHeadersForTab(tabName)
+  }
+
+  const hasIdentifier = emailColumn || phoneColumn || ticketCodeColumn
+
+  const handleSave = async () => {
+    if (!paidStatusColumn) {
+      toast.error('Select a paid status column')
+      return
+    }
+    if (!hasIdentifier) {
+      toast.error('Select at least one identifier (email, phone, or ticket code)')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const data = {
+        sheet_url: sheetUrl,
+        sheet_tab_name: sheetTabName || undefined,
+        email_column: emailColumn || undefined,
+        phone_column: phoneColumn || undefined,
+        ticket_code_column: ticketCodeColumn || undefined,
+        paid_status_column: paidStatusColumn,
+        paid_value: paidValue || 'TRUE',
+        active: true,
+      }
+
+      const result = config
+        ? await paymentSyncConfigApi.update(eventSlug, data)
+        : await paymentSyncConfigApi.create(eventSlug, data)
+
+      setConfig(result)
+      setDirty(false)
+      setAutoDetected(false)
+      toast.success(config ? 'Sync settings updated' : 'Sync settings saved')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save'
+      toast.error(message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSync = async () => {
+    setSyncing(true)
+    try {
+      const result = await paymentSyncConfigApi.sync(eventSlug)
+      setLastSyncResult(result)
+
+      if (config) {
+        setConfig({ ...config, last_synced_at: result.last_synced_at })
+      }
+
+      const { synced, errors: errCount, skipped } = result.results
+      toast.success(
+        `Sync complete: ${synced} updated, ${errCount} errors, ${skipped} skipped`,
+      )
+      onSyncComplete?.()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Sync failed'
+      toast.error(message)
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  const selectClass =
+    'w-full px-3 py-2 text-sm rounded-lg bg-background/10 border border-border text-foreground focus:outline-none focus:ring-2 focus:ring-primary transition-all'
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-5 h-5 animate-spin text-foreground/50" />
+        <span className="ml-2 text-sm text-foreground/50">Checking connection...</span>
+      </div>
+    )
+  }
+
+  // Not connected — show connect button
+  if (!connectionStatus?.connected) {
+    return (
+      <div className="rounded-lg border border-border bg-background/5 p-6 text-center space-y-3">
+        <Sheet className="w-8 h-8 mx-auto text-foreground/40" />
+        <div>
+          <p className="text-sm font-medium text-foreground">Connect Google Sheets</p>
+          <p className="text-xs text-foreground/50 mt-1">
+            Connect your Google account to sync vendor payment status from a spreadsheet.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleConnect}
+          className="px-4 py-2 text-sm font-medium rounded-lg voxxy-btn-solid transition-colors inline-flex items-center gap-2"
+        >
+          <Link2 className="w-4 h-4" />
+          Connect Google Sheets
+        </button>
+      </div>
+    )
+  }
+
+  // Connected — show config UI
+  return (
+    <div className="space-y-4">
+      {/* Connection Status Bar */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-xs text-foreground/60">
+          <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />
+          <span>
+            Connected as <strong>{connectionStatus.email}</strong>
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          {config && (
+            <button
+              type="button"
+              onClick={handleRemoveConfig}
+              disabled={removing}
+              className="text-xs text-foreground/40 hover:text-red-400 transition-colors inline-flex items-center gap-1"
+            >
+              <Trash2 className="w-3 h-3" />
+              {removing ? 'Removing...' : 'Remove Config'}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleDisconnect}
+            disabled={disconnecting}
+            className="text-xs text-foreground/40 hover:text-red-400 transition-colors inline-flex items-center gap-1"
+          >
+            <Unlink className="w-3 h-3" />
+            {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+          </button>
+        </div>
+      </div>
+
+      {/* Sheet URL Input */}
+      <div>
+        <label className="block text-xs text-foreground/80 font-medium mb-1.5">
+          Google Sheet URL <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="url"
+          value={sheetUrl}
+          onChange={(e) => handleSheetUrlChange(e.target.value)}
+          placeholder="Paste your Google Sheets link here..."
+          className="w-full px-3 py-2 text-sm rounded-lg bg-background/10 border border-border text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary transition-all"
+        />
+      </div>
+
+      {/* Loading metadata */}
+      {fetchingMetadata && (
+        <div className="flex items-center gap-2 text-xs text-foreground/50">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          <span>Reading your spreadsheet...</span>
+        </div>
+      )}
+
+      {/* Metadata error */}
+      {metadataError && (
+        <div className="flex items-start gap-2 text-xs text-red-400 bg-red-500/10 rounded-lg p-3">
+          <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium">Could not read sheet</p>
+            <p className="text-red-400/80 mt-0.5">{metadataError}</p>
+            <button
+              type="button"
+              onClick={() => sheetUrl && fetchMetadata(sheetUrl)}
+              className="mt-1 text-xs underline hover:no-underline inline-flex items-center gap-1"
+            >
+              <RefreshCw className="w-3 h-3" />
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Column Mapping (shown when headers are loaded) */}
+      {headers.length > 0 && (
+        <div className="space-y-3 pt-1">
+          {/* Auto-detect banner */}
+          {autoDetected && (
+            <div className="flex items-center gap-2 text-xs text-green-600 bg-green-500/10 rounded-lg p-2.5">
+              <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
+              <span>
+                We auto-detected your column mappings. Review and adjust if needed.
+              </span>
+            </div>
+          )}
+
+          {/* Tab Selector */}
+          {tabs.length > 1 && (
+            <div>
+              <label className="block text-xs text-foreground/80 font-medium mb-1.5">
+                Sheet Tab
+              </label>
+              <select
+                value={sheetTabName || tabs[0]}
+                onChange={(e) => handleTabChange(e.target.value)}
+                className={selectClass}
+              >
+                {tabs.map((tab) => (
+                  <option key={tab} value={tab}>
+                    {tab}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <p className="text-xs text-foreground/50">
+            Map your columns for matching. At least one identifier (email, phone, or ticket code) is required.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {/* Email Column */}
+            <div>
+              <label className="block text-xs text-foreground/80 font-medium mb-1.5">
+                Email Column
+              </label>
+              <select
+                value={emailColumn}
+                onChange={(e) => { setEmailColumn(e.target.value); setDirty(true) }}
+                className={selectClass}
+              >
+                <option value="">-- None --</option>
+                {headers.map((h) => (
+                  <option key={h} value={h}>{h}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Phone Column */}
+            <div>
+              <label className="block text-xs text-foreground/80 font-medium mb-1.5">
+                Phone Column
+              </label>
+              <select
+                value={phoneColumn}
+                onChange={(e) => { setPhoneColumn(e.target.value); setDirty(true) }}
+                className={selectClass}
+              >
+                <option value="">-- None --</option>
+                {headers.map((h) => (
+                  <option key={h} value={h}>{h}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Ticket Code Column */}
+            <div>
+              <label className="block text-xs text-foreground/80 font-medium mb-1.5">
+                Ticket Code Column
+                <span className="text-foreground/40 font-normal ml-1">(optional)</span>
+              </label>
+              <select
+                value={ticketCodeColumn}
+                onChange={(e) => { setTicketCodeColumn(e.target.value); setDirty(true) }}
+                className={selectClass}
+              >
+                <option value="">-- None --</option>
+                {headers.map((h) => (
+                  <option key={h} value={h}>{h}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Paid Status Column */}
+            <div>
+              <label className="block text-xs text-foreground/80 font-medium mb-1.5">
+                Paid Status Column <span className="text-red-400">*</span>
+              </label>
+              <select
+                value={paidStatusColumn}
+                onChange={(e) => { setPaidStatusColumn(e.target.value); setDirty(true) }}
+                className={selectClass}
+              >
+                <option value="">-- Select column --</option>
+                {headers.map((h) => (
+                  <option key={h} value={h}>{h}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Paid Value */}
+            <div className="md:col-span-2">
+              <label className="block text-xs text-foreground/80 font-medium mb-1.5">
+                Value that means "paid" <span className="text-red-400">*</span>
+              </label>
+              <input
+                type="text"
+                value={paidValue}
+                onChange={(e) => { setPaidValue(e.target.value); setDirty(true) }}
+                placeholder='e.g., "YES", "Paid", "TRUE"'
+                className="w-full md:w-1/2 px-3 py-2 text-sm rounded-lg bg-background/10 border border-border text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-2 focus:ring-primary transition-all"
+              />
+            </div>
+          </div>
+
+          {/* Validation hint */}
+          {!hasIdentifier && (
+            <div className="flex items-start gap-2 text-xs text-amber-500 bg-amber-500/10 rounded-lg p-3">
+              <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+              <span>Select at least one identifier column (email, phone, or ticket code) for matching.</span>
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex items-center gap-2 pt-2 border-t border-border">
+            {/* Save button — shown when dirty */}
+            {dirty && (
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving || !paidStatusColumn || !hasIdentifier}
+                className="px-4 py-2 text-sm font-medium rounded-lg voxxy-btn-solid transition-all disabled:opacity-50 inline-flex items-center gap-2"
+              >
+                {saving ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="w-3.5 h-3.5" />
+                )}
+                {saving ? 'Saving...' : config ? 'Update Settings' : 'Save Settings'}
+              </button>
+            )}
+
+            {/* Sync Now button — shown when config is saved */}
+            {config && !dirty && (
+              <button
+                type="button"
+                onClick={handleSync}
+                disabled={syncing}
+                className="px-4 py-2 text-sm font-medium rounded-lg voxxy-btn-solid transition-all disabled:opacity-50 inline-flex items-center gap-2"
+              >
+                {syncing ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <Play className="w-3.5 h-3.5" />
+                )}
+                {syncing ? 'Syncing...' : 'Sync Now'}
+              </button>
+            )}
+
+            {/* Last synced */}
+            {config?.last_synced_at && (
+              <span className="text-xs text-foreground/40 inline-flex items-center gap-1 ml-auto">
+                <Clock className="w-3 h-3" />
+                Last synced{' '}
+                {new Date(config.last_synced_at).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                })}
+              </span>
+            )}
+          </div>
+
+          {/* Sync result summary */}
+          {lastSyncResult && (
+            <div className="text-xs bg-green-500/10 text-green-600 rounded-lg p-2.5 flex items-center gap-2">
+              <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
+              <span>
+                {lastSyncResult.results.synced} payment{lastSyncResult.results.synced !== 1 ? 's' : ''}{' '}
+                updated
+                {lastSyncResult.results.errors > 0 &&
+                  `, ${lastSyncResult.results.errors} unmatched`}
+                {lastSyncResult.results.skipped > 0 &&
+                  `, ${lastSyncResult.results.skipped} skipped`}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/producer/GoogleSheets/SyncErrorsPanel.tsx
+++ b/src/components/producer/GoogleSheets/SyncErrorsPanel.tsx
@@ -35,11 +35,16 @@ export default function SyncErrorsPanel({
 
   const loadErrors = async () => {
     try {
-      const [errorsData, regsData] = await Promise.all([
-        paymentSyncErrorsApi.list(eventSlug, false),
-        registrationsApi.getByEvent(eventSlug),
-      ])
-      setErrors(errorsData)
+      const data = await paymentSyncErrorsApi.list(eventSlug, false)
+      setErrors(data)
+    } catch (err) {
+      console.error('Failed to load sync errors:', err)
+    } finally {
+      setLoading(false)
+    }
+
+    try {
+      const regsData = await registrationsApi.getByEvent(eventSlug)
       const regList = (regsData?.vendor_registrations || []).map((r: any) => ({
         id: r.id,
         name: r.name || r.first_name,
@@ -48,9 +53,7 @@ export default function SyncErrorsPanel({
       }))
       setRegistrations(regList)
     } catch (err) {
-      console.error('Failed to load sync errors:', err)
-    } finally {
-      setLoading(false)
+      console.error('Failed to load registrations:', err)
     }
   }
 

--- a/src/components/producer/GoogleSheets/SyncErrorsPanel.tsx
+++ b/src/components/producer/GoogleSheets/SyncErrorsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { AlertTriangle, CheckCircle2, X, Loader2, Search, User } from 'lucide-react'
 import { paymentSyncErrorsApi } from '@/services/googleSheetsApi'
+import { registrationsApi } from '@/services/api'
 import type { PaymentSyncError } from '@/types/googleSheets'
 
 interface Registration {
@@ -12,16 +13,17 @@ interface Registration {
 
 interface SyncErrorsPanelProps {
   eventSlug: string
-  registrations: Registration[]
+  refreshTrigger?: number
   onErrorsChange?: () => void
 }
 
 export default function SyncErrorsPanel({
   eventSlug,
-  registrations,
+  refreshTrigger = 0,
   onErrorsChange,
 }: SyncErrorsPanelProps) {
   const [errors, setErrors] = useState<PaymentSyncError[]>([])
+  const [registrations, setRegistrations] = useState<Registration[]>([])
   const [loading, setLoading] = useState(true)
   const [matchingErrorId, setMatchingErrorId] = useState<number | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
@@ -29,12 +31,22 @@ export default function SyncErrorsPanel({
 
   useEffect(() => {
     loadErrors()
-  }, [eventSlug])
+  }, [eventSlug, refreshTrigger])
 
   const loadErrors = async () => {
     try {
-      const data = await paymentSyncErrorsApi.list(eventSlug, false)
-      setErrors(data)
+      const [errorsData, regsData] = await Promise.all([
+        paymentSyncErrorsApi.list(eventSlug, false),
+        registrationsApi.getByEvent(eventSlug),
+      ])
+      setErrors(errorsData)
+      const regList = (regsData?.vendor_registrations || []).map((r: any) => ({
+        id: r.id,
+        name: r.name || r.first_name,
+        email: r.email,
+        phone: r.phone,
+      }))
+      setRegistrations(regList)
     } catch (err) {
       console.error('Failed to load sync errors:', err)
     } finally {

--- a/src/components/producer/GoogleSheets/SyncErrorsPanel.tsx
+++ b/src/components/producer/GoogleSheets/SyncErrorsPanel.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect } from 'react'
+import { AlertTriangle, CheckCircle2, X, Loader2, Search, User } from 'lucide-react'
+import { paymentSyncErrorsApi } from '@/services/googleSheetsApi'
+import type { PaymentSyncError } from '@/types/googleSheets'
+
+interface Registration {
+  id: number
+  name?: string
+  email?: string
+  phone?: string
+}
+
+interface SyncErrorsPanelProps {
+  eventSlug: string
+  registrations: Registration[]
+  onErrorsChange?: () => void
+}
+
+export default function SyncErrorsPanel({
+  eventSlug,
+  registrations,
+  onErrorsChange,
+}: SyncErrorsPanelProps) {
+  const [errors, setErrors] = useState<PaymentSyncError[]>([])
+  const [loading, setLoading] = useState(true)
+  const [matchingErrorId, setMatchingErrorId] = useState<number | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [resolving, setResolving] = useState<number | null>(null)
+
+  useEffect(() => {
+    loadErrors()
+  }, [eventSlug])
+
+  const loadErrors = async () => {
+    try {
+      const data = await paymentSyncErrorsApi.list(eventSlug, false)
+      setErrors(data)
+    } catch (err) {
+      console.error('Failed to load sync errors:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleResolve = async (errorId: number, registrationId: number) => {
+    setResolving(errorId)
+    try {
+      await paymentSyncErrorsApi.resolve(eventSlug, errorId, registrationId)
+      setErrors((prev) => prev.filter((e) => e.id !== errorId))
+      setMatchingErrorId(null)
+      setSearchQuery('')
+      onErrorsChange?.()
+    } catch (err) {
+      console.error('Failed to resolve error:', err)
+    } finally {
+      setResolving(null)
+    }
+  }
+
+  const handleDismiss = async (errorId: number) => {
+    try {
+      await paymentSyncErrorsApi.dismiss(eventSlug, errorId)
+      setErrors((prev) => prev.filter((e) => e.id !== errorId))
+      onErrorsChange?.()
+    } catch (err) {
+      console.error('Failed to dismiss error:', err)
+    }
+  }
+
+  const filteredRegistrations = registrations.filter((r) => {
+    if (!searchQuery) return true
+    const q = searchQuery.toLowerCase()
+    return (
+      r.name?.toLowerCase().includes(q) ||
+      r.email?.toLowerCase().includes(q) ||
+      r.phone?.includes(q)
+    )
+  })
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Loader2 className="w-4 h-4 animate-spin text-foreground/50" />
+        <span className="ml-2 text-sm text-foreground/50">Loading errors...</span>
+      </div>
+    )
+  }
+
+  if (errors.length === 0) {
+    return (
+      <div className="text-center py-6">
+        <CheckCircle2 className="w-6 h-6 mx-auto text-green-500 mb-2" />
+        <p className="text-sm text-foreground/60">No unresolved sync errors</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-foreground/50">
+        {errors.length} unmatched {errors.length === 1 ? 'row' : 'rows'} from your payment sheet.
+        Match them to participants or dismiss.
+      </p>
+
+      {errors.map((error) => (
+        <div
+          key={error.id}
+          className="bg-background/5 rounded-lg border border-border p-3 space-y-2"
+        >
+          {/* Error header */}
+          <div className="flex items-start justify-between">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+              <span className="text-xs font-medium text-foreground capitalize">
+                {error.reason.replace('_', ' ')}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => handleDismiss(error.id)}
+              className="p-1 rounded hover:bg-background/20 text-foreground/40 hover:text-foreground/70 transition-colors"
+              title="Dismiss"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </div>
+
+          {/* Raw row data */}
+          {error.raw_row && (
+            <div className="bg-background/10 rounded p-2">
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                {Object.entries(error.raw_row).map(([key, value]) => (
+                  <div key={key} className="text-xs">
+                    <span className="text-foreground/40">{key}: </span>
+                    <span className="text-foreground/80">{String(value)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Match button or matching UI */}
+          {matchingErrorId === error.id ? (
+            <div className="space-y-2 pt-1">
+              <div className="relative">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-foreground/40" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search by name, email, or phone..."
+                  className="w-full pl-8 pr-3 py-1.5 text-xs rounded-lg bg-background/10 border border-border text-foreground placeholder:text-foreground/40 focus:outline-none focus:ring-1 focus:ring-primary"
+                  autoFocus
+                />
+              </div>
+              <div className="max-h-32 overflow-y-auto space-y-1">
+                {filteredRegistrations.slice(0, 10).map((reg) => (
+                  <button
+                    key={reg.id}
+                    type="button"
+                    onClick={() => handleResolve(error.id, reg.id)}
+                    disabled={resolving === error.id}
+                    className="w-full text-left px-2.5 py-1.5 rounded text-xs hover:bg-primary/10 transition-colors flex items-center gap-2 disabled:opacity-50"
+                  >
+                    <User className="w-3 h-3 text-foreground/40 shrink-0" />
+                    <div className="truncate">
+                      <span className="font-medium text-foreground">{reg.name || 'Unknown'}</span>
+                      {reg.email && (
+                        <span className="text-foreground/50 ml-1.5">{reg.email}</span>
+                      )}
+                    </div>
+                  </button>
+                ))}
+                {filteredRegistrations.length === 0 && (
+                  <p className="text-xs text-foreground/40 py-2 text-center">No matches found</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setMatchingErrorId(null)
+                  setSearchQuery('')
+                }}
+                className="text-xs text-foreground/50 hover:text-foreground/70"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setMatchingErrorId(error.id)}
+              className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-primary/10 hover:border-primary/30 transition-colors inline-flex items-center gap-1.5"
+            >
+              <User className="w-3 h-3" />
+              Match to Participant
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/producer/GoogleSheets/columnAutoDetect.ts
+++ b/src/components/producer/GoogleSheets/columnAutoDetect.ts
@@ -1,0 +1,135 @@
+/**
+ * Auto-detect column mappings for Google Sheets payment sync.
+ * Fields to match: email_column, phone_column, ticket_code_column, paid_status_column
+ * Plus auto-detect the "paid value" by scanning column data.
+ */
+
+/** Normalize a header for comparison: lowercase, trim, underscores */
+function normalize(header: string): string {
+  return header.trim().toLowerCase().replace(/\s+/g, '_')
+}
+
+// Headers that map to the email identifier column
+const EMAIL_PATTERNS = [
+  'email', 'e_mail', 'email_address', 'e_mail_address',
+  'vendor_email', 'contact_email',
+]
+
+// Headers that map to the phone identifier column
+const PHONE_PATTERNS = [
+  'phone', 'phone_number', 'cell', 'cell_phone',
+  'mobile', 'mobile_phone', 'telephone', 'tel',
+]
+
+// Headers that map to the ticket code column
+const TICKET_CODE_PATTERNS = [
+  'ticket_code', 'ticketcode', 'ticket', 'code',
+  'application_code', 'confirmation_code', 'ref_code',
+  'reference', 'ref',
+]
+
+// Headers that map to the paid status column
+const PAID_STATUS_PATTERNS = [
+  'payment_status', 'paid', 'payment', 'status',
+  'paid_status', 'pay_status', 'is_paid',
+]
+
+// Common values that mean "paid" in a spreadsheet
+const PAID_VALUE_CANDIDATES = [
+  'TRUE', 'true', 'True',
+  'YES', 'yes', 'Yes',
+  'PAID', 'paid', 'Paid',
+  'X', 'x',
+  '1',
+  'Completed', 'completed', 'COMPLETED',
+]
+
+export interface AutoDetectResult {
+  emailColumn: string | null
+  phoneColumn: string | null
+  ticketCodeColumn: string | null
+  paidStatusColumn: string | null
+  paidValue: string | null
+  confidence: 'high' | 'medium' | 'low'
+}
+
+function tryMatch(
+  header: string,
+  norm: string,
+  patterns: string[],
+): boolean {
+  if (patterns.includes(norm)) return true
+  if (patterns.some((p) => norm.includes(p) || p.includes(norm))) return true
+  return false
+}
+
+/**
+ * Auto-detect which sheet columns map to email, phone, ticket code, and paid status.
+ * @param headers - column header strings from the sheet
+ * @param sampleRows - first few data rows as arrays of strings (matching header order)
+ */
+export function autoDetectColumns(
+  headers: string[],
+  sampleRows?: string[][],
+): AutoDetectResult {
+  let emailColumn: string | null = null
+  let phoneColumn: string | null = null
+  let ticketCodeColumn: string | null = null
+  let paidStatusColumn: string | null = null
+  let paidValue: string | null = null
+  let matchCount = 0
+
+  for (const header of headers) {
+    const norm = normalize(header)
+
+    if (!emailColumn && tryMatch(header, norm, EMAIL_PATTERNS)) {
+      emailColumn = header
+      matchCount++
+      continue
+    }
+
+    if (!phoneColumn && tryMatch(header, norm, PHONE_PATTERNS)) {
+      phoneColumn = header
+      matchCount++
+      continue
+    }
+
+    if (!ticketCodeColumn && tryMatch(header, norm, TICKET_CODE_PATTERNS)) {
+      ticketCodeColumn = header
+      matchCount++
+      continue
+    }
+
+    if (!paidStatusColumn && tryMatch(header, norm, PAID_STATUS_PATTERNS)) {
+      paidStatusColumn = header
+      matchCount++
+      continue
+    }
+  }
+
+  // Auto-detect paid value by scanning the paid status column's data
+  if (paidStatusColumn && sampleRows && sampleRows.length > 0) {
+    const colIndex = headers.indexOf(paidStatusColumn)
+    if (colIndex >= 0) {
+      const values = sampleRows
+        .map((row) => row[colIndex]?.trim())
+        .filter(Boolean)
+
+      for (const candidate of PAID_VALUE_CANDIDATES) {
+        if (values.some((v) => v === candidate)) {
+          paidValue = candidate
+          break
+        }
+      }
+    }
+  }
+
+  // Default paid value if we found a status column but no data match
+  if (paidStatusColumn && !paidValue) {
+    paidValue = 'TRUE'
+  }
+
+  const confidence = matchCount >= 3 ? 'high' : matchCount >= 2 ? 'medium' : 'low'
+
+  return { emailColumn, phoneColumn, ticketCodeColumn, paidStatusColumn, paidValue, confidence }
+}

--- a/src/components/producer/GoogleSheets/columnAutoDetect.ts
+++ b/src/components/producer/GoogleSheets/columnAutoDetect.ts
@@ -54,12 +54,15 @@ export interface AutoDetectResult {
 }
 
 function tryMatch(
-  header: string,
+  _header: string,
   norm: string,
   patterns: string[],
 ): boolean {
+  // Exact match (after normalization)
   if (patterns.includes(norm)) return true
-  if (patterns.some((p) => norm.includes(p) || p.includes(norm))) return true
+  // Substring match — only if the pattern is long enough to avoid false positives
+  // (e.g., "tel" matching "Hotel", "ref" matching "preferred")
+  if (patterns.some((p) => p.length >= 5 && (norm.includes(p) || p.includes(norm)))) return true
   return false
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
   Calendar,
   Users,
@@ -175,6 +175,7 @@ interface PresentsAnalytics {
 type CommandCenterTab = 'details' | 'applicants' | 'emails' | 'settings'
 
 export default function ProducerDashboard() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [activeNav, setActiveNav] = useState<NavItem>('events')
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [eventsView, setEventsView] = useState<EventsView>('empty')
@@ -367,6 +368,29 @@ export default function ProducerDashboard() {
       }
     }
   }, [loadingOrg, loadingEvents, organization, events.length])
+
+  // Handle deep-link query params (e.g., after Google OAuth redirect)
+  const deepLinkHandledRef = useRef(false)
+  useEffect(() => {
+    if (deepLinkHandledRef.current || loadingOrg || loadingEvents || events.length === 0) return
+
+    const tabParam = searchParams.get('tab')
+    const eventParam = searchParams.get('event')
+
+    if (tabParam && eventParam) {
+      deepLinkHandledRef.current = true
+      const matchedEvent = events.find((e) => e.slug === eventParam)
+      if (matchedEvent) {
+        setSelectedEvent(matchedEvent)
+        setEventsView('command-center')
+        if (tabParam === 'settings' || tabParam === 'applicants' || tabParam === 'emails' || tabParam === 'details') {
+          setCommandCenterTab(tabParam as CommandCenterTab)
+        }
+      }
+      // Clear query params from URL
+      setSearchParams({}, { replace: true })
+    }
+  }, [loadingOrg, loadingEvents, events, searchParams, setSearchParams])
 
   // Load admin data when admin tab is active
   useEffect(() => {

--- a/src/pages/GoogleOAuthCallback.tsx
+++ b/src/pages/GoogleOAuthCallback.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Loader2, AlertCircle } from 'lucide-react'
+import { googleSheetsOauthApi } from '@/services/googleSheetsApi'
+import { toast } from 'sonner'
+
+export default function GoogleOAuthCallback() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const code = searchParams.get('code')
+    const errorParam = searchParams.get('error')
+
+    if (errorParam) {
+      setError(errorParam === 'access_denied' ? 'Google Sheets access was denied.' : errorParam)
+      return
+    }
+
+    if (!code) {
+      setError('No authorization code received from Google.')
+      return
+    }
+
+    const orgId = localStorage.getItem('gsheets_org_id')
+    if (!orgId) {
+      setError('Missing organization context. Please try connecting again from your event settings.')
+      return
+    }
+
+    const exchangeCode = async () => {
+      try {
+        const redirectUri = `${window.location.origin}/google/callback`
+        await googleSheetsOauthApi.callback(Number(orgId), code, redirectUri)
+        localStorage.removeItem('gsheets_org_id')
+        toast.success('Google Sheets connected successfully!')
+
+        // Redirect back to event settings — use stored slug or dashboard
+        const returnSlug = localStorage.getItem('gsheets_return_slug')
+        localStorage.removeItem('gsheets_return_slug')
+        if (returnSlug) {
+          navigate(`/dashboard?tab=settings&event=${returnSlug}&gsheets=connected`, { replace: true })
+        } else {
+          navigate('/dashboard', { replace: true })
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to connect Google Sheets'
+        setError(message)
+      }
+    }
+
+    exchangeCode()
+  }, [searchParams, navigate])
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <div className="max-w-sm w-full text-center space-y-4">
+          <AlertCircle className="w-10 h-10 mx-auto text-red-500" />
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Connection Failed</h2>
+            <p className="text-sm text-foreground/60 mt-1">{error}</p>
+          </div>
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="px-4 py-2 text-sm font-medium rounded-lg voxxy-btn-solid transition-colors"
+          >
+            Back to Dashboard
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center space-y-3">
+        <Loader2 className="w-8 h-8 animate-spin mx-auto text-primary" />
+        <p className="text-sm text-foreground/60">Connecting Google Sheets...</p>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/GoogleOAuthCallback.tsx
+++ b/src/pages/GoogleOAuthCallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, AlertCircle } from 'lucide-react'
 import { googleSheetsOauthApi } from '@/services/googleSheetsApi'
@@ -8,8 +8,11 @@ export default function GoogleOAuthCallback() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
+  const exchangedRef = useRef(false)
 
   useEffect(() => {
+    if (exchangedRef.current) return
+    exchangedRef.current = true
     const code = searchParams.get('code')
     const errorParam = searchParams.get('error')
 

--- a/src/services/googleSheetsApi.ts
+++ b/src/services/googleSheetsApi.ts
@@ -1,0 +1,250 @@
+// Google Sheets Payment Sync API service
+import { getApiUrl } from '@/config/environments'
+import { getAuthToken } from './api'
+import type {
+  GoogleSheetsConnectionStatus,
+  PaymentSyncConfig,
+  CreatePaymentSyncConfigRequest,
+  UpdatePaymentSyncConfigRequest,
+  PaymentSyncError,
+  SheetMetadata,
+  TestSyncResult,
+  SyncResult,
+} from '@/types/googleSheets'
+
+const API_BASE_URL =
+  getApiUrl() || import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api'
+
+class GoogleSheetsApiError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public data?: Record<string, unknown>,
+  ) {
+    super(message)
+    this.name = 'GoogleSheetsApiError'
+  }
+}
+
+async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
+  const token = getAuthToken()
+
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...options.headers,
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new GoogleSheetsApiError(
+      errorData.error || `Request failed with status ${response.status}`,
+      response.status,
+      errorData,
+    )
+  }
+
+  return response
+}
+
+// Organization-level Google Sheets OAuth endpoints
+export const googleSheetsOauthApi = {
+  getAuthUrl: async (
+    organizationId: number,
+    redirectUri?: string,
+  ): Promise<{ auth_url: string }> => {
+    const params = redirectUri ? `?redirect_uri=${encodeURIComponent(redirectUri)}` : ''
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/organizations/${organizationId}/google_sheets/auth_url${params}`,
+    )
+    return response.json()
+  },
+
+  callback: async (
+    organizationId: number,
+    code: string,
+    redirectUri?: string,
+  ): Promise<GoogleSheetsConnectionStatus & { message: string }> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/organizations/${organizationId}/google_sheets/callback`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ code, redirect_uri: redirectUri }),
+      },
+    )
+    return response.json()
+  },
+
+  getStatus: async (organizationId: number): Promise<GoogleSheetsConnectionStatus> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/organizations/${organizationId}/google_sheets/status`,
+    )
+    return response.json()
+  },
+
+  disconnect: async (organizationId: number): Promise<{ message: string }> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/organizations/${organizationId}/google_sheets/disconnect`,
+      {
+        method: 'DELETE',
+      },
+    )
+    return response.json()
+  },
+
+  getSheetMetadata: async (
+    organizationId: number,
+    sheetUrl?: string,
+    sheetId?: string,
+    tabName?: string,
+  ): Promise<SheetMetadata> => {
+    const params = new URLSearchParams()
+    if (sheetUrl) params.set('sheet_url', sheetUrl)
+    if (sheetId) params.set('sheet_id', sheetId)
+    if (tabName) params.set('tab_name', tabName)
+
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/organizations/${organizationId}/google_sheets/sheet_metadata?${params}`,
+    )
+    return response.json()
+  },
+}
+
+// Event-level payment sync config endpoints
+export const paymentSyncConfigApi = {
+  get: async (eventSlug: string): Promise<PaymentSyncConfig> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_config`,
+    )
+    return response.json()
+  },
+
+  create: async (
+    eventSlug: string,
+    data: CreatePaymentSyncConfigRequest,
+  ): Promise<PaymentSyncConfig> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_config`,
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      },
+    )
+    return response.json()
+  },
+
+  update: async (
+    eventSlug: string,
+    data: UpdatePaymentSyncConfigRequest,
+  ): Promise<PaymentSyncConfig> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_config`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      },
+    )
+    return response.json()
+  },
+
+  delete: async (eventSlug: string): Promise<{ message: string }> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_config`,
+      {
+        method: 'DELETE',
+      },
+    )
+    return response.json()
+  },
+
+  test: async (eventSlug: string, limit?: number): Promise<TestSyncResult> => {
+    const params = limit ? `?limit=${limit}` : ''
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_config/test${params}`,
+      {
+        method: 'POST',
+      },
+    )
+    return response.json()
+  },
+
+  sync: async (eventSlug: string): Promise<SyncResult> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_config/sync`,
+      {
+        method: 'POST',
+      },
+    )
+    return response.json()
+  },
+
+  getSheetMetadata: async (
+    eventSlug: string,
+    sheetUrl?: string,
+    sheetId?: string,
+    tabName?: string,
+  ): Promise<SheetMetadata> => {
+    const params = new URLSearchParams()
+    if (sheetUrl) params.set('sheet_url', sheetUrl)
+    if (sheetId) params.set('sheet_id', sheetId)
+    if (tabName) params.set('tab_name', tabName)
+
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_config/sheet_metadata?${params}`,
+    )
+    return response.json()
+  },
+}
+
+// Payment sync error endpoints
+export const paymentSyncErrorsApi = {
+  list: async (eventSlug: string, resolved?: boolean): Promise<PaymentSyncError[]> => {
+    const params = resolved !== undefined ? `?resolved=${resolved}` : ''
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_errors${params}`,
+    )
+    return response.json()
+  },
+
+  resolve: async (
+    eventSlug: string,
+    errorId: number,
+    registrationId: number,
+  ): Promise<{ message: string; error: PaymentSyncError }> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_errors/${errorId}/resolve`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ registration_id: registrationId }),
+      },
+    )
+    return response.json()
+  },
+
+  dismiss: async (eventSlug: string, errorId: number): Promise<{ message: string }> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_errors/${errorId}/dismiss`,
+      {
+        method: 'POST',
+      },
+    )
+    return response.json()
+  },
+
+  resolveAll: async (eventSlug: string): Promise<{ message: string }> => {
+    const response = await fetchWithAuth(
+      `${API_BASE_URL}/v1/presents/events/${eventSlug}/payment_sync_errors/resolve_all`,
+      {
+        method: 'POST',
+      },
+    )
+    return response.json()
+  },
+}
+
+export { GoogleSheetsApiError }

--- a/src/types/googleSheets.ts
+++ b/src/types/googleSheets.ts
@@ -28,20 +28,20 @@ export interface PaymentSyncConfig {
 export interface CreatePaymentSyncConfigRequest {
   sheet_url?: string
   sheet_id?: string
-  sheet_tab_name?: string
-  email_column?: string
-  phone_column?: string
-  ticket_code_column?: string
+  sheet_tab_name?: string | null
+  email_column?: string | null
+  phone_column?: string | null
+  ticket_code_column?: string | null
   paid_status_column: string
   paid_value?: string
   active?: boolean
 }
 
 export interface UpdatePaymentSyncConfigRequest {
-  sheet_tab_name?: string
-  email_column?: string
-  phone_column?: string
-  ticket_code_column?: string
+  sheet_tab_name?: string | null
+  email_column?: string | null
+  phone_column?: string | null
+  ticket_code_column?: string | null
   paid_status_column?: string
   paid_value?: string
   active?: boolean

--- a/src/types/googleSheets.ts
+++ b/src/types/googleSheets.ts
@@ -1,0 +1,96 @@
+// Google Sheets Payment Sync types
+
+export interface GoogleSheetsConnectionStatus {
+  connected: boolean
+  email: string | null
+  connected_at: string | null
+}
+
+export interface PaymentSyncConfig {
+  id: number
+  event_id: number
+  sheet_id: string
+  sheet_url: string
+  sheet_tab_name: string | null
+  email_column: string | null
+  phone_column: string | null
+  ticket_code_column: string | null
+  paid_status_column: string
+  paid_value: string
+  active: boolean
+  last_synced_at: string | null
+  column_headers: string[]
+  unresolved_error_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface CreatePaymentSyncConfigRequest {
+  sheet_url?: string
+  sheet_id?: string
+  sheet_tab_name?: string
+  email_column?: string
+  phone_column?: string
+  ticket_code_column?: string
+  paid_status_column: string
+  paid_value?: string
+  active?: boolean
+}
+
+export interface UpdatePaymentSyncConfigRequest {
+  sheet_tab_name?: string
+  email_column?: string
+  phone_column?: string
+  ticket_code_column?: string
+  paid_status_column?: string
+  paid_value?: string
+  active?: boolean
+}
+
+export interface PaymentSyncError {
+  id: number
+  event_id: number
+  raw_row: Record<string, string>
+  reason: 'no_match' | 'duplicate' | 'missing_identifier'
+  resolved: boolean
+  resolved_by: string | null
+  resolved_at: string | null
+  matched_registration_id: number | null
+  created_at: string
+}
+
+export interface SheetMetadata {
+  tabs: string[]
+  headers: string[]
+  sheet_id: string
+}
+
+export interface TestSyncPreviewRow {
+  raw_data: Record<string, string>
+  email: string | null
+  phone: string | null
+  paid_in_sheet: boolean
+  match_status: 'matched' | 'no_match' | 'missing_identifier'
+  matched_registration: {
+    id: number
+    name: string
+    email: string
+  } | null
+  already_paid: boolean
+}
+
+export interface TestSyncResult {
+  headers: string[]
+  rows: TestSyncPreviewRow[]
+  total_rows: number
+}
+
+export interface SyncResult {
+  message: string
+  results: {
+    synced: number
+    errors: number
+    skipped: number
+  }
+  last_synced_at: string
+}


### PR DESCRIPTION
## Summary
- OAuth flow for connecting Google account to Voxxy
- Sync UI with column auto-detect from sheet headers
- Sync errors panel for manual resolution of unmatched rows

**Backend PR:** Voxxy-AI/voxxy-rails-react#204

## Test plan
- [ ] Connect Google account via OAuth flow
- [ ] Configure sheet ID, tab name, and column mappings
- [ ] Run manual sync and verify matched rows update payment status
- [ ] Verify unmatched rows appear in error resolution panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token exchange and UI that triggers payment-status sync and manual registration matching—incorrect mapping or resolution could mark the wrong vendors paid.
> 
> **Overview**
> Introduces **Google Sheets payment sync** in event settings so producers can pull vendor paid status from a spreadsheet instead of relying on the retired incoming-payments inbox route (noted in `App.tsx`).
> 
> **OAuth and routing:** New lazy route `/google/callback` exchanges the Google auth code (org context from `localStorage`), then redirects to the dashboard with `tab=settings` and `event` query params. The dashboard now reads those params once events load and opens the command center on the right event/settings tab.
> 
> **Event settings:** Two new accordions—**Google Sheets Payment Sync** embeds `GoogleSheetsSync` (connect/disconnect, sheet URL, tab/headers from API metadata, column mapping with header auto-detect, save/update config, manual sync, last-sync summary). **n8n Payment Sync Status** is informational: per-category Eventbrite ID readiness for org-wide webhook matching.
> 
> **Supporting pieces:** `googleSheetsApi` + types for org OAuth, event `payment_sync_config`, and `payment_sync_errors`; `SyncErrorsPanel` for listing unmatched sheet rows and manually matching them to registrations or dismissing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6f5a6700f23da6c1f1e84690ef10f4df01c3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->