### PR TITLE
feat: add SMS consent checkboxes to vendor application form

### DIFF
--- a/src/pages/VendorApplicationForm.tsx
+++ b/src/pages/VendorApplicationForm.tsx
@@ -877,7 +877,17 @@ export default function VendorApplicationForm() {
                     By checking this box, I consent to receive recurring promotional SMS messages
                     from Voxxy AI, Inc. at the phone number provided, including event announcements
                     and special offers. Consent is not a condition of purchase. Max 4 msgs/month.
-                    Reply STOP to cancel.
+                    Message &amp; data rates may apply. Reply STOP to cancel or HELP for assistance.
+                    See our{' '}
+                    <a
+                      href="https://www.voxxypresents.com/legal/privacy"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-violet-800 hover:text-violet-950 dark:text-primary dark:hover:text-primary/70 underline transition-colors"
+                    >
+                      Privacy Policy
+                    </a>
+                    .
                   </label>
                 </div>
               </div>

--- a/src/pages/VendorApplicationForm.tsx
+++ b/src/pages/VendorApplicationForm.tsx
@@ -97,6 +97,8 @@ export default function VendorApplicationForm() {
     agreed_to_terms: false,
     subscribed: true,
     affiliation: '',
+    sms_transactional_consent: false,
+    sms_marketing_consent: false,
   })
 
   useEffect(() => {
@@ -338,6 +340,8 @@ export default function VendorApplicationForm() {
             website: buildWebsiteUrl(formData.website),
             note_to_host: formData.note_to_host,
             affiliation: formData.affiliation,
+            sms_transactional_consent: formData.sms_transactional_consent,
+            sms_marketing_consent: formData.sms_marketing_consent,
           })
         },
         {
@@ -821,6 +825,59 @@ export default function VendorApplicationForm() {
                     <p className="text-foreground/60 text-[10px] mt-0.5">
                       Your information will be shared with the event organizer for this application.
                     </p>
+                  </label>
+                </div>
+
+                {/* SMS Transactional Consent */}
+                <div className="flex items-start gap-2.5">
+                  <input
+                    type="checkbox"
+                    id="sms_transactional_consent"
+                    checked={formData.sms_transactional_consent}
+                    onChange={(e) =>
+                      setFormData({ ...formData, sms_transactional_consent: e.target.checked })
+                    }
+                    className="mt-0.5 w-4 h-4 rounded border-border bg-background/10 text-primary focus:ring-primary"
+                  />
+                  <label
+                    htmlFor="sms_transactional_consent"
+                    className="text-xs text-foreground/90 dark:text-foreground/80"
+                  >
+                    By checking this box, I consent to receive recurring SMS messages from Voxxy
+                    AI, Inc. to the phone number provided, including event reminders and application
+                    updates. Message &amp; data rates may apply. Message frequency varies. Reply STOP
+                    to cancel or HELP for assistance. See our{' '}
+                    <a
+                      href="https://www.voxxypresents.com/legal/privacy"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-violet-800 hover:text-violet-950 dark:text-primary dark:hover:text-primary/70 underline transition-colors"
+                    >
+                      Privacy Policy
+                    </a>
+                    .
+                  </label>
+                </div>
+
+                {/* SMS Marketing Consent */}
+                <div className="flex items-start gap-2.5">
+                  <input
+                    type="checkbox"
+                    id="sms_marketing_consent"
+                    checked={formData.sms_marketing_consent}
+                    onChange={(e) =>
+                      setFormData({ ...formData, sms_marketing_consent: e.target.checked })
+                    }
+                    className="mt-0.5 w-4 h-4 rounded border-border bg-background/10 text-primary focus:ring-primary"
+                  />
+                  <label
+                    htmlFor="sms_marketing_consent"
+                    className="text-xs text-foreground/90 dark:text-foreground/80"
+                  >
+                    By checking this box, I consent to receive recurring promotional SMS messages
+                    from Voxxy AI, Inc. at the phone number provided, including event announcements
+                    and special offers. Consent is not a condition of purchase. Max 4 msgs/month.
+                    Reply STOP to cancel.
                   </label>
                 </div>
               </div>

--- a/src/types/eventPortal.ts
+++ b/src/types/eventPortal.ts
@@ -114,6 +114,8 @@ export interface VendorApplicationFormData {
   agreed_to_terms: boolean
   subscribed: boolean
   affiliation?: string
+  sms_transactional_consent: boolean
+  sms_marketing_consent: boolean
 }
 
 export interface VendorApplicationSubmit {
@@ -127,6 +129,7 @@ export interface VendorApplicationSubmit {
   tiktok_handle?: string
   website?: string
   note_to_host?: string
-  //to-do: backend change to accept this
   affiliation?: string
+  sms_transactional_consent?: boolean
+  sms_marketing_consent?: boolean
 }


### PR DESCRIPTION
## Summary
- Adds two TFN-compliant SMS consent checkboxes to the vendor application form
- **Transactional**: event reminders and application updates (links to Privacy Policy)
- **Marketing**: event announcements and special offers, max 4 msgs/month
- Neither checkbox is required (consent is not a condition of purchase, per TFN rules)
- Both values submitted to backend (`sms_transactional_consent`, `sms_marketing_consent`)

## Context
Backend migration already ran on dev and staging — the `registrations` table has `sms_transactional_consent`, `sms_marketing_consent`, and their timestamp columns. This PR adds the frontend checkboxes to match.

## Test plan
- [ ] Open a vendor application form (via event invite link)
- [ ] Verify two new checkboxes appear below the existing Terms agreement
- [ ] Submit form with checkboxes checked — verify values reach backend
- [ ] Submit form with checkboxes unchecked — verify form still submits (not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consent/compliance copy and persists marketing/transactional SMS flags on registration; behavior is limited to optional UI fields and API passthrough with backend already migrated.
> 
> **Overview**
> Adds **optional** TFN-style SMS consent capture on the vendor application form, wired through to registration submit.
> 
> `VendorApplicationForm` now tracks `sms_transactional_consent` and `sms_marketing_consent` (default `false`), shows two labeled checkboxes under **Permissions & Preferences** (transactional: reminders/updates; marketing: promos with “not a condition of purchase”), and sends both booleans in `registrationsApi.submitVendorApplication`. They are **not** part of required-field validation, so applications can still submit unchecked.
> 
> `VendorApplicationFormData` and `VendorApplicationSubmit` in `eventPortal.ts` were extended with the same fields (optional on submit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e0508eb9a34b98a9875748ba3d4960ae3c0eaee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->