### PR TITLE
fix: revert SMS consent checkboxes from staging

### DIFF
--- a/src/pages/VendorApplicationForm.tsx
+++ b/src/pages/VendorApplicationForm.tsx
@@ -97,8 +97,6 @@ export default function VendorApplicationForm() {
     agreed_to_terms: false,
     subscribed: true,
     affiliation: '',
-    sms_transactional_consent: false,
-    sms_marketing_consent: false,
   })
 
   useEffect(() => {
@@ -340,8 +338,6 @@ export default function VendorApplicationForm() {
             website: buildWebsiteUrl(formData.website),
             note_to_host: formData.note_to_host,
             affiliation: formData.affiliation,
-            sms_transactional_consent: formData.sms_transactional_consent,
-            sms_marketing_consent: formData.sms_marketing_consent,
           })
         },
         {
@@ -825,69 +821,6 @@ export default function VendorApplicationForm() {
                     <p className="text-foreground/60 text-[10px] mt-0.5">
                       Your information will be shared with the event organizer for this application.
                     </p>
-                  </label>
-                </div>
-
-                {/* SMS Transactional Consent */}
-                <div className="flex items-start gap-2.5">
-                  <input
-                    type="checkbox"
-                    id="sms_transactional_consent"
-                    checked={formData.sms_transactional_consent}
-                    onChange={(e) =>
-                      setFormData({ ...formData, sms_transactional_consent: e.target.checked })
-                    }
-                    className="mt-0.5 w-4 h-4 rounded border-border bg-background/10 text-primary focus:ring-primary"
-                  />
-                  <label
-                    htmlFor="sms_transactional_consent"
-                    className="text-xs text-foreground/90 dark:text-foreground/80"
-                  >
-                    By checking this box, I consent to receive recurring SMS messages from Voxxy
-                    AI, Inc. to the phone number provided, including event reminders and application
-                    updates. Message &amp; data rates may apply. Message frequency varies. Reply STOP
-                    to cancel or HELP for assistance. See our{' '}
-                    <a
-                      href="https://www.voxxypresents.com/legal/privacy"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-violet-800 hover:text-violet-950 dark:text-primary dark:hover:text-primary/70 underline transition-colors"
-                    >
-                      Privacy Policy
-                    </a>
-                    .
-                  </label>
-                </div>
-
-                {/* SMS Marketing Consent */}
-                <div className="flex items-start gap-2.5">
-                  <input
-                    type="checkbox"
-                    id="sms_marketing_consent"
-                    checked={formData.sms_marketing_consent}
-                    onChange={(e) =>
-                      setFormData({ ...formData, sms_marketing_consent: e.target.checked })
-                    }
-                    className="mt-0.5 w-4 h-4 rounded border-border bg-background/10 text-primary focus:ring-primary"
-                  />
-                  <label
-                    htmlFor="sms_marketing_consent"
-                    className="text-xs text-foreground/90 dark:text-foreground/80"
-                  >
-                    By checking this box, I consent to receive recurring promotional SMS messages
-                    from Voxxy AI, Inc. at the phone number provided, including event announcements
-                    and special offers. Consent is not a condition of purchase. Max 4 msgs/month.
-                    Message &amp; data rates may apply. Reply STOP to cancel or HELP for assistance.
-                    See our{' '}
-                    <a
-                      href="https://www.voxxypresents.com/legal/privacy"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-violet-800 hover:text-violet-950 dark:text-primary dark:hover:text-primary/70 underline transition-colors"
-                    >
-                      Privacy Policy
-                    </a>
-                    .
                   </label>
                 </div>
               </div>

--- a/src/types/eventPortal.ts
+++ b/src/types/eventPortal.ts
@@ -114,8 +114,6 @@ export interface VendorApplicationFormData {
   agreed_to_terms: boolean
   subscribed: boolean
   affiliation?: string
-  sms_transactional_consent: boolean
-  sms_marketing_consent: boolean
 }
 
 export interface VendorApplicationSubmit {
@@ -129,7 +127,6 @@ export interface VendorApplicationSubmit {
   tiktok_handle?: string
   website?: string
   note_to_host?: string
+  //to-do: backend change to accept this
   affiliation?: string
-  sms_transactional_consent?: boolean
-  sms_marketing_consent?: boolean
 }


### PR DESCRIPTION
## Summary
- Reverts SMS consent checkboxes from vendor application form
- Not ready until text messaging is enabled in the system
- Cherry-pick of revert commit `4cb8d4e` from dev (was lost in the dev→staging merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and type cleanup on a single form with no auth or payment logic changes; backend already did not require these fields for go-live.
> 
> **Overview**
> **Removes SMS consent from the vendor application flow** until text messaging is live in the product (cherry-pick of a prior revert on staging).
> 
> The vendor application form no longer shows transactional or promotional SMS opt-in checkboxes, and `sms_transactional_consent` / `sms_marketing_consent` are dropped from initial form state and from the `submitVendorApplication` payload. Matching fields are removed from `VendorApplicationFormData` and `VendorApplicationSubmit` in `eventPortal.ts`; terms/privacy checkboxes and other submission fields are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f603d7240ee52cdcc68fd08dee595a30c6972399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->