### PR TITLE
fix: stale tab on spreadsheet switch (closure bug)

### DIFF
--- a/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
+++ b/src/components/producer/GoogleSheets/GoogleSheetsSync.tsx
@@ -131,14 +131,15 @@ export default function GoogleSheetsSync({
           organizationId,
           url,
           undefined,
-          tabOverride || sheetTabName || undefined,
+          tabOverride !== undefined ? tabOverride || undefined : sheetTabName || undefined,
         )
 
         if (fetchUrlRef.current !== url) return
 
         setTabs(metadata.tabs || [])
         setHeaders(metadata.headers || [])
-        if (!sheetTabName && metadata.tabs?.length > 0) {
+        const effectiveTab = tabOverride !== undefined ? tabOverride : sheetTabName
+        if (!effectiveTab && metadata.tabs?.length > 0) {
           setSheetTabName(metadata.tabs[0])
         }
 
@@ -256,7 +257,7 @@ export default function GoogleSheetsSync({
     setTabs([])
     setDirty(true)
     if (url.includes('docs.google.com/spreadsheets')) {
-      fetchMetadata(url)
+      fetchMetadata(url, '')
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes the React closure bug flagged in PR #156 review.

### Problem
`handleSheetUrlChange` calls `setSheetTabName('')` then `fetchMetadata(url)` in the same tick. `fetchMetadata` closes over the old `sheetTabName` value because React hasn't flushed the state update. This causes:
- Metadata requested for a tab that may not exist in the new spreadsheet
- First-tab auto-select skipped because `!sheetTabName` still sees the old value

### Fix
- Pass empty string `''` as `tabOverride` when switching sheets
- Use strict `tabOverride !== undefined` check instead of `||` so empty string properly resets

## After merge
Merge into `dev`, then PR #156 (dev → staging) will include this fix automatically.

## Test plan
- [ ] Switch spreadsheet URL → tab dropdown resets to first tab of new sheet
- [ ] Existing tab selection still works when editing other fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI fix in Google Sheets sync setup with no auth, data, or API contract changes.
> 
> **Overview**
> Fixes a **React stale-closure bug** when producers paste a new Google Sheet URL: metadata was still requested for the **previous tab name**, and first-tab auto-select could be skipped because `fetchMetadata` read an outdated `sheetTabName` before `setSheetTabName('')` flushed.
> 
> `handleSheetUrlChange` now calls `fetchMetadata(url, '')` so the fetch explicitly clears the tab. Inside `fetchMetadata`, tab handling uses **`tabOverride !== undefined`** (instead of `||`) so an empty override is treated as “no tab” rather than falling back to the closed-over state; the same rule drives **first-tab auto-selection** when switching sheets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5041916b642b2762a19603f6eade2437400dc1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->