### PR TITLE
feat(dashboard): URL-based routing for all dashboard views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -355,7 +355,8 @@ export default function App() {
             <Route path="/profile" element={<RoleBasedDashboardRedirect />} />
 
             {/* Unified Dashboard - Protected (verified + paid producers/admins only) */}
-            <Route path="/dashboard" element={<ProtectedDashboard />} />
+            {/* Wildcard: sub-views are routed inside Dashboard (/dashboard/events/:slug/... etc.) */}
+            <Route path="/dashboard/*" element={<ProtectedDashboard />} />
 
             {/* 404 - Redirect to home */}
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -871,7 +871,7 @@ export default function ProducerDashboard() {
 
     if (eventsView === 'create') {
       // While the event is being created we stay on /dashboard/events/new with a loading screen
-      if (loadingCommandCenter) {
+      if (loadingCommandCenter && creatingEventTitle) {
         return <LoadingCommandCenter eventName={creatingEventTitle} progress={creationProgress} />
       }
       return (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams, useLocation, Navigate } from 'react-router-dom'
+import { analytics as analyticsClient } from '@/lib/analytics'
 import {
   Calendar,
   Users,
@@ -174,15 +175,75 @@ interface PresentsAnalytics {
 
 type CommandCenterTab = 'details' | 'applicants' | 'emails' | 'settings'
 
+// URL structure: /dashboard/<section>[/...]
+//   /dashboard/events                     → events list (or empty state)
+//   /dashboard/events/new                 → create event wizard
+//   /dashboard/events/:slug               → command center (Home tab)
+//   /dashboard/events/:slug/applicants    → command center (Applicants tab)
+//   /dashboard/events/:slug/emails        → command center (Mail tab)
+//   /dashboard/events/:slug/settings      → command center (Settings tab)
+//   /dashboard/events/:slug/edit          → edit event form
+//   /dashboard/network[/lists|/categories]→ network page tabs
+//   /dashboard/emails                     → email templates
+//   /dashboard/settings                   → account settings
+//   /dashboard/admin                      → admin panel (admins only)
+const SECTION_TO_NAV: Record<string, NavItem> = {
+  events: 'events',
+  network: 'network',
+  emails: 'email-templates',
+  settings: 'settings',
+  admin: 'admin',
+}
+
+const COMMAND_CENTER_TABS: CommandCenterTab[] = ['details', 'applicants', 'emails', 'settings']
+
+const navPath = (nav: NavItem): string => {
+  const sectionForNav = Object.entries(SECTION_TO_NAV).find(([, v]) => v === nav)?.[0] ?? 'events'
+  return `/dashboard/${sectionForNav}`
+}
+
+const commandCenterPath = (slug: string, tab: CommandCenterTab = 'details'): string =>
+  tab === 'details' ? `/dashboard/events/${slug}` : `/dashboard/events/${slug}/${tab}`
+
 export default function ProducerDashboard() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const [activeNav, setActiveNav] = useState<NavItem>('events')
+  const location = useLocation()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const [eventsView, setEventsView] = useState<EventsView>('empty')
   const [organization, setOrganization] = useState<Organization | null>(null)
   const [events, setEvents] = useState<Event[]>([])
-  const [selectedEvent, setSelectedEvent] = useState<Event | null>(null)
-  const [commandCenterTab, setCommandCenterTab] = useState<CommandCenterTab>('details')
+
+  // ---- Navigation state derived from the URL (single source of truth) ----
+  // pathSegments: ['dashboard', section?, ...rest]
+  const pathSegments = location.pathname.split('/').filter(Boolean)
+  const section = pathSegments[1]
+  const activeNav: NavItem = SECTION_TO_NAV[section] ?? 'events'
+  const eventSlugParam = section === 'events' ? pathSegments[2] : undefined
+  const eventSubPage = section === 'events' ? pathSegments[3] : undefined
+
+  const selectedEvent: Event | null =
+    eventSlugParam && eventSlugParam !== 'new'
+      ? (events.find((e) => e.slug === eventSlugParam) ?? null)
+      : null
+
+  let eventsView: EventsView
+  if (!eventSlugParam) {
+    eventsView = events.length > 0 ? 'list' : 'empty'
+  } else if (eventSlugParam === 'new') {
+    eventsView = 'create'
+  } else if (eventSubPage === 'edit') {
+    eventsView = 'edit'
+  } else {
+    eventsView = 'command-center'
+  }
+
+  const commandCenterTab: CommandCenterTab = COMMAND_CENTER_TABS.includes(
+    eventSubPage as CommandCenterTab,
+  )
+    ? (eventSubPage as CommandCenterTab)
+    : 'details'
+
+  // Title shown on the create-event loading screen (event has no slug/URL yet)
+  const [creatingEventTitle, setCreatingEventTitle] = useState('')
 
   // Events page controls state
   const [eventsSearchTerm, setEventsSearchTerm] = useState('')
@@ -192,7 +253,10 @@ export default function ProducerDashboard() {
 
   // Network page controls state
   type NetworkTab = 'contacts' | 'lists' | 'categories'
-  const [networkTab, setNetworkTab] = useState<NetworkTab>('contacts')
+  const networkTab: NetworkTab =
+    section === 'network' && (pathSegments[2] === 'lists' || pathSegments[2] === 'categories')
+      ? pathSegments[2]
+      : 'contacts'
   const [networkShowAddModal, setNetworkShowAddModal] = useState(false)
   const [networkShowCSVModal, setNetworkShowCSVModal] = useState(false)
 
@@ -219,6 +283,30 @@ export default function ProducerDashboard() {
   const { dialogOpen, dialogProps, handleEmailNotification, handleConfirmSend, closeDialog } =
     useEmailNotifications()
   const [guidebookOpen, setGuidebookOpen] = useState(false)
+
+  // Track each dashboard screen as a Mixpanel page view (no-op outside production)
+  useEffect(() => {
+    // Skip transient URLs that immediately redirect (e.g. bare /dashboard)
+    if (!section || !SECTION_TO_NAV[section]) return
+
+    let pageName = 'Dashboard: Events'
+    if (section === 'events') {
+      if (eventSlugParam === 'new') pageName = 'Dashboard: Create Event'
+      else if (eventSubPage === 'edit') pageName = 'Dashboard: Edit Event'
+      else if (eventSlugParam) pageName = `Dashboard: Command Center — ${commandCenterTab}`
+    } else if (section === 'network') {
+      pageName = `Dashboard: Network — ${networkTab}`
+    } else if (section === 'emails') {
+      pageName = 'Dashboard: Email Templates'
+    } else if (section === 'settings') {
+      pageName = 'Dashboard: Settings'
+    } else if (section === 'admin') {
+      pageName = 'Dashboard: Admin'
+    }
+
+    analyticsClient.trackPageView({ page_name: pageName, page_url: location.pathname })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname])
 
   // Redirect if not authenticated
   useEffect(() => {
@@ -369,7 +457,8 @@ export default function ProducerDashboard() {
     }
   }, [loadingOrg, loadingEvents, organization, events.length])
 
-  // Handle deep-link query params (e.g., after Google OAuth redirect)
+  // Legacy deep-link support: translate old ?tab=&event= query params (e.g. from
+  // pre-routing OAuth redirects or bookmarks) into the new URL structure
   const deepLinkHandledRef = useRef(false)
   useEffect(() => {
     if (deepLinkHandledRef.current || loadingOrg || loadingEvents || events.length === 0) return
@@ -381,16 +470,15 @@ export default function ProducerDashboard() {
       deepLinkHandledRef.current = true
       const matchedEvent = events.find((e) => e.slug === eventParam)
       if (matchedEvent) {
-        setSelectedEvent(matchedEvent)
-        setEventsView('command-center')
-        if (tabParam === 'settings' || tabParam === 'applicants' || tabParam === 'emails' || tabParam === 'details') {
-          setCommandCenterTab(tabParam as CommandCenterTab)
-        }
+        const tab = COMMAND_CENTER_TABS.includes(tabParam as CommandCenterTab)
+          ? (tabParam as CommandCenterTab)
+          : 'details'
+        navigate(commandCenterPath(matchedEvent.slug, tab), { replace: true })
+      } else {
+        setSearchParams({}, { replace: true })
       }
-      // Clear query params from URL
-      setSearchParams({}, { replace: true })
     }
-  }, [loadingOrg, loadingEvents, events, searchParams, setSearchParams])
+  }, [loadingOrg, loadingEvents, events, searchParams, setSearchParams, navigate])
 
   // Load admin data when admin tab is active
   useEffect(() => {
@@ -409,15 +497,7 @@ export default function ProducerDashboard() {
       console.log('Fetched events:', fetchedEvents)
       console.log('Number of events:', fetchedEvents.length)
       setEvents(fetchedEvents)
-
-      // Set view based on whether there are events
-      if (fetchedEvents.length === 0) {
-        console.log('No events found, setting view to empty')
-        setEventsView('empty')
-      } else {
-        console.log('Events found, setting view to list')
-        setEventsView('list')
-      }
+      // Note: list vs empty view is derived from the URL + events.length
     } catch (err) {
       console.error('Failed to fetch events:', err)
       setError('Failed to load events')
@@ -473,20 +553,10 @@ export default function ProducerDashboard() {
       return
     }
 
-    // Prepare temporary event object for loading state
-    const tempEvent: Event = {
-      id: 0,
-      slug: '',
-      title: wizardState.eventDetails.title,
-      description: wizardState.eventDetails.description,
-      event_date: wizardState.eventDetails.event_date,
-    }
-
     try {
-      // Show loading state immediately
-      setSelectedEvent(tempEvent)
+      // Show loading state immediately (stays on /dashboard/events/new until the event exists)
+      setCreatingEventTitle(wizardState.eventDetails.title)
       setLoadingCommandCenter(true)
-      setEventsView('command-center')
       setCreationProgress('Creating your event...')
 
       // Ensure we have an email template ID - fetch default if not set
@@ -637,29 +707,25 @@ export default function ProducerDashboard() {
       // Note: Scheduled emails are created in "paused" state
       // They will be activated when event goes live
 
-      // Step 4: Refresh events list and prepare to show Command Center
+      // Step 4: Refresh events list and navigate to the new event's Command Center
       setCreationProgress('Loading Command Center...')
       const refreshedEvents = await eventsApi.getByOrganization(organization.slug)
       setEvents(refreshedEvents)
 
-      // Find the newly created event in the refreshed list
-      const createdEvent = refreshedEvents.find((e: Event) => e.slug === newEvent.slug)
-
-      if (createdEvent) {
-        setSelectedEvent(createdEvent)
-      }
+      navigate(commandCenterPath(newEvent.slug))
 
       // Turn off loading to reveal Command Center
       setTimeout(() => {
         setLoadingCommandCenter(false)
         setCreationProgress('')
+        setCreatingEventTitle('')
       }, 500) // Small delay for smooth transition
     } catch (err) {
       console.error('Failed to create event:', err)
-      // Reset states on error
+      // Reset states on error (URL is still /dashboard/events/new, so the wizard stays visible)
       setLoadingCommandCenter(false)
       setCreationProgress('')
-      setEventsView('create')
+      setCreatingEventTitle('')
       throw err // Re-throw to let wizard handle the error
     }
   }
@@ -686,8 +752,7 @@ export default function ProducerDashboard() {
       await fetchEvents(organization.slug)
 
       // Navigate back to list
-      setEventsView('list')
-      setSelectedEvent(null)
+      navigate('/dashboard/events')
     } catch (err) {
       console.error('Failed to update event:', err)
       throw err
@@ -709,9 +774,8 @@ export default function ProducerDashboard() {
       // Refresh events list
       await fetchEvents(organization.slug)
 
-      // Navigate back to list
-      setEventsView(events.length > 1 ? 'list' : 'empty')
-      setSelectedEvent(null)
+      // Navigate back to list (empty state derives automatically if no events remain)
+      navigate('/dashboard/events')
     } catch (err) {
       console.error('Failed to delete event:', err)
       throw err
@@ -726,20 +790,15 @@ export default function ProducerDashboard() {
 
     try {
       const updatedEvent = await eventsApi.getById(selectedEvent.slug)
-      setSelectedEvent(updatedEvent)
-      // Update the events array cache to prevent stale data when navigating back
+      // selectedEvent is derived from the events array, so updating the array updates it
       setEvents((prevEvents) =>
         prevEvents.map((e) => (e.slug === updatedEvent.slug ? updatedEvent : e)),
       )
     } catch (err) {
       console.error('Failed to refetch event:', err)
-      // Fallback: refresh entire events list
+      // Fallback: refresh entire events list (selectedEvent re-derives from it)
       if (organization) {
         await fetchEvents(organization.slug)
-        const refreshedEvent = events.find((e) => e.slug === selectedEvent.slug)
-        if (refreshedEvent) {
-          setSelectedEvent(refreshedEvent)
-        }
       }
     }
   }
@@ -807,13 +866,17 @@ export default function ProducerDashboard() {
     }
 
     if (eventsView === 'empty') {
-      return <EventsEmptyState onCreateEvent={() => setEventsView('create')} />
+      return <EventsEmptyState onCreateEvent={() => navigate('/dashboard/events/new')} />
     }
 
     if (eventsView === 'create') {
+      // While the event is being created we stay on /dashboard/events/new with a loading screen
+      if (loadingCommandCenter) {
+        return <LoadingCommandCenter eventName={creatingEventTitle} progress={creationProgress} />
+      }
       return (
         <CreateEventWizard
-          onCancel={() => setEventsView(events.length > 0 ? 'list' : 'empty')}
+          onCancel={() => navigate('/dashboard/events')}
           onSubmit={handleCreateEvent}
           organizationId={organization?.id || 0}
         />
@@ -824,17 +887,14 @@ export default function ProducerDashboard() {
       return (
         <EditEventForm
           event={selectedEvent}
-          onCancel={() => {
-            setEventsView('list')
-            setSelectedEvent(null)
-          }}
+          onCancel={() => navigate('/dashboard/events')}
           onUpdate={handleUpdateEvent}
           onDelete={handleDeleteEvent}
         />
       )
     }
 
-    if (eventsView === 'command-center') {
+    if (eventsView === 'command-center' || eventsView === 'edit') {
       if (loadingCommandCenter && selectedEvent) {
         return <LoadingCommandCenter eventName={selectedEvent.title} progress={creationProgress} />
       }
@@ -869,23 +929,35 @@ export default function ProducerDashboard() {
             event={selectedEvent}
             organizationId={organization.id}
             activeTab={commandCenterTab}
-            onTabChange={setCommandCenterTab}
-            onBack={() => {
-              setEventsView('list')
-              setSelectedEvent(null)
-              setCommandCenterTab('details') // Reset to default tab when leaving
-            }}
+            onTabChange={(tab: CommandCenterTab) =>
+              navigate(commandCenterPath(selectedEvent.slug, tab))
+            }
+            onBack={() => navigate('/dashboard/events')}
             onUpdateEvent={handleUpdateEvent}
             onDeleteEvent={async (eventSlug: string) => {
               await handleDeleteEvent(eventSlug)
-              setEventsView('list')
-              setSelectedEvent(null)
-              setCommandCenterTab('details') // Reset to default tab
             }}
             onRefreshEvent={handleRefreshEvent}
           />
         )
       }
+
+      // URL points at an event slug that doesn't exist (deleted, typo, or wrong account)
+      return (
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <p className="text-sm text-foreground/60 mb-3">
+              Event not found. It may have been deleted or the link is incorrect.
+            </p>
+            <button
+              onClick={() => navigate('/dashboard/events')}
+              className="px-3 py-1.5 text-sm rounded-lg voxxy-btn-solid transition-smooth"
+            >
+              Back to Events
+            </button>
+          </div>
+        </div>
+      )
     }
 
     return (
@@ -895,20 +967,18 @@ export default function ProducerDashboard() {
         statusFilter={eventsStatusFilter}
         showPastEvents={eventsShowPast}
         sortBy={eventsSortBy}
-        onCreateEvent={() => setEventsView('create')}
+        onCreateEvent={() => navigate('/dashboard/events/new')}
         onEditEvent={(slug) => {
           const event = events.find((e) => e.slug === slug)
           if (event) {
-            setSelectedEvent(event)
-            setEventsView('edit')
+            navigate(`/dashboard/events/${event.slug}/edit`)
           }
         }}
         onCommandCenter={(slug) => {
           const event = events.find((e) => e.slug === slug)
           if (event) {
-            setSelectedEvent(event)
             setLoadingCommandCenter(true)
-            setEventsView('command-center')
+            navigate(commandCenterPath(event.slug))
 
             // Simulate loading delay
             setTimeout(() => {
@@ -920,6 +990,17 @@ export default function ProducerDashboard() {
         isAdmin={isAdmin}
       />
     )
+  }
+
+  // Canonicalize URLs: bare /dashboard and unknown sections go to the events list.
+  // Preserve the query string so legacy ?tab=&event= deep links still resolve.
+  if (!section || !SECTION_TO_NAV[section]) {
+    return <Navigate to={{ pathname: '/dashboard/events', search: location.search }} replace />
+  }
+
+  // Admin section is admin-only
+  if (section === 'admin' && !authLoading && !isAdmin) {
+    return <Navigate to="/dashboard/events" replace />
   }
 
   return (
@@ -970,9 +1051,7 @@ export default function ProducerDashboard() {
             <>
               <button
                 onClick={() => {
-                  setEventsView('list')
-                  setSelectedEvent(null)
-                  setCommandCenterTab('details')
+                  navigate('/dashboard/events')
                   setIsMobileMenuOpen(false)
                 }}
                 className="voxxy-hover-row w-full flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-smooth border border-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent hover:border-ring/40 mb-2"
@@ -995,7 +1074,9 @@ export default function ProducerDashboard() {
                   <button
                     key={tab.id}
                     onClick={() => {
-                      setCommandCenterTab(tab.id)
+                      if (selectedEvent) {
+                        navigate(commandCenterPath(selectedEvent.slug, tab.id))
+                      }
                       setIsMobileMenuOpen(false)
                     }}
                     className={`
@@ -1025,13 +1106,8 @@ export default function ProducerDashboard() {
                   key={item.id}
                   data-onboarding={`nav-${item.id}`}
                   onClick={() => {
-                    setActiveNav(item.id)
+                    navigate(navPath(item.id))
                     setIsMobileMenuOpen(false)
-                    // Reset to appropriate events view when clicking Events nav
-                    if (item.id === 'events' && eventsView !== 'list' && eventsView !== 'empty') {
-                      setEventsView(events.length > 0 ? 'list' : 'empty')
-                      setSelectedEvent(null)
-                    }
                   }}
                   className={`
                     w-full flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg
@@ -1125,7 +1201,7 @@ export default function ProducerDashboard() {
               {/* Events List - Create New Event Button */}
               {activeNav === 'events' && eventsView === 'list' && (
                 <button
-                  onClick={() => setEventsView('create')}
+                  onClick={() => navigate('/dashboard/events/new')}
                   className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg voxxy-btn-cta font-medium hover:shadow-lg hover:shadow-primary/30 transition-smooth text-xs"
                 >
                   <Plus className="w-3.5 h-3.5" />
@@ -1236,7 +1312,11 @@ export default function ProducerDashboard() {
                 return (
                   <button
                     key={tab.id}
-                    onClick={() => setNetworkTab(tab.id)}
+                    onClick={() =>
+                      navigate(
+                        tab.id === 'contacts' ? '/dashboard/network' : `/dashboard/network/${tab.id}`,
+                      )
+                    }
                     className={`flex items-center gap-2 px-4 py-2.5 text-xs font-medium transition-all relative ${
                       networkTab === tab.id
                         ? 'text-sidebar-foreground'
@@ -1262,7 +1342,7 @@ export default function ProducerDashboard() {
         >
           {activeNav === 'settings' ? (
             <SettingsPage
-              onBack={() => setActiveNav('events')}
+              onBack={() => navigate('/dashboard/events')}
               onStartGuide={() => setGuidebookOpen(true)}
             />
           ) : activeNav === 'events' ? (
@@ -1278,7 +1358,9 @@ export default function ProducerDashboard() {
                   setShowAddModal={setNetworkShowAddModal}
                   showCSVUploadModal={networkShowCSVModal}
                   setShowCSVUploadModal={setNetworkShowCSVModal}
-                  onTabChange={setNetworkTab}
+                  onTabChange={(tab: NetworkTab) =>
+                    navigate(tab === 'contacts' ? '/dashboard/network' : `/dashboard/network/${tab}`)
+                  }
                 />
               ) : (
                 <div className="flex items-center justify-center py-8">

--- a/src/pages/GoogleOAuthCallback.tsx
+++ b/src/pages/GoogleOAuthCallback.tsx
@@ -43,9 +43,9 @@ export default function GoogleOAuthCallback() {
         const returnSlug = localStorage.getItem('gsheets_return_slug')
         localStorage.removeItem('gsheets_return_slug')
         if (returnSlug) {
-          navigate(`/dashboard?tab=settings&event=${returnSlug}&gsheets=connected`, { replace: true })
+          navigate(`/dashboard/events/${returnSlug}/settings`, { replace: true })
         } else {
-          navigate('/dashboard', { replace: true })
+          navigate('/dashboard/events', { replace: true })
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to connect Google Sheets'

--- a/src/test/features/routeRegression.test.ts
+++ b/src/test/features/routeRegression.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+import { matchRoutes } from 'react-router-dom'
+
+// Extract the actual route patterns defined in App.tsx and verify URL matching
+// with React Router's own matcher. Guards against accidentally breaking
+// vendor-facing links (emails, QR codes, bookmarks) when routes change.
+
+const source = readFileSync(path.resolve(__dirname, '../../App.tsx'), 'utf-8')
+
+const routePaths = [...source.matchAll(/<Route\s+path="([^"]+)"/g)].map((m) => m[1])
+const routes = routePaths.map((p) => ({ path: p }))
+
+function matchedRoute(url: string): string | undefined {
+  const matches = matchRoutes(routes, url)
+  return matches?.[matches.length - 1]?.route.path
+}
+
+describe('App routes — vendor-facing URLs keep resolving', () => {
+  it('defines all critical public route patterns', () => {
+    expect(routePaths).toContain('/events/:slug/apply/:applicationId')
+    expect(routePaths).toContain('/events/*')
+    expect(routePaths).toContain('/portal/*')
+    expect(routePaths).toContain('/apply/:code')
+    expect(routePaths).toContain('/applications/track/:ticketCode')
+    expect(routePaths).toContain('/invitations/:token')
+    expect(routePaths).toContain('/unsubscribe/:token')
+  })
+
+  it('matches legacy event page URLs (plain slug)', () => {
+    expect(matchedRoute('/events/brooklyn-show-45')).toBe('/events/*')
+  })
+
+  it('matches namespaced event page URLs (org-slug/event-slug)', () => {
+    expect(matchedRoute('/events/pancake-and-booze-12/brooklyn-show-45')).toBe('/events/*')
+  })
+
+  it('matches application form URLs (plain slug + application id)', () => {
+    expect(matchedRoute('/events/brooklyn-show-45/apply/3')).toBe(
+      '/events/:slug/apply/:applicationId',
+    )
+  })
+
+  it('documents the known limitation: namespaced apply URLs fall through to the event page', () => {
+    // The app never generates this URL shape; if this assertion starts failing,
+    // someone changed apply-route matching — make sure old links still work.
+    expect(matchedRoute('/events/pancake-and-booze-12/brooklyn-show-45/apply/3')).toBe('/events/*')
+  })
+
+  it('matches vendor portal URLs (slug, namespaced slug, and access token)', () => {
+    expect(matchedRoute('/portal/brooklyn-show-45')).toBe('/portal/*')
+    expect(matchedRoute('/portal/pancake-and-booze-12/brooklyn-show-45')).toBe('/portal/*')
+    expect(matchedRoute('/portal/aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789_-abcde')).toBe('/portal/*')
+  })
+
+  it('matches short links and application tracking URLs', () => {
+    expect(matchedRoute('/apply/X7K2M')).toBe('/apply/:code')
+    expect(matchedRoute('/applications/track/TICKET123')).toBe('/applications/track/:ticketCode')
+  })
+})
+
+describe('App routes — dashboard wildcard routing', () => {
+  it('defines the dashboard wildcard route', () => {
+    expect(routePaths).toContain('/dashboard/*')
+  })
+
+  it('matches bare /dashboard and nested dashboard URLs', () => {
+    expect(matchedRoute('/dashboard')).toBe('/dashboard/*')
+    expect(matchedRoute('/dashboard/events')).toBe('/dashboard/*')
+    expect(matchedRoute('/dashboard/events/brooklyn-show-45/applicants')).toBe('/dashboard/*')
+    expect(matchedRoute('/dashboard/network/lists')).toBe('/dashboard/*')
+  })
+})


### PR DESCRIPTION
## Summary
- Every dashboard screen now has its own URL (`/dashboard/events/:slug/applicants`, `/dashboard/network/lists`, etc.) instead of living behind component state at a single `/dashboard` address. The URL is the single source of truth: refresh keeps your place, back/forward work, and links are shareable.
- Each screen fires a Mixpanel page view (production only), so we get per-screen behavior data before the fall onboarding wave.
- Backwards compatible: bare `/dashboard` redirects to `/dashboard/events`, and legacy `?tab=&event=` deep links (Google OAuth return format) translate to the new URLs. The Google Sheets callback now returns straight to the event's settings URL.
- Vendor-facing routes (`/events/*`, `/portal/*`, `/apply/:code`, ...) are untouched, and a new route regression test extracts the real patterns from `App.tsx` and asserts every distributed link shape still resolves via React Router's own matcher.
- Unknown event slugs in dashboard URLs show a friendly "Event not found" screen.

Frontend only — no API or backend changes.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:run` — 187 tests pass (9 new route regression tests)
- [ ] Manual: create event end-to-end (loading screen on `/events/new`, then lands on the new event's URL)
- [ ] Manual: refresh mid-command-center tab keeps the view; back/forward navigate correctly
- [ ] Manual: Google Sheets OAuth round-trip returns to the event's settings tab
- [ ] Manual: old bookmark `/dashboard` and `/dashboard?tab=settings&event=<slug>` both land correctly

Made with [Cursor](https://cursor.com)