### PR TITLE
fix: gracefully handle billing portal for legacy accounts

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -180,10 +180,21 @@ export default function SettingsPage({ onBack, onStartGuide }: SettingsPageProps
     try {
       const { url } = await stripeService.createBillingPortalSession()
       window.open(url, '_blank')
-      setIsLoadingBilling(false)
-    } catch (error) {
-      console.error('Failed to open billing portal:', error)
-      alert('Failed to open billing portal. Please try again or contact support.')
+    } catch (error: any) {
+      // No Stripe customer yet (legacy account) — redirect to checkout to set up billing
+      if (error?.status === 404) {
+        try {
+          await stripeService.redirectToCheckout()
+          return
+        } catch (checkoutError) {
+          console.error('Failed to redirect to checkout:', checkoutError)
+          alert('Unable to set up billing. Please try again or contact support.')
+        }
+      } else {
+        console.error('Failed to open billing portal:', error)
+        alert('Failed to open billing portal. Please try again or contact support.')
+      }
+    } finally {
       setIsLoadingBilling(false)
     }
   }


### PR DESCRIPTION
## Summary
- When "Manage Billing" fails with 404 (no Stripe customer), automatically redirect to Stripe Checkout instead of showing a dead-end error
- After checkout completes, billing portal works normally on subsequent clicks
- Companion to backend PR in voxxy-rails-react

## Context
Legacy active accounts on dev have no `stripe_customer_id` because they were seeded without going through Stripe. The billing portal API returns 404 for these accounts. Instead of showing "Failed to open billing portal", we now catch the 404 and redirect to checkout so the user can set up billing seamlessly.

## Test plan
- [ ] Log in as a seeded active account on dev
- [ ] Click "Manage Billing" in Settings
- [ ] Should redirect to Stripe Checkout (not show an error alert)
- [ ] After completing checkout, click "Manage Billing" again — should open Stripe portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription/billing UX and redirects users into Stripe Checkout on a specific API error; scope is small but billing flows are user-facing and payment-related.
> 
> **Overview**
> **Manage Billing** on Settings now treats a billing-portal **404** (no Stripe customer, e.g. legacy seeded accounts) as a signal to start checkout via `stripeService.redirectToCheckout()` instead of only showing a failure alert.
> 
> Non-404 portal errors still alert as before; checkout failures get a separate “set up billing” message. **`setIsLoadingBilling(false)`** runs in a **`finally`** block so the button spinner clears on success, redirect, and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f719bc14942fcba95560fb7b9cbb799ac0bb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->